### PR TITLE
Depositor w/nonReentrant `finalizeDeposit()` and `_transferTbtc` becomes last interaction

### DIFF
--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -400,8 +400,6 @@ abstract contract AbstractL1BTCDepositor is
             tbtcAmount
         );
 
-        _transferTbtc(tbtcAmount, destinationChainDepositOwner);
-
         // `ReimbursementPool` calls the untrusted receiver address using a
         // low-level call. Reentrancy risk is mitigated by making sure that
         // `ReimbursementPool.refund` is a non-reentrant function and executing
@@ -442,6 +440,8 @@ abstract contract AbstractL1BTCDepositor is
                 );
             }
         }
+
+        _transferTbtc(tbtcAmount, destinationChainDepositOwner);
     }
 
     /// @notice The `ReimbursementPool` contract issues refunds based on

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -403,7 +403,7 @@ abstract contract AbstractL1BTCDepositor is
             initialDepositAmount,
             tbtcAmount
         );
-        
+
         // `ReimbursementPool` calls the untrusted receiver address using a
         // low-level call. Reentrancy risk is mitigated by making sure that
         // `ReimbursementPool.refund` is a non-reentrant function and executing
@@ -444,7 +444,7 @@ abstract contract AbstractL1BTCDepositor is
                 );
             }
         }
-        
+
         _transferTbtc(tbtcAmount, destinationChainDepositOwner);
     }
 


### PR DESCRIPTION
Developers may inadvertently introduce reentrancy vulnerabilities in child implementations. So:

- Move state cleanup and reembursements before _transferTbtc() call
- Add reentrancy guard to finalizeDeposit()

Assuming the external calls in `_transferTbtc()` are more financially sensible so left to the end of `finalizeDeposit()`, and also some state cleanups now come ealier. The `nonReentrant` is more clear why it can help.

Closes #885