### PR TITLE
fix(starknet): enforce strict fee equality in StarkNetBitcoinDepositor

### DIFF
--- a/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
+++ b/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
@@ -108,9 +108,11 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         override
     {
         // This function is called by finalizeDeposit which is payable
-        // The caller must send ETH to cover the StarkGate bridge fee
+        // The caller must send ETH to cover the StarkGate bridge fee.
+        // Use strict equality to prevent excess ETH loss, consistent
+        // with the Wormhole depositor implementations.
         uint256 fee = estimateFee();
-        require(msg.value >= fee, "Insufficient L1->L2 message fee");
+        require(msg.value == fee, "Incorrect L1->L2 message fee");
         require(address(tbtcToken) != address(0), "tBTC token not initialized");
 
         // Convert bytes32 to uint256 for StarkNet address format
@@ -121,7 +123,6 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         tbtcToken.safeIncreaseAllowance(address(starkGateBridge), amount);
 
         // Bridge tBTC to StarkNet
-        // All msg.value is sent to the bridge (no refund)
         // slither-disable-next-line unused-return
         starkGateBridge.deposit{value: msg.value}(
             address(tbtcToken),


### PR DESCRIPTION
## Summary

Replace the weak fee check (`>=`) with strict equality (`==`) in `StarkNetBitcoinDepositor._transferTbtc()` to prevent callers from accidentally losing excess ETH sent above the required StarkGate bridge fee.

## Problem

`StarkNetBitcoinDepositor._transferTbtc()` uses `require(msg.value >= fee)` (line 113), then forwards **all** `msg.value` to StarkGate via `starkGateBridge.deposit{value: msg.value}(...)`. StarkGate does not refund excess ETH — any amount above the estimated fee is permanently lost.

All Wormhole-based depositors in the same codebase already use strict equality:
- `L1BTCDepositorWormhole.sol:193` — `require(msg.value == cost)`
- `BTCDepositorWormhole.sol:114` — `require(msg.value == wormholeMessageFee)`

The StarkNet depositor is the only implementation using `>=`, creating an inconsistent and unsafe pattern.

## Fix

Single-line change: `require(msg.value >= fee)` → `require(msg.value == fee, "Incorrect L1->L2 message fee")`.

This ensures callers send exactly the required fee, consistent with all other depositor implementations. Callers that already send the exact fee are unaffected; callers that overpay will now get a clear revert instead of silent ETH loss.