### PR TITLE
chore: ccip pools upgradeability hardening

### DIFF
--- a/cross-chain/bob/contracts/BurnFromMintTokenPoolUpgradeable.sol
+++ b/cross-chain/bob/contracts/BurnFromMintTokenPoolUpgradeable.sol
@@ -107,4 +107,7 @@ contract BurnFromMintTokenPoolUpgradeable is
 
         return Pool.ReleaseOrMintOutV1({destinationAmount: localAmount});
     }
+
+    /// @dev Reserved storage space to allow for layout changes in the future.
+    uint256[50] private __gap;
 }

--- a/cross-chain/bob/contracts/BurnFromMintTokenPoolUpgradeable.sol
+++ b/cross-chain/bob/contracts/BurnFromMintTokenPoolUpgradeable.sol
@@ -14,7 +14,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 /// @dev This contract provides burn/mint functionality for cross-chain token transfers with upgradeability
 /// and inherits all CCIP features from TokenPoolUpgradeable
 contract BurnFromMintTokenPoolUpgradeable is
-    Initializable,
     TokenPoolUpgradeable,
     ITypeAndVersion
 {

--- a/cross-chain/bob/contracts/LockReleaseTokenPoolUpgradeable.sol
+++ b/cross-chain/bob/contracts/LockReleaseTokenPoolUpgradeable.sol
@@ -15,7 +15,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeab
 /// @dev This contract provides lock/release functionality for cross-chain token transfers with upgradeability
 /// and inherits all CCIP features from TokenPoolUpgradeable
 contract LockReleaseTokenPoolUpgradeable is
-    Initializable,
     TokenPoolUpgradeable,
     ILiquidityContainer,
     ITypeAndVersion

--- a/cross-chain/bob/contracts/LockReleaseTokenPoolUpgradeable.sol
+++ b/cross-chain/bob/contracts/LockReleaseTokenPoolUpgradeable.sol
@@ -175,4 +175,7 @@ contract LockReleaseTokenPoolUpgradeable is
 
         emit LiquidityTransferred(from, amount);
     }
+
+    /// @dev Reserved storage space to allow for layout changes in the future.
+    uint256[50] private __gap;
 }

--- a/cross-chain/bob/contracts/TokenPoolUpgradeable.sol
+++ b/cross-chain/bob/contracts/TokenPoolUpgradeable.sol
@@ -179,6 +179,12 @@ abstract contract TokenPoolUpgradeable is
         }
         token = _token;
         rmnProxy = _rmnProxy;
+
+        // One-time validation to prevent silent misconfiguration of token decimals
+        uint8 actualDecimals = IERC20MetadataUpgradeable(address(_token)).decimals();
+        if (actualDecimals != _localTokenDecimals) {
+            revert InvalidDecimalArgs(_localTokenDecimals, actualDecimals);
+        }
         tokenDecimals = _localTokenDecimals;
 
         router = IRouter(_router);

--- a/cross-chain/bob/contracts/TokenPoolUpgradeable.sol
+++ b/cross-chain/bob/contracts/TokenPoolUpgradeable.sol
@@ -147,6 +147,9 @@ abstract contract TokenPoolUpgradeable is
     /// @dev Can be address(0) if none is configured.
     address internal rateLimitAdmin;
 
+    /// @dev Reserved storage space to allow for layout changes in the future.
+    uint256[50] private __gap;
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();


### PR DESCRIPTION
### Summary

-   Validate token decimals in `TokenPoolUpgradeable` initializer; revert `InvalidDecimalArgs` on mismatch.
-   Remove redundant `Initializable` from child pools to simplify initializer linearization.
-   Add storage gaps to all upgradeable pools to prevent future storage collisions.

---

### Changes

-   **feat: validate token decimals in token pool initializer**
    -   Add one-time check in `TokenPoolUpgradeable._initializeTokenPool` comparing `_localTokenDecimals` with `IERC20MetadataUpgradeable(_token).decimals()`. Revert with `InvalidDecimalArgs` on mismatch.
-   **refactor: remove redundant initializable from child pools**
    -   Drop `Initializable` from `LockReleaseTokenPoolUpgradeable` and `BurnFromMintTokenPoolUpgradeable` (they already inherit it via `TokenPoolUpgradeable`).
-   **chore: add storage gaps to upgradeable pools**
    -   Add `uint256[50] private __gap;` to `TokenPoolUpgradeable`, `LockReleaseTokenPoolUpgradeable`, and `BurnFromMintTokenPoolUpgradeable`.

---

### Scope

-   `tbtc-v2/cross-chain/bob/contracts/TokenPoolUpgradeable.sol`
-   `tbtc-v2/cross-chain/bob/contracts/LockReleaseTokenPoolUpgradeable.sol`
-   `tbtc-v2/cross-chain/bob/contracts/BurnFromMintTokenPoolUpgradeable.sol`

---

### Behavior and compatibility

No runtime behavior change except for the initializer-time decimals validation, which protects against silent misconfiguration.
External interfaces and events remain unchanged and compatible with CCIP v1.6.

---

### Acknowledgements

**I-02 Acknowledgement:** We acknowledge that `TokenPoolUpgradeable` uses `OwnableUpgradeable` (single-step ownership) instead of `Ownable2StepUpgradeable`. We are deferring a code change here to minimize upgrade surface during the CCIP migration. Operationally, all ownership actions are executed via a governed multisig with change-management procedures, which mitigates misconfiguration risk. We’ll consider migrating to `Ownable2StepUpgradeable` in a subsequent release and update runbooks to use the two-step flow (`transferOwnership` → `acceptOwnership`). No functional/security impact to current deployment; this is a defense-in-depth improvement.

**I-04 Acknowledgement:** We acknowledge the self-allowance pattern in `BurnFromMintTokenPoolUpgradeable.initialize`. In our upgrade model, initializers are versioned and called exactly once per version (e.g., `initialize`, `initializeV2`), with each initializer performing only the state transitions specific to that version. We do not re-run prior initializer logic or repeat allowance setup in later initializers. Given this explicit, one-time initialization approach and the contract’s constructor calling `_disableInitializers()`, the overflow scenario described (re-running the same allowance logic with a non-zero prior value) is not reachable in our process. For clarity, we are keeping the original allowance logic and documenting in our runbooks that future versioned initializers must not repeat prior allowance configuration. If our upgrade process ever required re-running allowance setup, we would adopt a zero-then-set pattern.

**I-05 Acknowledgement:** We acknowledge that `RateLimiter._consume` reverts when the requested amount exceeds available capacity. This is intentional to preserve atomic execution and maintain CCIP v1.6 compatibility in `TokenPoolUpgradeable`, `LockReleaseTokenPoolUpgradeable`, and `BurnFromMintTokenPoolUpgradeable`. Allowing partial consumption (or a “consume-all” sentinel) would enable under-execution and complicate cross-chain accounting. Operationally, we rely on `getCurrent{Outbound,Inbound}RateLimiterState` to read available capacity, and we schedule/split transactions or adjust limits as needed. We are keeping the current revert-on-overage design and will update runbooks to emphasize pre-checking capacity before submitting transactions.