### PR TITLE
SDK: harden network and response binding

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1257,7 +1257,7 @@ Electrum script hash as a hex string.
 
 #### Defined in
 
-[src/lib/electrum/client.ts:780](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L780)
+[src/lib/electrum/client.ts:784](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L784)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1034,7 +1034,7 @@ Use SolanaExtraDataEncoder instead
 
 #### Defined in
 
-[src/lib/solana/extra-data-encoder.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/extra-data-encoder.ts#L60)
+[src/lib/solana/extra-data-encoder.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/extra-data-encoder.ts#L61)
 
 ___
 
@@ -1062,7 +1062,7 @@ Use StarkNetBitcoinDepositor instead
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:1009](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1009)
+[src/lib/starknet/starknet-depositor.ts:1012](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1012)
 
 ___
 
@@ -1685,7 +1685,7 @@ Use loadStarkNetCrossChainInterfaces instead
 
 #### Defined in
 
-[src/lib/starknet/index.ts:122](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L122)
+[src/lib/starknet/index.ts:124](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L124)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1698,10 +1698,14 @@ Use loadStarkNetCrossChainInterfaces instead
 #### Defined in
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 [src/lib/starknet/index.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L139)
 =======
 [lib/starknet/index.ts:95](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L95)
 >>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+=======
+[lib/starknet/index.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L92)
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -683,11 +683,7 @@ Use StarkNetBitcoinDepositorConfig instead
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:162](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L162)
-=======
-[lib/starknet/starknet-depositor.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L66)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -1066,11 +1062,7 @@ Use StarkNetBitcoinDepositor instead
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/starknet-depositor.ts:1041](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1041)
-=======
-[lib/starknet/starknet-depositor.ts:457](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L457)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/starknet-depositor.ts:1009](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1009)
 
 ___
 
@@ -1672,11 +1664,7 @@ ___
 
 ### loadStarkNetCrossChainContracts
 
-<<<<<<< HEAD
-▸ **loadStarkNetCrossChainContracts**(`walletAddress`, `provider?`, `chainId?`, `relayerStatusUrl?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
-=======
-▸ **loadStarkNetCrossChainContracts**(`walletAddress`, `provider`, `chainId?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+▸ **loadStarkNetCrossChainContracts**(`walletAddress`, `provider`, `chainId?`, `relayerStatusUrl?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
 
 #### Parameters
 
@@ -1697,25 +1685,13 @@ Use loadStarkNetCrossChainInterfaces instead
 
 #### Defined in
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-[src/lib/starknet/index.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L139)
-=======
-[lib/starknet/index.ts:95](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L95)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
-=======
-[lib/starknet/index.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L92)
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
+[src/lib/starknet/index.ts:122](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L122)
 
 ___
 
 ### loadStarkNetCrossChainInterfaces
 
-<<<<<<< HEAD
-▸ **loadStarkNetCrossChainInterfaces**(`walletAddress`, `provider?`, `chainId?`, `relayerStatusUrl?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
-=======
-▸ **loadStarkNetCrossChainInterfaces**(`walletAddress`, `provider`, `chainId?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+▸ **loadStarkNetCrossChainInterfaces**(`walletAddress`, `provider`, `chainId?`, `relayerStatusUrl?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
 
 Loads StarkNet implementation of tBTC cross-chain contracts.
 Now supports balance queries with deployed tBTC contracts and enhanced configuration.

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -683,7 +683,11 @@ Use StarkNetBitcoinDepositorConfig instead
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:162](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L162)
+=======
+[lib/starknet/starknet-depositor.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L66)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -1062,7 +1066,11 @@ Use StarkNetBitcoinDepositor instead
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:1041](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1041)
+=======
+[lib/starknet/starknet-depositor.ts:457](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L457)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -1664,14 +1672,18 @@ ___
 
 ### loadStarkNetCrossChainContracts
 
+<<<<<<< HEAD
 ▸ **loadStarkNetCrossChainContracts**(`walletAddress`, `provider?`, `chainId?`, `relayerStatusUrl?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
+=======
+▸ **loadStarkNetCrossChainContracts**(`walletAddress`, `provider`, `chainId?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 #### Parameters
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
 | `walletAddress` | `string` | `undefined` |
-| `provider?` | [`StarkNetProvider`](README.md#starknetprovider) | `undefined` |
+| `provider` | [`StarkNetProvider`](README.md#starknetprovider) | `undefined` |
 | `chainId` | `string` | `Chains.StarkNet.Sepolia` |
 | `relayerStatusUrl?` | `string` | `undefined` |
 
@@ -1685,13 +1697,21 @@ Use loadStarkNetCrossChainInterfaces instead
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/index.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L139)
+=======
+[lib/starknet/index.ts:95](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/index.ts#L95)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
 ### loadStarkNetCrossChainInterfaces
 
+<<<<<<< HEAD
 ▸ **loadStarkNetCrossChainInterfaces**(`walletAddress`, `provider?`, `chainId?`, `relayerStatusUrl?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
+=======
+▸ **loadStarkNetCrossChainInterfaces**(`walletAddress`, `provider`, `chainId?`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 Loads StarkNet implementation of tBTC cross-chain contracts.
 Now supports balance queries with deployed tBTC contracts and enhanced configuration.
@@ -1701,7 +1721,7 @@ Now supports balance queries with deployed tBTC contracts and enhanced configura
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
 | `walletAddress` | `string` | `undefined` | The StarkNet wallet address to use as deposit owner |
-| `provider?` | [`StarkNetProvider`](README.md#starknetprovider) | `undefined` | Optional StarkNet provider for blockchain interactions |
+| `provider` | [`StarkNetProvider`](README.md#starknetprovider) | `undefined` | StarkNet provider for blockchain interactions |
 | `chainId` | `string` | `Chains.StarkNet.Sepolia` | Optional chain ID (defaults to Sepolia) |
 | `relayerStatusUrl?` | `string` | `undefined` | Optional override for the relayer's deposit-status endpoint, used to verify 409 conflicts. Falls back to `STARKNET_RELAYER_STATUS_URL` when not supplied. |
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1257,7 +1257,7 @@ Electrum script hash as a hex string.
 
 #### Defined in
 
-[src/lib/electrum/client.ts:756](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L756)
+[src/lib/electrum/client.ts:780](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L780)
 
 ___
 
@@ -1634,7 +1634,7 @@ ___
 
 ### loadSolanaCrossChainInterfaces
 
-▸ **loadSolanaCrossChainInterfaces**(`solanaProvider`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
+▸ **loadSolanaCrossChainInterfaces**(`solanaProvider`, `genesisHash`): `Promise`\<[`DestinationChainInterfaces`](README.md#destinationchaininterfaces)\>
 
 Loads Solana implementation of tBTC cross-chain interfaces using
 an AnchorProvider (which includes the connection and the wallet).
@@ -1644,6 +1644,7 @@ an AnchorProvider (which includes the connection and the wallet).
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `solanaProvider` | `AnchorProvider` | Anchor provider for Solana. Must include both `connection` and `wallet`. |
+| `genesisHash` | [`Solana`](enums/Chains.Solana.md) | The expected Solana genesis hash (from `Chains.Solana.*`). |
 
 #### Returns
 

--- a/typescript/api-reference/classes/ElectrumClient.md
+++ b/typescript/api-reference/classes/ElectrumClient.md
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:721](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L721)
+[src/lib/electrum/client.ts:725](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L725)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:735](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L735)
+[src/lib/electrum/client.ts:739](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L739)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:671](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L671)
+[src/lib/electrum/client.ts:669](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L669)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:484](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L484)
+[src/lib/electrum/client.ts:480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L480)
 
 ___
 
@@ -341,7 +341,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:505](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L505)
+[src/lib/electrum/client.ts:503](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L503)
 
 ___
 
@@ -395,7 +395,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:690](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L690)
+[src/lib/electrum/client.ts:688](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L688)
 
 ___
 
@@ -421,7 +421,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:597](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L597)
+[src/lib/electrum/client.ts:595](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L595)
 
 ___
 
@@ -441,7 +441,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:655](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L655)
+[src/lib/electrum/client.ts:653](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L653)
 
 ___
 

--- a/typescript/api-reference/classes/ElectrumClient.md
+++ b/typescript/api-reference/classes/ElectrumClient.md
@@ -139,7 +139,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:725](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L725)
+[src/lib/electrum/client.ts:728](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L728)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:739](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L739)
+[src/lib/electrum/client.ts:742](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L742)
 
 ___
 
@@ -218,7 +218,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:669](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L669)
+[src/lib/electrum/client.ts:672](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L672)
 
 ___
 
@@ -289,7 +289,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L480)
+[src/lib/electrum/client.ts:481](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L481)
 
 ___
 
@@ -341,7 +341,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:503](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L503)
+[src/lib/electrum/client.ts:505](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L505)
 
 ___
 
@@ -395,7 +395,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:688](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L688)
+[src/lib/electrum/client.ts:691](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L691)
 
 ___
 
@@ -421,7 +421,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:595](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L595)
+[src/lib/electrum/client.ts:598](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L598)
 
 ___
 
@@ -441,7 +441,7 @@ ___
 
 #### Defined in
 
-[src/lib/electrum/client.ts:653](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L653)
+[src/lib/electrum/client.ts:656](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/electrum/client.ts#L656)
 
 ___
 

--- a/typescript/api-reference/classes/SolanaExtraDataEncoder.md
+++ b/typescript/api-reference/classes/SolanaExtraDataEncoder.md
@@ -66,7 +66,7 @@ Error if the extra data is missing, null, or not exactly 32 bytes.
 
 #### Defined in
 
-[src/lib/solana/extra-data-encoder.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/extra-data-encoder.ts#L41)
+[src/lib/solana/extra-data-encoder.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/extra-data-encoder.ts#L42)
 
 ___
 
@@ -100,4 +100,4 @@ Error if the deposit owner is not a SolanaAddress instance.
 
 #### Defined in
 
-[src/lib/solana/extra-data-encoder.ts:23](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/extra-data-encoder.ts#L23)
+[src/lib/solana/extra-data-encoder.ts:24](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/extra-data-encoder.ts#L24)

--- a/typescript/api-reference/classes/StarkNetAddress.md
+++ b/typescript/api-reference/classes/StarkNetAddress.md
@@ -42,11 +42,7 @@ StarkNet addresses are field elements (felt252) in the StarkNet prime field.
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/address.ts:14](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L14)
-=======
-[lib/starknet/address.ts:18](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L18)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/address.ts:18](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L18)
 
 ## Properties
 
@@ -63,11 +59,7 @@ This is always normalized to lowercase and padded to 32 bytes.
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/address.ts:12](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L12)
-=======
-[lib/starknet/address.ts:16](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L16)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/address.ts:16](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L16)
 
 ## Methods
 
@@ -95,11 +87,7 @@ true if both are StarkNetAddress instances with the same identifierHex
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/address.ts:50](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L50)
-=======
-[lib/starknet/address.ts:56](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L56)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/address.ts:56](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L56)
 
 ___
 
@@ -118,11 +106,7 @@ The address as a 0x-prefixed 64-character hex string
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/address.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L62)
-=======
-[lib/starknet/address.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L68)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/address.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L68)
 
 ___
 
@@ -140,11 +124,7 @@ The address as a 0x-prefixed hex string
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/address.ts:70](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L70)
-=======
-[lib/starknet/address.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L76)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/address.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L76)
 
 ___
 
@@ -172,8 +152,4 @@ Error if the address format is invalid or exceeds field element size
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/address.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L41)
-=======
-[lib/starknet/address.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L47)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/address.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L47)

--- a/typescript/api-reference/classes/StarkNetAddress.md
+++ b/typescript/api-reference/classes/StarkNetAddress.md
@@ -42,7 +42,11 @@ StarkNet addresses are field elements (felt252) in the StarkNet prime field.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/address.ts:14](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L14)
+=======
+[lib/starknet/address.ts:18](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L18)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Properties
 
@@ -59,7 +63,11 @@ This is always normalized to lowercase and padded to 32 bytes.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/address.ts:12](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L12)
+=======
+[lib/starknet/address.ts:16](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L16)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Methods
 
@@ -87,7 +95,11 @@ true if both are StarkNetAddress instances with the same identifierHex
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/address.ts:50](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L50)
+=======
+[lib/starknet/address.ts:56](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L56)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -106,7 +118,11 @@ The address as a 0x-prefixed 64-character hex string
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/address.ts:62](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L62)
+=======
+[lib/starknet/address.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L68)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -124,7 +140,11 @@ The address as a 0x-prefixed hex string
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/address.ts:70](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L70)
+=======
+[lib/starknet/address.ts:76](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L76)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -152,4 +172,8 @@ Error if the address format is invalid or exceeds field element size
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/address.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L41)
+=======
+[lib/starknet/address.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/address.ts#L47)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)

--- a/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
+++ b/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
@@ -68,7 +68,11 @@ Error if provider is not provided or if chain-ID/relayerUrl requirements are unm
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:408](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L408)
+=======
+[lib/starknet/starknet-depositor.ts:91](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L91)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Properties
 
@@ -78,7 +82,11 @@ Error if provider is not provided or if chain-ID/relayerUrl requirements are unm
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:396](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L396)
+=======
+[lib/starknet/starknet-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L80)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -88,7 +96,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:395](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L395)
+=======
+[lib/starknet/starknet-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L79)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -98,7 +110,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:398](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L398)
+=======
+[lib/starknet/starknet-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L82)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -108,7 +124,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:394](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L394)
+=======
+[lib/starknet/starknet-depositor.ts:78](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L78)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -118,7 +138,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:397](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L397)
+=======
+[lib/starknet/starknet-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L81)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Methods
 
@@ -140,6 +164,7 @@ The StarkNetExtraDataEncoder instance.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:533](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L533)
 
 ___
@@ -168,6 +193,9 @@ A descriptive error message
 #### Defined in
 
 [src/lib/starknet/starknet-depositor.ts:876](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L876)
+=======
+[lib/starknet/starknet-depositor.ts:198](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L198)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -191,7 +219,11 @@ Formatted error message
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:944](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L944)
+=======
+[lib/starknet/starknet-depositor.ts:375](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L375)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -219,7 +251,11 @@ Error if the address is invalid
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:1014](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1014)
+=======
+[lib/starknet/starknet-depositor.ts:449](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L449)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -243,7 +279,11 @@ Always throws since StarkNet deposits are handled via L1.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:493](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L493)
+=======
+[lib/starknet/starknet-depositor.ts:158](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L158)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -261,7 +301,11 @@ The chain name (e.g., "StarkNet")
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:476](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L476)
+=======
+[lib/starknet/starknet-depositor.ts:141](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L141)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -283,7 +327,11 @@ The StarkNet address set as deposit owner, or undefined if not set.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:504](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L504)
+=======
+[lib/starknet/starknet-depositor.ts:169](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L169)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -301,6 +349,7 @@ The StarkNet provider instance
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:484](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L484)
 
 ___
@@ -339,6 +388,9 @@ StarkNetRelayerDepositConflictError always; carries the deposit ID and
 #### Defined in
 
 [src/lib/starknet/starknet-depositor.ts:766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L766)
+=======
+[lib/starknet/starknet-depositor.ts:149](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L149)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -394,7 +446,11 @@ StarkNetRelayerDepositConflictError if the relayer reports the deposit
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:566](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L566)
+=======
+[lib/starknet/starknet-depositor.ts:217](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L217)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -421,6 +477,7 @@ True if the error is retryable
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:921](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L921)
 
 ___
@@ -448,6 +505,9 @@ The parsed status response, or undefined if the relayer did
 #### Defined in
 
 [src/lib/starknet/starknet-depositor.ts:839](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L839)
+=======
+[lib/starknet/starknet-depositor.ts:347](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L347)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -477,4 +537,8 @@ Error if the deposit owner is not a StarkNetAddress and not undefined/null.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:514](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L514)
+=======
+[lib/starknet/starknet-depositor.ts:179](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L179)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)

--- a/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
+++ b/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
@@ -167,7 +167,7 @@ A descriptive error message
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:863](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L863)
+[src/lib/starknet/starknet-depositor.ts:866](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L866)
 
 ___
 
@@ -191,7 +191,7 @@ Formatted error message
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:931](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L931)
+[src/lib/starknet/starknet-depositor.ts:934](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L934)
 
 ___
 
@@ -219,7 +219,7 @@ Error if the address is invalid
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:1001](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1001)
+[src/lib/starknet/starknet-depositor.ts:1004](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1004)
 
 ___
 
@@ -338,7 +338,7 @@ StarkNetRelayerDepositConflictError always; carries the deposit ID and
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:753](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L753)
+[src/lib/starknet/starknet-depositor.ts:756](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L756)
 
 ___
 
@@ -421,7 +421,7 @@ True if the error is retryable
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:908](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L908)
+[src/lib/starknet/starknet-depositor.ts:911](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L911)
 
 ___
 
@@ -447,7 +447,7 @@ The parsed status response, or undefined if the relayer did
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:826](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L826)
+[src/lib/starknet/starknet-depositor.ts:829](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L829)
 
 ___
 

--- a/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
+++ b/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
@@ -68,11 +68,7 @@ Error if provider is not provided or if chain-ID/relayerUrl requirements are unm
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:408](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L408)
-=======
-[lib/starknet/starknet-depositor.ts:91](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L91)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Properties
 
@@ -82,11 +78,7 @@ Error if provider is not provided or if chain-ID/relayerUrl requirements are unm
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:396](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L396)
-=======
-[lib/starknet/starknet-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L80)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -96,11 +88,7 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:395](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L395)
-=======
-[lib/starknet/starknet-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L79)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -110,11 +98,7 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:398](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L398)
-=======
-[lib/starknet/starknet-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L82)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -124,11 +108,7 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:394](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L394)
-=======
-[lib/starknet/starknet-depositor.ts:78](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L78)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -138,11 +118,7 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:397](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L397)
-=======
-[lib/starknet/starknet-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L81)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Methods
 
@@ -164,7 +140,6 @@ The StarkNetExtraDataEncoder instance.
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:533](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L533)
 
 ___
@@ -192,10 +167,7 @@ A descriptive error message
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:876](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L876)
-=======
-[lib/starknet/starknet-depositor.ts:198](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L198)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/starknet-depositor.ts:863](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L863)
 
 ___
 
@@ -219,11 +191,7 @@ Formatted error message
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/starknet-depositor.ts:944](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L944)
-=======
-[lib/starknet/starknet-depositor.ts:375](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L375)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/starknet-depositor.ts:931](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L931)
 
 ___
 
@@ -251,11 +219,7 @@ Error if the address is invalid
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/starknet-depositor.ts:1014](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1014)
-=======
-[lib/starknet/starknet-depositor.ts:449](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L449)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/starknet-depositor.ts:1001](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L1001)
 
 ___
 
@@ -279,11 +243,7 @@ Always throws since StarkNet deposits are handled via L1.
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:493](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L493)
-=======
-[lib/starknet/starknet-depositor.ts:158](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L158)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -301,11 +261,7 @@ The chain name (e.g., "StarkNet")
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:476](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L476)
-=======
-[lib/starknet/starknet-depositor.ts:141](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L141)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -327,11 +283,7 @@ The StarkNet address set as deposit owner, or undefined if not set.
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:504](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L504)
-=======
-[lib/starknet/starknet-depositor.ts:169](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L169)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -349,7 +301,6 @@ The StarkNet provider instance
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:484](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L484)
 
 ___
@@ -387,10 +338,7 @@ StarkNetRelayerDepositConflictError always; carries the deposit ID and
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:766](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L766)
-=======
-[lib/starknet/starknet-depositor.ts:149](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L149)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/starknet-depositor.ts:753](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L753)
 
 ___
 
@@ -446,11 +394,7 @@ StarkNetRelayerDepositConflictError if the relayer reports the deposit
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:566](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L566)
-=======
-[lib/starknet/starknet-depositor.ts:217](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L217)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -477,8 +421,7 @@ True if the error is retryable
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/lib/starknet/starknet-depositor.ts:921](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L921)
+[src/lib/starknet/starknet-depositor.ts:908](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L908)
 
 ___
 
@@ -504,10 +447,7 @@ The parsed status response, or undefined if the relayer did
 
 #### Defined in
 
-[src/lib/starknet/starknet-depositor.ts:839](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L839)
-=======
-[lib/starknet/starknet-depositor.ts:347](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L347)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/lib/starknet/starknet-depositor.ts:826](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L826)
 
 ___
 
@@ -537,8 +477,4 @@ Error if the deposit owner is not a StarkNetAddress and not undefined/null.
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:514](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L514)
-=======
-[lib/starknet/starknet-depositor.ts:179](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L179)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)

--- a/typescript/api-reference/classes/TBTC.md
+++ b/typescript/api-reference/classes/TBTC.md
@@ -66,11 +66,7 @@ subpath which exports the base TBTC class.
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L41)
-=======
-[services/tbtc.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L41)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L42)
 
 ## Properties
 
@@ -80,11 +76,7 @@ subpath which exports the base TBTC class.
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:36](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L36)
-=======
-[services/tbtc.ts:36](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L36)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:37](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L37)
 
 ___
 
@@ -94,11 +86,7 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L34)
-=======
-[services/tbtc.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L34)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:35](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L35)
 
 ___
 
@@ -114,11 +102,7 @@ Will be removed in next major version.
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:210](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L210)
-=======
-[services/tbtc.ts:192](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L192)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:211](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L211)
 
 ___
 
@@ -231,11 +215,7 @@ Cross-chain contracts for the given L2 chain or
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:407](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L407)
-=======
-[services/tbtc.ts:357](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L357)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:390](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L390)
 
 ___
 
@@ -289,11 +269,7 @@ Throws an error if:
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:257](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L257)
-=======
-[services/tbtc.ts:232](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L232)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:258](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L258)
 
 ___
 
@@ -321,11 +297,7 @@ Throws an error if the provider is invalid or address cannot be extracted.
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:164](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L164)
-=======
-[services/tbtc.ts:146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L146)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:165](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L165)
 
 ___
 
@@ -400,11 +372,7 @@ Throws an error if the underlying signer's Ethereum network is
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:120](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L120)
-=======
-[services/tbtc.ts:106](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L106)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:121](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L121)
 
 ___
 
@@ -440,11 +408,7 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L60)
-=======
-[services/tbtc.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L60)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L61)
 
 ___
 
@@ -489,8 +453,4 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
-<<<<<<< HEAD
-[src/services/tbtc.ts:93](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L93)
-=======
-[services/tbtc.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L82)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
+[src/services/tbtc.ts:94](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L94)

--- a/typescript/api-reference/classes/TBTC.md
+++ b/typescript/api-reference/classes/TBTC.md
@@ -66,7 +66,11 @@ subpath which exports the base TBTC class.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L41)
+=======
+[services/tbtc.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L41)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ## Properties
 
@@ -76,7 +80,11 @@ subpath which exports the base TBTC class.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:36](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L36)
+=======
+[services/tbtc.ts:36](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L36)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -86,7 +94,11 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L34)
+=======
+[services/tbtc.ts:34](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L34)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -102,7 +114,11 @@ Will be removed in next major version.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:210](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L210)
+=======
+[services/tbtc.ts:192](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L192)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -215,7 +231,11 @@ Cross-chain contracts for the given L2 chain or
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:407](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L407)
+=======
+[services/tbtc.ts:357](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L357)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -269,7 +289,11 @@ Throws an error if:
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:257](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L257)
+=======
+[services/tbtc.ts:232](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L232)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -297,7 +321,11 @@ Throws an error if the provider is invalid or address cannot be extracted.
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:164](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L164)
+=======
+[services/tbtc.ts:146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L146)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -372,7 +400,11 @@ Throws an error if the underlying signer's Ethereum network is
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:120](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L120)
+=======
+[services/tbtc.ts:106](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L106)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -408,7 +440,11 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L60)
+=======
+[services/tbtc.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L60)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -453,4 +489,8 @@ Throws an error if the signer's Ethereum network is other than
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/services/tbtc.ts:93](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L93)
+=======
+[services/tbtc.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L82)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)

--- a/typescript/api-reference/classes/TBTC.md
+++ b/typescript/api-reference/classes/TBTC.md
@@ -215,7 +215,7 @@ Cross-chain contracts for the given L2 chain or
 
 #### Defined in
 
-[src/services/tbtc.ts:402](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L402)
+[src/services/tbtc.ts:407](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/services/tbtc.ts#L407)
 
 ___
 

--- a/typescript/api-reference/interfaces/BitcoinDepositor.md
+++ b/typescript/api-reference/interfaces/BitcoinDepositor.md
@@ -112,7 +112,7 @@ issued by this contract.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `depositOwner` | [`ChainIdentifier`](ChainIdentifier.md) | Identifier of the deposit owner or undefined to clear. |
+| `depositOwner` | `undefined` \| ``null`` \| [`ChainIdentifier`](ChainIdentifier.md) | Identifier of the deposit owner or undefined to clear. |
 
 #### Returns
 

--- a/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
+++ b/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
@@ -19,11 +19,7 @@ Configuration for StarkNetBitcoinDepositor
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L146)
-=======
-[lib/starknet/starknet-depositor.ts:58](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L58)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -33,7 +29,6 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L156)
 
 ___
@@ -51,9 +46,6 @@ or similar placeholders.
 #### Defined in
 
 [src/lib/starknet/starknet-depositor.ts:155](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L155)
-=======
-[lib/starknet/starknet-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L60)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -63,8 +55,4 @@ ___
 
 #### Defined in
 
-<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:147](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L147)
-=======
-[lib/starknet/starknet-depositor.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L59)
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)

--- a/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
+++ b/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
@@ -19,7 +19,11 @@ Configuration for StarkNetBitcoinDepositor
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L146)
+=======
+[lib/starknet/starknet-depositor.ts:58](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L58)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -29,6 +33,7 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L156)
 
 ___
@@ -46,6 +51,9 @@ or similar placeholders.
 #### Defined in
 
 [src/lib/starknet/starknet-depositor.ts:155](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L155)
+=======
+[lib/starknet/starknet-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L60)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
 ___
 
@@ -55,4 +63,8 @@ ___
 
 #### Defined in
 
+<<<<<<< HEAD
 [src/lib/starknet/starknet-depositor.ts:147](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L147)
+=======
+[lib/starknet/starknet-depositor.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L59)
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)

--- a/typescript/src/lib/contracts/cross-chain.ts
+++ b/typescript/src/lib/contracts/cross-chain.ts
@@ -90,7 +90,7 @@ export interface BitcoinDepositor {
    * issued by this contract.
    * @param depositOwner Identifier of the deposit owner or undefined to clear.
    */
-  setDepositOwner(depositOwner: ChainIdentifier): void
+  setDepositOwner(depositOwner: ChainIdentifier | null | undefined): void
 
   /**
    * @returns Extra data encoder for this contract. The encoder is used to

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -446,12 +446,8 @@ export class ElectrumClient implements BitcoinClient {
         }
       )
 
-      if (!rawTransaction) {
-        throw new Error(`Transaction not found`)
-      }
-
       // Decode the raw transaction.
-      const transaction = Tx.fromHex(rawTransaction)
+      const transaction = decodeTransaction(rawTransaction, transactionHash)
 
       const inputs = transaction.ins.map(
         (input: TxInput): BitcoinTxInput => ({
@@ -492,6 +488,8 @@ export class ElectrumClient implements BitcoinClient {
         }
       )
 
+      decodeTransaction(transaction, transactionHash)
+
       return {
         transactionHex: transaction,
       }
@@ -519,7 +517,7 @@ export class ElectrumClient implements BitcoinClient {
       )
 
       // Decode the raw transaction.
-      const transaction = Tx.fromHex(rawTransaction)
+      const transaction = decodeTransaction(rawTransaction, transactionHash)
 
       // As a workaround for the problem described in https://github.com/Blockstream/electrs/pull/36
       // we need to calculate the number of confirmations based on the latest
@@ -705,6 +703,12 @@ export class ElectrumClient implements BitcoinClient {
           )
         })
 
+        if (merkle.block_height !== blockHeight) {
+          throw new Error(
+            `Merkle proof block height mismatch: expected ${blockHeight}, got ${merkle.block_height}`
+          )
+        }
+
         return {
           blockHeight: merkle.block_height,
           merkle: merkle.merkle.map((m) => Hex.from(m)),
@@ -745,6 +749,26 @@ export class ElectrumClient implements BitcoinClient {
       return BitcoinTxHash.from(txHash)
     })
   }
+}
+
+function decodeTransaction(
+  rawTransaction: string,
+  expectedTransactionHash: BitcoinTxHash
+): Tx {
+  if (!rawTransaction) {
+    throw new Error(`Transaction not found`)
+  }
+
+  const transaction = Tx.fromHex(rawTransaction)
+  const actualTransactionHash = BitcoinTxHash.from(transaction.getId())
+
+  if (actualTransactionHash.toString() !== expectedTransactionHash.toString()) {
+    throw new Error(
+      `Transaction hash mismatch: expected ${expectedTransactionHash.toString()}, got ${actualTransactionHash.toString()}`
+    )
+  }
+
+  return transaction
 }
 
 /**

--- a/typescript/src/lib/electrum/client.ts
+++ b/typescript/src/lib/electrum/client.ts
@@ -447,7 +447,8 @@ export class ElectrumClient implements BitcoinClient {
       )
 
       // Decode the raw transaction.
-      const transaction = decodeTransaction(rawTransaction, transactionHash)
+      const transaction = decodeTransaction(rawTransaction)
+      verifyTransactionHash(transaction, transactionHash)
 
       const inputs = transaction.ins.map(
         (input: TxInput): BitcoinTxInput => ({
@@ -488,7 +489,8 @@ export class ElectrumClient implements BitcoinClient {
         }
       )
 
-      decodeTransaction(transaction, transactionHash)
+      const decodedTransaction = decodeTransaction(transaction)
+      verifyTransactionHash(decodedTransaction, transactionHash)
 
       return {
         transactionHex: transaction,
@@ -517,7 +519,8 @@ export class ElectrumClient implements BitcoinClient {
       )
 
       // Decode the raw transaction.
-      const transaction = decodeTransaction(rawTransaction, transactionHash)
+      const transaction = decodeTransaction(rawTransaction)
+      verifyTransactionHash(transaction, transactionHash)
 
       // As a workaround for the problem described in https://github.com/Blockstream/electrs/pull/36
       // we need to calculate the number of confirmations based on the latest
@@ -751,15 +754,18 @@ export class ElectrumClient implements BitcoinClient {
   }
 }
 
-function decodeTransaction(
-  rawTransaction: string,
-  expectedTransactionHash: BitcoinTxHash
-): Tx {
+function decodeTransaction(rawTransaction: string): Tx {
   if (!rawTransaction) {
     throw new Error(`Transaction not found`)
   }
 
-  const transaction = Tx.fromHex(rawTransaction)
+  return Tx.fromHex(rawTransaction)
+}
+
+function verifyTransactionHash(
+  transaction: Tx,
+  expectedTransactionHash: BitcoinTxHash
+): void {
   const actualTransactionHash = BitcoinTxHash.from(transaction.getId())
 
   if (actualTransactionHash.toString() !== expectedTransactionHash.toString()) {
@@ -767,8 +773,6 @@ function decodeTransaction(
       `Transaction hash mismatch: expected ${expectedTransactionHash.toString()}, got ${actualTransactionHash.toString()}`
     )
   }
-
-  return transaction
 }
 
 /**

--- a/typescript/src/lib/solana/extra-data-encoder.ts
+++ b/typescript/src/lib/solana/extra-data-encoder.ts
@@ -1,6 +1,7 @@
 import { ExtraDataEncoder, ChainIdentifier } from "../contracts"
 import { SolanaAddress } from "./address"
 import { Hex } from "../utils"
+import { PublicKey } from "@solana/web3.js"
 
 /**
  * Implementation of the Solana ExtraDataEncoder.
@@ -49,8 +50,8 @@ export class SolanaExtraDataEncoder implements ExtraDataEncoder {
       throw new Error(`Extra data must be 32 bytes. Got ${buffer.length}.`)
     }
 
-    // Create sOLANA address from the extra data
-    return SolanaAddress.from(Hex.from(buffer).toString())
+    // Create Solana address from the 32-byte public key material in extra data.
+    return SolanaAddress.from(new PublicKey(buffer).toBase58())
   }
 }
 

--- a/typescript/src/lib/solana/index.ts
+++ b/typescript/src/lib/solana/index.ts
@@ -1,5 +1,5 @@
 import { AnchorProvider } from "@coral-xyz/anchor"
-import { DestinationChainInterfaces } from "../contracts"
+import { Chains, DestinationChainInterfaces } from "../contracts"
 
 import { SolanaDepositorInterface } from "./solana-depositor-interface"
 import { SolanaTBTCToken } from "./solana-tbtc-token"
@@ -18,10 +18,18 @@ export * from "./extra-data-encoder"
  * @throws If the connection's genesis hash does not match the expected `genesisHash`.
  */
 export async function loadSolanaCrossChainInterfaces(
-  solanaProvider: AnchorProvider
+  solanaProvider: AnchorProvider,
+  genesisHash: Chains.Solana
 ): Promise<DestinationChainInterfaces> {
   if (!solanaProvider.wallet || !solanaProvider.wallet.publicKey) {
     throw new Error("No connected wallet found in the provided AnchorProvider.")
+  }
+
+  const providerGenesisHash = await solanaProvider.connection.getGenesisHash()
+  if (providerGenesisHash !== genesisHash) {
+    throw new Error(
+      `Solana provider genesis hash mismatch: expected ${genesisHash}, got ${providerGenesisHash}`
+    )
   }
 
   const solanaDepositorInterface = new SolanaDepositorInterface()

--- a/typescript/src/lib/solana/solana-depositor-interface.ts
+++ b/typescript/src/lib/solana/solana-depositor-interface.ts
@@ -66,34 +66,37 @@ export class SolanaDepositorInterface implements BitcoinDepositor {
       throw new Error("Extra data is required.")
     }
 
-    if (!this.#depositOwner) {
+    const depositOwner = deposit.extraData
+      ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
+      : this.#depositOwner
+
+    if (!depositOwner) {
       throw new Error("Deposit owner is required.")
     }
 
-    try {
-      const response = await axios.post(
-        "https://relayer.tbtcscan.com/api/reveal",
-        {
-          fundingTx,
-          reveal,
-          l2DepositOwner: extraData,
-          l2Sender: `0x${this.#depositOwner.identifierHex}`,
-        }
+    const sender = this.#depositOwner ?? depositOwner
+    const formattedOwner = `0x${depositOwner.identifierHex}`
+    const formattedSender = `0x${sender.identifierHex}`
+
+    const response = await axios.post(
+      "https://relayer.tbtcscan.com/api/reveal",
+      {
+        fundingTx,
+        reveal,
+        l2DepositOwner: formattedOwner,
+        l2Sender: formattedSender,
+      },
+      { timeout: 90000 }
+    )
+
+    const { data } = response
+    if (!isTransactionReceipt(data.receipt)) {
+      throw new Error(
+        `Unexpected response from /api/reveal: ${JSON.stringify(data)}`
       )
-
-      const { data } = response
-      if (!isTransactionReceipt(data.receipt)) {
-        throw new Error(
-          `Unexpected response from /api/reveal: ${JSON.stringify(data)}`
-        )
-      }
-
-      return data.receipt
-    } catch (error) {
-      // You can add logging, rethrow, etc.
-      console.error("Error calling /api/reveal endpoint:", error)
-      throw error
     }
+
+    return data.receipt
   }
 }
 

--- a/typescript/src/lib/solana/solana-depositor-interface.ts
+++ b/typescript/src/lib/solana/solana-depositor-interface.ts
@@ -45,7 +45,7 @@ export class SolanaDepositorInterface implements BitcoinDepositor {
   /**
    * @see {BitcoinDepositor#initializeDeposit}
    *
-   * This method calls the external service at `https://api.tbtcscan.org/reveal`
+   * This method calls the external service at `https://relayer.tbtcscan.com/api/reveal`
    * to trigger the deposit transaction via a relayer off-chain process.
    * It returns the resulting transaction hash as a Hex.
    */
@@ -66,19 +66,23 @@ export class SolanaDepositorInterface implements BitcoinDepositor {
       throw new Error("Extra data is required.")
     }
 
+    if (!this.#depositOwner) {
+      throw new Error("Deposit owner is required.")
+    }
+
     try {
       const response = await axios.post(
-        "http://relayer.tbtcscan.com/api/reveal",
+        "https://relayer.tbtcscan.com/api/reveal",
         {
           fundingTx,
           reveal,
           l2DepositOwner: extraData,
-          l2Sender: `0x${this.#depositOwner?.identifierHex}`,
+          l2Sender: `0x${this.#depositOwner.identifierHex}`,
         }
       )
 
       const { data } = response
-      if (!data.receipt) {
+      if (!isTransactionReceipt(data.receipt)) {
         throw new Error(
           `Unexpected response from /api/reveal: ${JSON.stringify(data)}`
         )
@@ -91,4 +95,13 @@ export class SolanaDepositorInterface implements BitcoinDepositor {
       throw error
     }
   }
+}
+
+function isTransactionReceipt(receipt: unknown): receipt is TransactionReceipt {
+  return (
+    typeof receipt === "object" &&
+    receipt !== null &&
+    typeof (receipt as TransactionReceipt).transactionHash === "string" &&
+    /^0x[0-9a-fA-F]{64}$/.test((receipt as TransactionReceipt).transactionHash)
+  )
 }

--- a/typescript/src/lib/starknet/address.ts
+++ b/typescript/src/lib/starknet/address.ts
@@ -1,5 +1,9 @@
 import { ChainIdentifier } from "../contracts"
 
+const STARKNET_FIELD_PRIME = BigInt(
+  "0x0800000000000011000000000000000000000000000000000000000000000001"
+)
+
 /**
  * Represents a StarkNet address compliant with the ChainIdentifier interface.
  * StarkNet addresses are field elements (felt252) in the StarkNet prime field.
@@ -20,12 +24,14 @@ export class StarkNetAddress implements ChainIdentifier {
       throw new Error(`Invalid StarkNet address format: ${address}`)
     }
 
-    // Validate it's within felt252 range (prime field element)
-    // For simplicity, we'll just check it's not too long
     if (normalized.length > 64) {
       throw new Error(
         `StarkNet address exceeds maximum field element size: ${address}`
       )
+    }
+
+    if (BigInt(`0x${normalized}`) >= STARKNET_FIELD_PRIME) {
+      throw new Error(`StarkNet address exceeds field prime range: ${address}`)
     }
 
     // Pad to 64 characters (32 bytes)

--- a/typescript/src/lib/starknet/index.ts
+++ b/typescript/src/lib/starknet/index.ts
@@ -41,7 +41,7 @@ let relayerStatusWarningEmitted = false
  * Now supports balance queries with deployed tBTC contracts and enhanced configuration.
  *
  * @param walletAddress The StarkNet wallet address to use as deposit owner
- * @param provider Optional StarkNet provider for blockchain interactions
+ * @param provider StarkNet provider for blockchain interactions
  * @param chainId Optional chain ID (defaults to Sepolia)
  * @param relayerStatusUrl Optional override for the relayer's deposit-status
  *        endpoint, used to verify 409 conflicts. Falls back to
@@ -51,10 +51,16 @@ let relayerStatusWarningEmitted = false
  */
 export async function loadStarkNetCrossChainInterfaces(
   walletAddress: string,
-  provider?: StarkNetProvider,
+  provider: StarkNetProvider,
   chainId: string = Chains.StarkNet.Sepolia,
   relayerStatusUrl?: string
 ): Promise<DestinationChainInterfaces> {
+  if (!provider) {
+    throw new Error("StarkNet provider is required")
+  }
+
+  await validateProviderChain(provider, chainId)
+
   // Build depositor configuration with environment variable support
   const depositorConfig: StarkNetBitcoinDepositorConfig = {
     chainId,
@@ -64,14 +70,11 @@ export async function loadStarkNetCrossChainInterfaces(
     defaultVault: process.env.STARKNET_TBTC_VAULT, // Optional override
   }
 
-  // Create provider if not provided (for testing/backward compatibility)
-  const actualProvider = provider || createMockProvider()
-
   // Create the main depositor instance
   const starkNetBitcoinDepositor = new StarkNetBitcoinDepositor(
     depositorConfig,
     "StarkNet",
-    actualProvider
+    provider
   )
   if (
     !relayerStatusWarningEmitted &&
@@ -90,42 +93,22 @@ export async function loadStarkNetCrossChainInterfaces(
   // Set the deposit owner
   starkNetBitcoinDepositor.setDepositOwner(StarkNetAddress.from(walletAddress))
 
-  // Create token instance
-  let starkNetTbtcToken: StarkNetTBTCToken
-
-  if (provider) {
-    // Provider available - create full implementation with balance queries
-    const tokenContract = Object.prototype.hasOwnProperty.call(
-      TBTC_CONTRACT_ADDRESSES,
-      chainId
-    )
-      ? TBTC_CONTRACT_ADDRESSES[chainId]
-      : undefined
-    if (!tokenContract) {
-      throw new Error(`No tBTC contract address for chain ${chainId}`)
-    }
-
-    const tokenConfig: StarkNetTBTCTokenConfig = {
-      chainId,
-      tokenContract,
-    }
-
-    starkNetTbtcToken = new StarkNetTBTCToken(tokenConfig, provider)
-  } else {
-    // No provider - create interface-only implementation
-    // This maintains backward compatibility for tests
-    const mockConfig: StarkNetTBTCTokenConfig = {
-      chainId,
-      tokenContract: "0x0", // Placeholder
-    }
-
-    // Create a mock provider that throws errors
-    const mockProvider = {
-      getChainId: () => Promise.resolve(chainId),
-    } as unknown as StarkNetProvider
-
-    starkNetTbtcToken = new StarkNetTBTCToken(mockConfig, mockProvider)
+  const tokenContract = Object.prototype.hasOwnProperty.call(
+    TBTC_CONTRACT_ADDRESSES,
+    chainId
+  )
+    ? TBTC_CONTRACT_ADDRESSES[chainId]
+    : undefined
+  if (!tokenContract) {
+    throw new Error(`No tBTC contract address for chain ${chainId}`)
   }
+
+  const tokenConfig: StarkNetTBTCTokenConfig = {
+    chainId,
+    tokenContract,
+  }
+
+  const starkNetTbtcToken = new StarkNetTBTCToken(tokenConfig, provider)
 
   return {
     destinationChainBitcoinDepositor: starkNetBitcoinDepositor,
@@ -138,13 +121,44 @@ export async function loadStarkNetCrossChainInterfaces(
  */
 export const loadStarkNetCrossChainContracts = loadStarkNetCrossChainInterfaces
 
-/**
- * Creates a mock StarkNet provider for testing purposes
- * @returns A mock StarkNet provider with minimal interface
- */
-function createMockProvider(): StarkNetProvider {
-  return {
-    getChainId: () => Promise.resolve("0x534e5f5345504f4c4941"),
-    // Add minimal provider interface for testing
-  } as StarkNetProvider
+async function validateProviderChain(
+  provider: StarkNetProvider,
+  expectedChainId: string
+): Promise<void> {
+  const providerChainId = await resolveProviderChainId(provider)
+  if (providerChainId !== normalizeStarkNetChainId(expectedChainId)) {
+    throw new Error(
+      `StarkNet provider chain mismatch: expected ${expectedChainId}, got ${providerChainId}`
+    )
+  }
+}
+
+async function resolveProviderChainId(
+  provider: StarkNetProvider
+): Promise<string> {
+  if ("getChainId" in provider && typeof provider.getChainId === "function") {
+    return normalizeStarkNetChainId(await provider.getChainId())
+  }
+
+  const nestedProvider = (provider as any).provider
+  if (
+    nestedProvider &&
+    typeof nestedProvider === "object" &&
+    "getChainId" in nestedProvider &&
+    typeof nestedProvider.getChainId === "function"
+  ) {
+    return normalizeStarkNetChainId(await nestedProvider.getChainId())
+  }
+
+  throw new Error("StarkNet provider must expose getChainId")
+}
+
+function normalizeStarkNetChainId(chainId: string): string {
+  const aliases: Record<string, string> = {
+    SN_MAIN: Chains.StarkNet.Mainnet,
+    SN_SEPOLIA: Chains.StarkNet.Sepolia,
+    SN_GOERLI: Chains.StarkNet.Sepolia,
+  }
+
+  return aliases[chainId] || chainId.toLowerCase()
 }

--- a/typescript/src/lib/starknet/index.ts
+++ b/typescript/src/lib/starknet/index.ts
@@ -59,11 +59,13 @@ export async function loadStarkNetCrossChainInterfaces(
     throw new Error("StarkNet provider is required")
   }
 
-  await validateProviderChain(provider, chainId)
+  const normalizedChainId = normalizeStarkNetChainId(chainId)
+
+  await validateProviderChain(provider, normalizedChainId)
 
   // Build depositor configuration with environment variable support
   const depositorConfig: StarkNetBitcoinDepositorConfig = {
-    chainId,
+    chainId: normalizedChainId,
     relayerUrl: process.env.STARKNET_RELAYER_URL, // Optional override
     relayerStatusUrl:
       relayerStatusUrl || process.env.STARKNET_RELAYER_STATUS_URL, // Optional override
@@ -95,16 +97,16 @@ export async function loadStarkNetCrossChainInterfaces(
 
   const tokenContract = Object.prototype.hasOwnProperty.call(
     TBTC_CONTRACT_ADDRESSES,
-    chainId
+    normalizedChainId
   )
-    ? TBTC_CONTRACT_ADDRESSES[chainId]
+    ? TBTC_CONTRACT_ADDRESSES[normalizedChainId]
     : undefined
   if (!tokenContract) {
-    throw new Error(`No tBTC contract address for chain ${chainId}`)
+    throw new Error(`No tBTC contract address for chain ${normalizedChainId}`)
   }
 
   const tokenConfig: StarkNetTBTCTokenConfig = {
-    chainId,
+    chainId: normalizedChainId,
     tokenContract,
   }
 

--- a/typescript/src/lib/starknet/starknet-depositor.ts
+++ b/typescript/src/lib/starknet/starknet-depositor.ts
@@ -569,13 +569,6 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier
   ): Promise<Hex | TransactionReceipt> {
-    // Check if deposit owner is set
-    if (!this.#depositOwner) {
-      throw new Error(
-        "L2 deposit owner must be set before initializing deposit"
-      )
-    }
-
     const { fundingTx, reveal } = packRevealDepositParameters(
       depositTx,
       depositOutputIndex,
@@ -587,11 +580,21 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
       ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
       : this.#depositOwner
 
+    if (!depositOwner) {
+      throw new Error(
+        "L2 deposit owner must be set before initializing deposit"
+      )
+    }
+
+    const l2SenderOwner = this.#depositOwner ?? depositOwner
+
     // Format addresses for relayer
     const formattedL2DepositOwner = this.formatStarkNetAddressAsBytes32(
       depositOwner.toString()
     )
-    const formattedL2Sender = formattedL2DepositOwner
+    const formattedL2Sender = this.formatStarkNetAddressAsBytes32(
+      l2SenderOwner.toString()
+    )
 
     // Derive the canonical deposit ID once, up front, so it is available on
     // BOTH the success path (for logging) and the 409-conflict path (to

--- a/typescript/src/lib/starknet/starknet-depositor.ts
+++ b/typescript/src/lib/starknet/starknet-depositor.ts
@@ -11,7 +11,6 @@ import { StarkNetProvider } from "./types"
 import { Hex } from "../utils"
 import { packRevealDepositParameters } from "../ethereum"
 import axios from "axios"
-import { ethers } from "ethers"
 import { TransactionReceipt } from "@ethersproject/providers"
 
 /**
@@ -583,16 +582,15 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
       vault
     )
 
-    // Use deposit owner from extraData if available, otherwise use the set owner
-    const l2DepositOwner = deposit.extraData
-      ? deposit.extraData.toString()
-      : this.#depositOwner.toString()
-    const l2Sender = this.#depositOwner.toString()
+    const depositOwner = deposit.extraData
+      ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
+      : this.#depositOwner
 
     // Format addresses for relayer
-    const formattedL2DepositOwner =
-      this.formatStarkNetAddressAsBytes32(l2DepositOwner)
-    const formattedL2Sender = this.formatStarkNetAddressAsBytes32(l2Sender)
+    const formattedL2DepositOwner = this.formatStarkNetAddressAsBytes32(
+      depositOwner.toString()
+    )
+    const formattedL2Sender = formattedL2DepositOwner
 
     // Derive the canonical deposit ID once, up front, so it is available on
     // BOTH the success path (for logging) and the 409-conflict path (to
@@ -624,16 +622,6 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
           l2DepositOwner: formattedL2DepositOwner,
           l2Sender: formattedL2Sender,
         }
-
-        console.log(
-          `Sending reveal request to relayer (attempt ${attempt + 1}/${
-            maxRetries + 1
-          }):`,
-          {
-            url: this.#config.relayerUrl,
-            payload: requestPayload,
-          }
-        )
 
         const response = await axios.post<RelayerRevealResponse>(
           this.#config.relayerUrl!,
@@ -697,7 +685,6 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
         if (locallyDerivedDepositId) {
           console.log(`Deposit initialized with ID: ${locallyDerivedDepositId}`)
         }
-
         return data.receipt as TransactionReceipt
       } catch (error: any) {
         lastError = error
@@ -737,7 +724,6 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
 
     // Format and throw the error
     const formattedError = this.formatRelayerError(lastError)
-    console.error("StarkNet depositor throwing error:", formattedError)
     throw new Error(formattedError)
   }
 
@@ -1012,26 +998,7 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
    * @throws Error if the address is invalid
    */
   private formatStarkNetAddressAsBytes32(address: string): string {
-    // Ensure 0x prefix
-    if (!address.startsWith("0x")) {
-      address = "0x" + address
-    }
-
-    // Must be exactly 66 characters (0x + 64 hex)
-    if (address.length !== 66) {
-      throw new Error(
-        `Invalid StarkNet address length: ${address.length}. Expected 66 characters (0x + 64 hex).`
-      )
-    }
-
-    // Validate hex format
-    if (!/^0x[0-9a-fA-F]{64}$/.test(address)) {
-      throw new Error(
-        `Invalid StarkNet address format: ${address}. Must be 0x followed by 64 hexadecimal characters.`
-      )
-    }
-
-    return address.toLowerCase()
+    return StarkNetAddress.from(address).toBytes32()
   }
 }
 

--- a/typescript/src/lib/starknet/starknet-depositor.ts
+++ b/typescript/src/lib/starknet/starknet-depositor.ts
@@ -11,6 +11,7 @@ import { StarkNetProvider } from "./types"
 import { Hex } from "../utils"
 import { packRevealDepositParameters } from "../ethereum"
 import axios from "axios"
+import { ethers } from "ethers"
 import { TransactionReceipt } from "@ethersproject/providers"
 
 /**

--- a/typescript/src/lib/sui/bitcoin-depositor.ts
+++ b/typescript/src/lib/sui/bitcoin-depositor.ts
@@ -56,7 +56,16 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
   /**
    * @see {BitcoinDepositor#setDepositOwner}
    */
-  setDepositOwner(depositOwner: ChainIdentifier): void {
+  setDepositOwner(depositOwner: ChainIdentifier | undefined): void {
+    if (depositOwner === undefined || depositOwner === null) {
+      this.#depositOwner = undefined
+      return
+    }
+
+    if (!(depositOwner instanceof SuiAddress)) {
+      throw new Error("Deposit owner must be a SUI address")
+    }
+
     this.#depositOwner = depositOwner
   }
 
@@ -78,8 +87,15 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier // Ignored for SUI - no vault support
   ): Promise<Hex | any> {
-    // This method is called by CrossChainDepositor in L2Transaction mode
-    // It initiates the deposit on SUI, which triggers the relayer
+    const depositOwner = deposit.extraData
+      ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
+      : this.#depositOwner
+
+    if (!depositOwner) {
+      throw new SuiError(
+        "SUI deposit owner must be set before initializing deposit"
+      )
+    }
 
     // Import SUI SDK with error handling
     let Transaction: typeof import("@mysten/sui/transactions").Transaction
@@ -104,19 +120,16 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
       depositOutputIndex
     )
 
-    // Extract deposit owner from extra data
-    const depositOwner = deposit.extraData
-      ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
-          .identifierHex
-      : this.#depositOwner?.identifierHex || ""
-
     // Call initialize_deposit on the Move module
     tx.moveCall({
       target: `${this.#packageId}::BitcoinDepositor::initialize_deposit`,
       arguments: [
         tx.pure.vector("u8", Array.from(fundingTx)),
         tx.pure.vector("u8", Array.from(depositReveal)),
-        tx.pure.vector("u8", Array.from(Buffer.from(depositOwner, "hex"))),
+        tx.pure.vector(
+          "u8",
+          Array.from(Buffer.from(depositOwner.identifierHex, "hex"))
+        ),
       ],
     })
 
@@ -177,10 +190,7 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
       )
 
       if (!depositEvent) {
-        console.warn(
-          "DepositInitialized event not found in transaction. " +
-            "The relayer may not process this deposit."
-        )
+        throw new SuiError("DepositInitialized event not found in transaction")
       }
 
       // Return the indexed transaction result which has all the proper fields

--- a/typescript/src/lib/sui/bitcoin-depositor.ts
+++ b/typescript/src/lib/sui/bitcoin-depositor.ts
@@ -56,7 +56,7 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
   /**
    * @see {BitcoinDepositor#setDepositOwner}
    */
-  setDepositOwner(depositOwner: ChainIdentifier | undefined): void {
+  setDepositOwner(depositOwner: ChainIdentifier | null | undefined): void {
     if (depositOwner === undefined || depositOwner === null) {
       this.#depositOwner = undefined
       return
@@ -87,9 +87,17 @@ export class SuiBitcoinDepositor implements BitcoinDepositor {
     deposit: DepositReceipt,
     vault?: ChainIdentifier // Ignored for SUI - no vault support
   ): Promise<Hex | any> {
-    const depositOwner = deposit.extraData
-      ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
-      : this.#depositOwner
+    let depositOwner: ChainIdentifier | undefined
+    try {
+      depositOwner = deposit.extraData
+        ? this.#extraDataEncoder.decodeDepositOwner(deposit.extraData)
+        : this.#depositOwner
+    } catch (error) {
+      throw new SuiError(
+        "Failed to decode SUI deposit owner from extra data",
+        error
+      )
+    }
 
     if (!depositOwner) {
       throw new SuiError(

--- a/typescript/src/services/tbtc.ts
+++ b/typescript/src/services/tbtc.ts
@@ -14,7 +14,8 @@ import type { AnchorProvider } from "@coral-xyz/anchor"
 import type { StarkNetProvider } from "../lib/starknet"
 import type { SuiSignerWithAddress } from "../lib/sui"
 import { TBTC as TBTCCore } from "./tbtc-core"
-import { providers } from "ethers"
+import { providers, Signer } from "ethers"
+import { StarkNetAddress } from "../lib/starknet/address"
 
 // Re-export everything from the base module so that consumers importing
 // from the root entry point get the same symbols as from /core.
@@ -168,6 +169,13 @@ export class TBTC extends TBTCCore {
       throw new Error("StarkNet provider is required")
     }
 
+    if (
+      Signer.isSigner(provider) ||
+      ("getNetwork" in provider && typeof provider.getNetwork === "function")
+    ) {
+      throw new Error("Expected a StarkNet provider or account")
+    }
+
     let address: string | undefined
 
     // Check if it's an Account object with address property
@@ -192,14 +200,7 @@ export class TBTC extends TBTCCore {
       )
     }
 
-    // Validate address format (basic check for hex string)
-    // StarkNet addresses are felt252 values represented as hex strings
-    if (!/^0x[0-9a-fA-F]+$/.test(address)) {
-      throw new Error("Invalid StarkNet address format")
-    }
-
-    // Normalize to lowercase for consistency
-    return address.toLowerCase()
+    return StarkNetAddress.from(address).toString()
   }
 
   /**
@@ -318,27 +319,9 @@ export class TBTC extends TBTCCore {
         }
 
         const starknetProvider = signerOrEthereumSigner as StarkNetProvider
-        let walletAddressHex: string
-
-        // Extract address from StarkNet provider using the new method
-        try {
-          walletAddressHex = await TBTC.extractStarkNetAddress(starknetProvider)
-        } catch (error) {
-          // Check if it's a Provider-only (no account) for backward compatibility
-          // Only apply backward compatibility if it's NOT an Account object
-          if (
-            !("address" in starknetProvider) &&
-            !("account" in starknetProvider) &&
-            "getChainId" in starknetProvider &&
-            typeof starknetProvider.getChainId === "function"
-          ) {
-            // Provider-only - use placeholder address for backward compatibility
-            walletAddressHex = "0x0"
-          } else {
-            // Re-throw the error for invalid providers or invalid addresses
-            throw error
-          }
-        }
+        const walletAddressHex = await TBTC.extractStarkNetAddress(
+          starknetProvider
+        )
 
         const { loadStarkNetCrossChainInterfaces } = await import(
           "../lib/starknet"

--- a/typescript/src/services/tbtc.ts
+++ b/typescript/src/services/tbtc.ts
@@ -365,13 +365,18 @@ export class TBTC extends TBTCCore {
         // prettier-ignore
         break;
       case "Solana":
+        const solanaChainId = chainMapping.solana
+        if (!solanaChainId) {
+          throw new Error("Solana chain ID not available in chain mapping")
+        }
         if (!signerOrEthereumSigner) {
           throw new Error("Solana provider is required")
         }
         this._l2Signer = signerOrEthereumSigner as AnchorProvider
         const { loadSolanaCrossChainInterfaces } = await import("../lib/solana")
         l2CrossChainContracts = await loadSolanaCrossChainInterfaces(
-          signerOrEthereumSigner as AnchorProvider
+          signerOrEthereumSigner as AnchorProvider,
+          solanaChainId
         )
         // prettier-ignore
         break;

--- a/typescript/test/integration/starknet-single-param-flow.test.ts
+++ b/typescript/test/integration/starknet-single-param-flow.test.ts
@@ -18,7 +18,7 @@ const axios = require("axios")
 
 const STARKNET_ADDRESS =
   "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-const TEST_CHAIN_ID = "0x534e5f544553544e4554"
+const TEST_CHAIN_ID = "0x534e5f5345504f4c4941"
 
 function createMockStarkNetAccount(address = STARKNET_ADDRESS): any {
   return {
@@ -34,9 +34,9 @@ describe("StarkNet Single-Parameter Deposit Flow", () => {
   let mockBitcoinClient: BitcoinClient
 
   beforeEach(async () => {
-    // Mock loadStarkNetCrossChainContracts
+    // Mock loadStarkNetCrossChainInterfaces
     sinon
-      .stub(starknet, "loadStarkNetCrossChainContracts")
+      .stub(starknet, "loadStarkNetCrossChainInterfaces")
       .callsFake(
         async (
           walletAddress: string,

--- a/typescript/test/integration/starknet-single-param-flow.test.ts
+++ b/typescript/test/integration/starknet-single-param-flow.test.ts
@@ -6,7 +6,6 @@ use(chaiAsPromised)
 
 import { TBTC } from "../../src/services/tbtc"
 import { BitcoinClient } from "../../src/lib/bitcoin"
-import { RpcProvider, Account } from "starknet"
 import { BitcoinRawTxVectors } from "../../src/lib/bitcoin"
 import { DepositReceipt } from "../../src/lib/contracts/bridge"
 import { Hex } from "../../src/lib/utils"
@@ -16,6 +15,17 @@ import { TransactionReceipt } from "@ethersproject/providers"
 
 // Mock axios for relayer calls
 const axios = require("axios")
+
+const STARKNET_ADDRESS =
+  "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+const TEST_CHAIN_ID = "0x534e5f544553544e4554"
+
+function createMockStarkNetAccount(address = STARKNET_ADDRESS): any {
+  return {
+    address,
+    getChainId: async () => TEST_CHAIN_ID,
+  }
+}
 
 describe("StarkNet Single-Parameter Deposit Flow", () => {
   let tbtc: TBTC
@@ -146,15 +156,8 @@ describe("StarkNet Single-Parameter Deposit Flow", () => {
   describe("Complete deposit flow with single-parameter", () => {
     it("should complete deposit with only StarkNet wallet", async () => {
       // Arrange
-      const starknetAddress =
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      const starknetAccount = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        starknetAddress,
-        "0x1" // dummy private key for testing
-      )
+      const starknetAddress = STARKNET_ADDRESS
+      const starknetAccount = createMockStarkNetAccount(starknetAddress)
 
       // Mock relayer response
       axiosStub.resolves({
@@ -226,15 +229,8 @@ describe("StarkNet Single-Parameter Deposit Flow", () => {
 
     it("should preserve StarkNet address through entire flow", async () => {
       // Arrange
-      const starknetAddress =
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      const starknetAccount = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        starknetAddress,
-        "0x1"
-      )
+      const starknetAddress = STARKNET_ADDRESS
+      const starknetAccount = createMockStarkNetAccount(starknetAddress)
 
       // Mock relayer to capture the request
       let capturedRequest: any
@@ -292,13 +288,7 @@ describe("StarkNet Single-Parameter Deposit Flow", () => {
       this.timeout(15000) // Increase timeout to handle retry delays
 
       // Arrange
-      const starknetAccount = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const starknetAccount = createMockStarkNetAccount()
 
       // Mock setTimeout to speed up retries
       const setTimeoutStub = sinon
@@ -378,13 +368,7 @@ describe("StarkNet Single-Parameter Deposit Flow", () => {
       this.timeout(15000) // Increase timeout to handle retry delays
 
       // Arrange
-      const starknetAccount = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const starknetAccount = createMockStarkNetAccount()
 
       // Mock setTimeout to speed up retries
       const setTimeoutStub = sinon

--- a/typescript/test/lib/electrum.test.ts
+++ b/typescript/test/lib/electrum.test.ts
@@ -207,6 +207,26 @@ describe("Electrum", () => {
     })
   })
 
+  describe("response validation", () => {
+    it("should reject a raw transaction that does not match the requested hash", async () => {
+      const client = new ElectrumClient([])
+      const wrongTransactionHash = BitcoinTxHash.from(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      )
+
+      const clientWithMockedElectrum = client as any
+      clientWithMockedElectrum.withElectrum = async (action: any) =>
+        action({
+          blockchain_transaction_get: async () =>
+            testnetRawTransaction.transactionHex,
+        })
+
+      await expect(
+        client.getRawTransaction(wrongTransactionHash)
+      ).to.be.rejectedWith("Transaction hash mismatch")
+    })
+  })
+
   /**
    * This test suite is meant to check the behavior of the Electrum-based
    * Bitcoin client implementation. This suite requires an integration with a

--- a/typescript/test/lib/electrum.test.ts
+++ b/typescript/test/lib/electrum.test.ts
@@ -225,6 +225,63 @@ describe("Electrum", () => {
         client.getRawTransaction(wrongTransactionHash)
       ).to.be.rejectedWith("Transaction hash mismatch")
     })
+
+    it("should reject getTransaction when raw hex does not match the requested hash", async () => {
+      const client = new ElectrumClient([])
+      const wrongTransactionHash = BitcoinTxHash.from(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      )
+
+      const clientWithMockedElectrum = client as any
+      clientWithMockedElectrum.withElectrum = async (action: any) =>
+        action({
+          blockchain_transaction_get: async () =>
+            testnetRawTransaction.transactionHex,
+        })
+
+      await expect(
+        client.getTransaction(wrongTransactionHash)
+      ).to.be.rejectedWith("Transaction hash mismatch")
+    })
+
+    it("should reject getTransactionConfirmations when raw hex does not match the requested hash", async () => {
+      const client = new ElectrumClient([])
+      const wrongTransactionHash = BitcoinTxHash.from(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      )
+
+      const clientWithMockedElectrum = client as any
+      clientWithMockedElectrum.withElectrum = async (action: any) =>
+        action({
+          blockchain_transaction_get: async () =>
+            testnetRawTransaction.transactionHex,
+        })
+
+      await expect(
+        client.getTransactionConfirmations(wrongTransactionHash)
+      ).to.be.rejectedWith("Transaction hash mismatch")
+    })
+
+    it("should reject merkle proofs whose block_height does not match the request", async () => {
+      const client = new ElectrumClient([])
+
+      const clientWithMockedElectrum = client as any
+      clientWithMockedElectrum.withElectrum = async (action: any) =>
+        action({
+          blockchain_transaction_getMerkle: async () => ({
+            block_height: 999999,
+            merkle: ["abc"],
+            pos: 0,
+          }),
+        })
+
+      await expect(
+        client.getTransactionMerkle(
+          testnetTransaction.transactionHash,
+          testnetTransactionMerkleBranch.blockHeight
+        )
+      ).to.be.rejectedWith("Merkle proof block height mismatch")
+    })
   })
 
   /**

--- a/typescript/test/lib/solana/index.test.ts
+++ b/typescript/test/lib/solana/index.test.ts
@@ -1,0 +1,30 @@
+import chai, { expect } from "chai"
+import chaiAsPromised from "chai-as-promised"
+
+import { Chains } from "../../../src/lib/contracts"
+import { loadSolanaCrossChainInterfaces } from "../../../src/lib/solana"
+
+chai.use(chaiAsPromised)
+
+describe("Solana Module", () => {
+  describe("loadSolanaCrossChainInterfaces", () => {
+    it("should reject a provider connected to a different genesis hash", async () => {
+      const provider = {
+        wallet: {
+          publicKey: {
+            toBase58: () => "11111111111111111111111111111111",
+          },
+        },
+        connection: {
+          getGenesisHash: async () => Chains.Solana.Devnet,
+        },
+      }
+
+      await expect(
+        loadSolanaCrossChainInterfaces(provider as any, Chains.Solana.Solana)
+      ).to.be.rejectedWith(
+        `Solana provider genesis hash mismatch: expected ${Chains.Solana.Solana}, got ${Chains.Solana.Devnet}`
+      )
+    })
+  })
+})

--- a/typescript/test/lib/solana/solana-depositor-interface.test.ts
+++ b/typescript/test/lib/solana/solana-depositor-interface.test.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai"
+import chaiAsPromised from "chai-as-promised"
+import chai from "chai"
+import sinon from "sinon"
+import axios from "axios"
+import { SolanaDepositorInterface } from "../../../src/lib/solana/solana-depositor-interface"
+import {
+  SolanaAddress,
+  SolanaExtraDataEncoder,
+} from "../../../src/lib/solana"
+import { BitcoinRawTxVectors } from "../../../src/lib/bitcoin"
+import { DepositReceipt } from "../../../src/lib/contracts"
+import { Hex } from "../../../src/lib/utils"
+import { EthereumAddress } from "../../../src/lib/ethereum"
+
+chai.use(chaiAsPromised)
+
+describe("SolanaDepositorInterface", () => {
+  let depositor: SolanaDepositorInterface
+  let axiosStub: sinon.SinonStub
+  const ownerAddress = "11111111111111111111111111111111"
+  const senderAddress = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+  const depositTx: BitcoinRawTxVectors = {
+    version: Hex.from("0x02000000"),
+    inputs: Hex.from("0x01234567"),
+    outputs: Hex.from("0x89abcdef"),
+    locktime: Hex.from("0x00000000"),
+  }
+
+  function buildDeposit(extraData?: Hex): DepositReceipt {
+    const encoder = new SolanaExtraDataEncoder()
+    const owner = SolanaAddress.from(ownerAddress)
+    return {
+      depositor: EthereumAddress.from("0x" + "1".repeat(40)),
+      walletPublicKeyHash: Hex.from("0x" + "2".repeat(40)),
+      refundPublicKeyHash: Hex.from("0x" + "3".repeat(40)),
+      blindingFactor: Hex.from("0x" + "4".repeat(16)),
+      refundLocktime: Hex.from("0x" + "5".repeat(8)),
+      extraData: extraData ?? encoder.encodeDepositOwner(owner),
+    }
+  }
+
+  const validReceipt = {
+    transactionHash: "0x" + "a".repeat(64),
+    blockNumber: 1,
+    blockHash: "0x" + "b".repeat(64),
+    confirmations: 1,
+    from: "0x" + "c".repeat(40),
+    to: "0x" + "d".repeat(40),
+    gasUsed: { toString: () => "21000" },
+    logs: [],
+  }
+
+  beforeEach(() => {
+    depositor = new SolanaDepositorInterface()
+    axiosStub = sinon.stub(axios, "post")
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it("should reject when deposit owner is missing", async () => {
+    const deposit = buildDeposit()
+    deposit.extraData = undefined
+
+    await expect(
+      depositor.initializeDeposit(depositTx, 0, deposit)
+    ).to.be.rejectedWith("Extra data is required.")
+    expect(axiosStub.called).to.be.false
+  })
+
+  it("should post to HTTPS relayer URL", async () => {
+    depositor.setDepositOwner(SolanaAddress.from(senderAddress))
+    axiosStub.resolves({ data: { receipt: validReceipt } })
+
+    await depositor.initializeDeposit(depositTx, 0, buildDeposit())
+
+    expect(axiosStub.calledOnce).to.be.true
+    expect(axiosStub.getCall(0).args[0]).to.equal(
+      "https://relayer.tbtcscan.com/api/reveal"
+    )
+  })
+
+  it("should reject malformed receipt responses", async () => {
+    depositor.setDepositOwner(SolanaAddress.from(senderAddress))
+    axiosStub.resolves({ data: { receipt: { transactionHash: "not-hex" } } })
+
+    await expect(
+      depositor.initializeDeposit(depositTx, 0, buildDeposit())
+    ).to.be.rejectedWith("Unexpected response from /api/reveal")
+  })
+
+  it("should send aligned owner encodings on valid receipt path", async () => {
+    depositor.setDepositOwner(SolanaAddress.from(senderAddress))
+    axiosStub.resolves({ data: { receipt: validReceipt } })
+
+    await depositor.initializeDeposit(depositTx, 0, buildDeposit())
+
+    const payload = axiosStub.getCall(0).args[1]
+    const owner = SolanaAddress.from(ownerAddress)
+    expect(payload.l2DepositOwner).to.equal(`0x${owner.identifierHex}`)
+    expect(payload.l2Sender).to.equal(
+      `0x${SolanaAddress.from(senderAddress).identifierHex}`
+    )
+    expect(axiosStub.getCall(0).args[2]).to.deep.include({ timeout: 90000 })
+  })
+})

--- a/typescript/test/lib/solana/solana-depositor-interface.test.ts
+++ b/typescript/test/lib/solana/solana-depositor-interface.test.ts
@@ -4,10 +4,7 @@ import chai from "chai"
 import sinon from "sinon"
 import axios from "axios"
 import { SolanaDepositorInterface } from "../../../src/lib/solana/solana-depositor-interface"
-import {
-  SolanaAddress,
-  SolanaExtraDataEncoder,
-} from "../../../src/lib/solana"
+import { SolanaAddress, SolanaExtraDataEncoder } from "../../../src/lib/solana"
 import { BitcoinRawTxVectors } from "../../../src/lib/bitcoin"
 import { DepositReceipt } from "../../../src/lib/contracts"
 import { Hex } from "../../../src/lib/utils"

--- a/typescript/test/lib/starknet/address.test.ts
+++ b/typescript/test/lib/starknet/address.test.ts
@@ -2,6 +2,9 @@ import { expect } from "chai"
 import { StarkNetAddress } from "../../../src/lib/starknet/address"
 
 describe("StarkNetAddress", () => {
+  const maxValidAddress =
+    "0x0800000000000011000000000000000000000000000000000000000000000000"
+
   describe("from", () => {
     it("should create address from valid hex string with 0x prefix", () => {
       const address = "0x1234567890abcdef"
@@ -38,9 +41,23 @@ describe("StarkNetAddress", () => {
     })
 
     it("should accept maximum length addresses (64 hex chars)", () => {
-      const address = "0x" + "f".repeat(64)
+      const address = "0x07" + "f".repeat(62)
       const starknetAddress = StarkNetAddress.from(address)
-      expect(starknetAddress.identifierHex).to.equal("f".repeat(64))
+      expect(starknetAddress.identifierHex).to.equal("07" + "f".repeat(62))
+    })
+
+    it("should accept the maximum StarkNet field element address", () => {
+      const starknetAddress = StarkNetAddress.from(maxValidAddress)
+      expect(starknetAddress.identifierHex).to.equal(maxValidAddress.slice(2))
+    })
+
+    it("should reject addresses outside the StarkNet field prime", () => {
+      const invalidAddress =
+        "0x0800000000000011000000000000000000000000000000000000000000000001"
+
+      expect(() => StarkNetAddress.from(invalidAddress)).to.throw(
+        `StarkNet address exceeds field prime range: ${invalidAddress}`
+      )
     })
 
     it("should throw error for invalid hex characters", () => {
@@ -116,9 +133,9 @@ describe("StarkNetAddress", () => {
     })
 
     it("should return properly formatted bytes32 for full address", () => {
-      const address = StarkNetAddress.from("0x" + "a".repeat(64))
+      const address = StarkNetAddress.from("0x07" + "a".repeat(62))
       const bytes32 = address.toBytes32()
-      expect(bytes32).to.equal("0x" + "a".repeat(64))
+      expect(bytes32).to.equal("0x07" + "a".repeat(62))
     })
   })
 

--- a/typescript/test/lib/starknet/extra-data-encoder.test.ts
+++ b/typescript/test/lib/starknet/extra-data-encoder.test.ts
@@ -6,6 +6,7 @@ import { Hex } from "../../../src/lib/utils"
 
 describe("StarkNetExtraDataEncoder", () => {
   let encoder: StarkNetExtraDataEncoder
+  const validFullLengthAddress = "0x07" + "f".repeat(62)
 
   beforeEach(() => {
     encoder = new StarkNetExtraDataEncoder()
@@ -22,10 +23,10 @@ describe("StarkNetExtraDataEncoder", () => {
     })
 
     it("should encode a full-length StarkNet address", () => {
-      const address = StarkNetAddress.from("0x" + "f".repeat(64))
+      const address = StarkNetAddress.from(validFullLengthAddress)
       const encoded = encoder.encodeDepositOwner(address)
 
-      expect(encoded.toPrefixedString()).to.equal("0x" + "f".repeat(64))
+      expect(encoded.toPrefixedString()).to.equal(validFullLengthAddress)
     })
 
     it("should encode a short StarkNet address with proper padding", () => {
@@ -83,11 +84,11 @@ describe("StarkNetExtraDataEncoder", () => {
     })
 
     it("should decode full-length hex to StarkNet address", () => {
-      const extraData = Hex.from("0x" + "f".repeat(64))
+      const extraData = Hex.from(validFullLengthAddress)
       const decoded = encoder.decodeDepositOwner(extraData)
 
       expect(decoded).to.be.instanceOf(StarkNetAddress)
-      expect(decoded.identifierHex).to.equal("f".repeat(64))
+      expect(decoded.identifierHex).to.equal(validFullLengthAddress.slice(2))
     })
 
     it("should throw error for invalid length hex", () => {
@@ -138,7 +139,7 @@ describe("StarkNetExtraDataEncoder", () => {
     })
 
     it("should handle maximum length addresses", () => {
-      const originalAddress = StarkNetAddress.from("0x" + "e".repeat(64))
+      const originalAddress = StarkNetAddress.from(validFullLengthAddress)
       const encoded = encoder.encodeDepositOwner(originalAddress)
       const decoded = encoder.decodeDepositOwner(encoded)
 

--- a/typescript/test/lib/starknet/index.test.ts
+++ b/typescript/test/lib/starknet/index.test.ts
@@ -2,14 +2,20 @@ import { expect } from "chai"
 import { loadStarkNetCrossChainInterfaces } from "../../../src/lib/starknet"
 import { StarkNetAddress } from "../../../src/lib/starknet"
 import { DestinationChainInterfaces } from "../../../src/lib/contracts"
+import { createMockProvider } from "./test-helpers"
 
 describe("StarkNet Module", () => {
   describe("loadStarkNetCrossChainInterfaces", () => {
     let contracts: DestinationChainInterfaces
+    let provider: any
 
     beforeEach(async () => {
+      provider = createMockProvider()
       const walletAddress = "0x1234567890abcdef"
-      contracts = await loadStarkNetCrossChainInterfaces(walletAddress)
+      contracts = await loadStarkNetCrossChainInterfaces(
+        walletAddress,
+        provider
+      )
     })
 
     it("should return DestinationChainInterfaces with required properties", () => {
@@ -41,7 +47,8 @@ describe("StarkNet Module", () => {
     it("should handle wallet address without 0x prefix", async () => {
       const walletAddress = "abcdef123456"
       const contractsWithoutPrefix = await loadStarkNetCrossChainInterfaces(
-        walletAddress
+        walletAddress,
+        provider
       )
 
       const depositOwner =
@@ -53,21 +60,22 @@ describe("StarkNet Module", () => {
     })
 
     it("should handle full-length wallet address", async () => {
-      const walletAddress = "0x" + "f".repeat(64)
+      const walletAddress = "0x07" + "f".repeat(62)
       const contractsFullLength = await loadStarkNetCrossChainInterfaces(
-        walletAddress
+        walletAddress,
+        provider
       )
 
       const depositOwner =
         contractsFullLength.destinationChainBitcoinDepositor.getDepositOwner()
-      expect(depositOwner?.identifierHex).to.equal("f".repeat(64))
+      expect(depositOwner?.identifierHex).to.equal("07" + "f".repeat(62))
     })
 
     it("should throw error for invalid wallet address", async () => {
       const invalidAddress = "xyz123" // Invalid hex
 
       await expect(
-        loadStarkNetCrossChainInterfaces(invalidAddress)
+        loadStarkNetCrossChainInterfaces(invalidAddress, provider)
       ).to.be.rejectedWith("Invalid StarkNet address format")
     })
 
@@ -75,7 +83,7 @@ describe("StarkNet Module", () => {
       const tooLongAddress = "0x" + "f".repeat(65) // 65 hex chars exceeds limit
 
       await expect(
-        loadStarkNetCrossChainInterfaces(tooLongAddress)
+        loadStarkNetCrossChainInterfaces(tooLongAddress, provider)
       ).to.be.rejectedWith(
         "StarkNet address exceeds maximum field element size"
       )
@@ -85,7 +93,7 @@ describe("StarkNet Module", () => {
       const addresses = ["0x111", "0x222", "0x333"]
 
       const promises = addresses.map((addr) =>
-        loadStarkNetCrossChainInterfaces(addr)
+        loadStarkNetCrossChainInterfaces(addr, provider)
       )
 
       const results = await Promise.all(promises)
@@ -100,14 +108,20 @@ describe("StarkNet Module", () => {
     })
 
     it("should handle empty string address", async () => {
-      await expect(loadStarkNetCrossChainInterfaces("")).to.be.rejectedWith(
-        "Invalid StarkNet address format"
-      )
+      await expect(
+        loadStarkNetCrossChainInterfaces("", provider)
+      ).to.be.rejectedWith("Invalid StarkNet address format")
     })
 
     it("should create independent instances for different addresses", async () => {
-      const contracts1 = await loadStarkNetCrossChainInterfaces("0x111")
-      const contracts2 = await loadStarkNetCrossChainInterfaces("0x222")
+      const contracts1 = await loadStarkNetCrossChainInterfaces(
+        "0x111",
+        provider
+      )
+      const contracts2 = await loadStarkNetCrossChainInterfaces(
+        "0x222",
+        provider
+      )
 
       // Verify they are different instances
       expect(contracts1.destinationChainBitcoinDepositor).to.not.equal(
@@ -123,6 +137,22 @@ describe("StarkNet Module", () => {
       const owner2 =
         contracts2.destinationChainBitcoinDepositor.getDepositOwner()
       expect(owner1?.identifierHex).to.not.equal(owner2?.identifierHex)
+    })
+
+    it("should require a provider", async () => {
+      await expect(
+        loadStarkNetCrossChainInterfaces("0x111", undefined as any)
+      ).to.be.rejectedWith("StarkNet provider is required")
+    })
+
+    it("should reject provider chain mismatches", async () => {
+      const wrongProvider = {
+        getChainId: () => Promise.resolve("SN_MAIN"),
+      }
+
+      await expect(
+        loadStarkNetCrossChainInterfaces("0x111", wrongProvider as any)
+      ).to.be.rejectedWith("StarkNet provider chain mismatch")
     })
   })
 

--- a/typescript/test/lib/starknet/index.test.ts
+++ b/typescript/test/lib/starknet/index.test.ts
@@ -154,6 +154,21 @@ describe("StarkNet Module", () => {
         loadStarkNetCrossChainInterfaces("0x111", wrongProvider as any)
       ).to.be.rejectedWith("StarkNet provider chain mismatch")
     })
+
+    it("should resolve SN_SEPOLIA alias for contract lookup", async () => {
+      const sepoliaProvider = {
+        getChainId: async () => "SN_SEPOLIA",
+      }
+
+      const contracts = await loadStarkNetCrossChainInterfaces(
+        "0x1234567890abcdef",
+        sepoliaProvider as any,
+        "SN_SEPOLIA"
+      )
+
+      expect(contracts.destinationChainTbtcToken).to.exist
+      expect(contracts.destinationChainBitcoinDepositor).to.exist
+    })
   })
 
   describe("module exports", () => {

--- a/typescript/test/lib/starknet/integration.test.ts
+++ b/typescript/test/lib/starknet/integration.test.ts
@@ -6,15 +6,19 @@ import {
 } from "../../../src/lib/starknet"
 import { Chains } from "../../../src/lib/contracts"
 import { Hex } from "../../../src/lib/utils"
+import { createMockProvider } from "./test-helpers"
 
 describe("StarkNet Integration Tests", () => {
+  const provider = createMockProvider()
+
   describe("L1 Bitcoin Depositor with StarkNet Integration", () => {
     it("should encode StarkNet recipient address for L1 deposit", async () => {
       // Create StarkNet contracts
       const starkNetRecipient =
         "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
       const contracts = await loadStarkNetCrossChainInterfaces(
-        starkNetRecipient
+        starkNetRecipient,
+        provider
       )
 
       // Get the extra data encoder
@@ -65,7 +69,10 @@ describe("StarkNet Integration Tests", () => {
     it("should handle deposit owner flow correctly", async () => {
       // Create contracts with initial owner
       const initialOwner = "0xaaa"
-      const contracts = await loadStarkNetCrossChainInterfaces(initialOwner)
+      const contracts = await loadStarkNetCrossChainInterfaces(
+        initialOwner,
+        provider
+      )
 
       // Verify initial owner is set
       const owner1 =
@@ -96,12 +103,16 @@ describe("StarkNet Integration Tests", () => {
         expect(() => StarkNetAddress.from(invalid)).to.throw()
 
         // Module loader should also fail
-        await expect(loadStarkNetCrossChainInterfaces(invalid)).to.be.rejected
+        await expect(loadStarkNetCrossChainInterfaces(invalid, provider)).to.be
+          .rejected
       }
     })
 
     it.skip("should handle error propagation correctly", async () => {
-      const contracts = await loadStarkNetCrossChainInterfaces("0x123")
+      const contracts = await loadStarkNetCrossChainInterfaces(
+        "0x123",
+        provider
+      )
 
       // Verify errors propagate correctly from token interface
       const validAddress = StarkNetAddress.from("0x456")
@@ -125,7 +136,7 @@ describe("StarkNet Integration Tests", () => {
       const addresses = Array.from({ length: 10 }, (_, i) => `0x${i}`)
 
       for (const addr of addresses) {
-        const contracts = await loadStarkNetCrossChainInterfaces(addr)
+        const contracts = await loadStarkNetCrossChainInterfaces(addr, provider)
         expect(contracts).to.exist
         expect(contracts.destinationChainBitcoinDepositor).to.exist
         expect(contracts.destinationChainTbtcToken).to.exist
@@ -133,8 +144,14 @@ describe("StarkNet Integration Tests", () => {
     })
 
     it("should maintain isolation between instances", async () => {
-      const contracts1 = await loadStarkNetCrossChainInterfaces("0x111")
-      const contracts2 = await loadStarkNetCrossChainInterfaces("0x222")
+      const contracts1 = await loadStarkNetCrossChainInterfaces(
+        "0x111",
+        provider
+      )
+      const contracts2 = await loadStarkNetCrossChainInterfaces(
+        "0x222",
+        provider
+      )
 
       // Change owner in first instance
       const newOwner = StarkNetAddress.from("0x333")

--- a/typescript/test/lib/starknet/module-integration.test.ts
+++ b/typescript/test/lib/starknet/module-integration.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import { loadStarkNetCrossChainContracts } from "../../../src/lib/starknet"
 import { L2Chain } from "../../../src/lib/contracts"
+import { createMockProvider } from "./test-helpers"
 
 describe("StarkNet Module Integration", () => {
   describe("SDK exports", () => {
@@ -39,7 +40,10 @@ describe("StarkNet Module Integration", () => {
     it("should support StarkNet in cross-chain contract loading", async () => {
       // Test that we can load StarkNet contracts
       const walletAddress = "0x1234567890abcdef1234567890abcdef12345678"
-      const contracts = await loadStarkNetCrossChainContracts(walletAddress)
+      const contracts = await loadStarkNetCrossChainContracts(
+        walletAddress,
+        createMockProvider()
+      )
 
       expect(contracts).to.have.property("destinationChainBitcoinDepositor")
       expect(contracts).to.have.property("destinationChainTbtcToken")

--- a/typescript/test/lib/starknet/provider-integration.test.ts
+++ b/typescript/test/lib/starknet/provider-integration.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { RpcProvider, Account } from "starknet"
+import { Account } from "starknet"
 import { TBTC } from "../../../src/services/tbtc"
 import {
   StarkNetAddress,
@@ -11,6 +11,23 @@ import { MockTBTCContracts } from "../../utils/mock-tbtc-contracts"
 import { MockCrossChainContractsLoader } from "../../utils/mock-cross-chain-contracts-loader"
 import { Chains } from "../../../src/lib/contracts/chain"
 import { BigNumber } from "ethers"
+
+const STARKNET_ADDRESS =
+  "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+
+function createMockAccount(address = STARKNET_ADDRESS): any {
+  return {
+    address,
+    getChainId: async () => "SN_SEPOLIA",
+  }
+}
+
+function createProviderWithAccount(address = STARKNET_ADDRESS): any {
+  return {
+    account: { address },
+    getChainId: async () => "SN_SEPOLIA",
+  }
+}
 
 describe("StarkNet Provider Integration", () => {
   let tbtc: TBTC
@@ -33,11 +50,8 @@ describe("StarkNet Provider Integration", () => {
   })
 
   describe("Complete deposit flow with provider", () => {
-    it("should complete deposit flow with Provider instance", async () => {
-      // Arrange
-      const starknetProvider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+    it("should complete deposit flow with provider connected to account", async () => {
+      const starknetProvider = createProviderWithAccount()
 
       // Initialize cross-chain with provider
       await tbtc.initializeCrossChain("StarkNet", starknetProvider)
@@ -64,12 +78,7 @@ describe("StarkNet Provider Integration", () => {
     })
 
     it("should complete deposit flow with Account instance", async () => {
-      // Arrange
-      const mockAccount = {
-        address:
-          "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        // Mock account methods
-      } as unknown as Account
+      const mockAccount = createMockAccount()
 
       // Initialize cross-chain with account
       await tbtc.initializeCrossChain("StarkNet", mockAccount)
@@ -85,20 +94,15 @@ describe("StarkNet Provider Integration", () => {
   })
 
   describe("Provider type validation", () => {
-    it("should accept Provider instance", async () => {
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-mainnet.public.blastapi.io/rpc/v0_6",
-      })
+    it("should accept provider with connected account", async () => {
+      const provider = createProviderWithAccount()
 
       await expect(tbtc.initializeCrossChain("StarkNet", provider)).to.not.be
         .rejected
     })
 
     it("should accept Account instance", async () => {
-      const account = {
-        address: "0x123",
-        // Minimal Account interface
-      } as unknown as Account
+      const account = createMockAccount("0x123")
 
       await expect(tbtc.initializeCrossChain("StarkNet", account)).to.not.be
         .rejected
@@ -195,7 +199,11 @@ describe("StarkNet Provider Integration", () => {
       mockProvider = {
         nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
       }
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       depositor = new StarkNetBitcoinDepositor(config, "StarkNet", mockProvider)
     })
 
@@ -221,15 +229,13 @@ describe("StarkNet Provider Integration", () => {
   describe("End-to-end provider scenarios", () => {
     it("should handle provider switching", async () => {
       // Initialize with first provider
-      const provider1 = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider1 = createProviderWithAccount()
       await tbtc.initializeCrossChain("StarkNet", provider1)
 
       // Switch to different provider
-      const provider2 = new RpcProvider({
-        nodeUrl: "https://starknet-mainnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider2 = createProviderWithAccount(
+        "0x06904a90dcc86f096c4f6daafa2d4e96cb926e5301bb5e6ed5cedc9981fa7064"
+      )
       await tbtc.initializeCrossChain("StarkNet", provider2)
 
       // Verify contracts were updated but _l2Signer not stored
@@ -242,15 +248,14 @@ describe("StarkNet Provider Integration", () => {
 
     it("should handle mixed provider types", async () => {
       // Start with Provider
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider = createProviderWithAccount()
       await tbtc.initializeCrossChain("StarkNet", provider)
 
       // Switch to Account
       const account = {
         address: "0x123",
         provider: provider,
+        getChainId: async () => "SN_SEPOLIA",
       } as unknown as Account
       await tbtc.initializeCrossChain("StarkNet", account)
 

--- a/typescript/test/lib/starknet/provider-integration.test.ts
+++ b/typescript/test/lib/starknet/provider-integration.test.ts
@@ -9,7 +9,6 @@ import {
 import { MockBitcoinClient } from "../../utils/mock-bitcoin-client"
 import { MockTBTCContracts } from "../../utils/mock-tbtc-contracts"
 import { MockCrossChainContractsLoader } from "../../utils/mock-cross-chain-contracts-loader"
-import { Chains } from "../../../src/lib/contracts/chain"
 import { BigNumber } from "ethers"
 
 const STARKNET_ADDRESS =
@@ -199,11 +198,7 @@ describe("StarkNet Provider Integration", () => {
       mockProvider = {
         nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
       }
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       depositor = new StarkNetBitcoinDepositor(config, "StarkNet", mockProvider)
     })
 
@@ -270,7 +265,7 @@ describe("StarkNet Provider Integration", () => {
 
   describe("Error handling", () => {
     it("should provide clear error when provider is missing", async () => {
-      const config = { chainId: Chains.StarkNet.Mainnet }
+      const config = { chainId: "SN_MAIN" }
 
       expect(
         () => new StarkNetBitcoinDepositor(config, "StarkNet", undefined as any)

--- a/typescript/test/lib/starknet/starknet-depositor-implementation.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-implementation.test.ts
@@ -84,7 +84,8 @@ describe("StarkNetDepositor - T-001 Implementation", () => {
         mockReceipt.extraData.toPrefixedString()
       )
       expect(stub.getCall(0).args[1].l2Sender).to.equal(
-        mockReceipt.extraData.toPrefixedString()
+        // @ts-ignore - accessing private method for testing
+        depositor["formatStarkNetAddressAsBytes32"](depositOwner.toString())
       )
     })
 
@@ -96,6 +97,7 @@ describe("StarkNetDepositor - T-001 Implementation", () => {
 
       const mockDepositTx = createMockDepositTx()
       const mockReceipt = createMockDeposit()
+      mockReceipt.extraData = undefined
 
       // Act & Assert
       try {

--- a/typescript/test/lib/starknet/starknet-depositor-implementation.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-implementation.test.ts
@@ -83,7 +83,9 @@ describe("StarkNetDepositor - T-001 Implementation", () => {
       expect(stub.getCall(0).args[1].l2DepositOwner).to.equal(
         mockReceipt.extraData.toPrefixedString()
       )
-      expect(stub.getCall(0).args[1].l2Sender).to.equal(depositOwner.toString())
+      expect(stub.getCall(0).args[1].l2Sender).to.equal(
+        mockReceipt.extraData.toPrefixedString()
+      )
     })
 
     it("should throw error if deposit owner not set", async () => {

--- a/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
@@ -80,13 +80,15 @@ describe("StarkNetDepositor Payload Format", () => {
     expect(payload).to.have.property("reveal")
   })
 
-  it("should validate StarkNet address format", () => {
-    const invalidAddress = "0x123" // Too short
+  it("should pad short StarkNet addresses", () => {
+    const address = "0x123"
 
-    expect(() => {
-      // @ts-ignore - accessing private method for testing
-      depositor["formatStarkNetAddressAsBytes32"](invalidAddress)
-    }).to.throw("Invalid StarkNet address length")
+    // @ts-ignore - accessing private method for testing
+    const formatted = depositor["formatStarkNetAddressAsBytes32"](address)
+
+    expect(formatted).to.equal(
+      "0x0000000000000000000000000000000000000000000000000000000000000123"
+    )
   })
 
   it("should format addresses as lowercase", async () => {
@@ -126,6 +128,44 @@ describe("StarkNetDepositor Payload Format", () => {
     // Should be lowercase
     expect(payload.l2DepositOwner).to.equal(testAddress.toLowerCase())
     expect(payload.l2Sender).to.equal(testAddress.toLowerCase())
+  })
+
+  it("should bind l2Sender to the owner encoded in deposit extra data", async () => {
+    axiosStub.resolves({
+      data: {
+        success: true,
+        receipt: {
+          transactionHash: "0xabc123",
+          blockNumber: 12345,
+        },
+      },
+    })
+
+    const receiptOwner =
+      "0x01268f380a5232144f34e7b7acf86b73ce1419eec641804823f66ce071482605"
+    depositor.setDepositOwner(StarkNetAddress.from(testAddress))
+
+    const depositTx: BitcoinRawTxVectors = {
+      version: Hex.from("02000000"),
+      inputs: Hex.from("01" + "a".repeat(64)),
+      outputs: Hex.from("02" + "e".repeat(64)),
+      locktime: Hex.from("00000000"),
+    }
+
+    const deposit: DepositReceipt = {
+      depositor: EthereumAddress.from("0x" + "0".repeat(40)),
+      walletPublicKeyHash: Hex.from("ef5a2946f294f1742a779c9ac034bc3fa5d417b8"),
+      refundPublicKeyHash: Hex.from("b4f19a044feea3aa4a7d3f494433a11d0f1c400e"),
+      blindingFactor: Hex.from("b3460f26eda61ad1"),
+      refundLocktime: Hex.from("a1faa569"),
+      extraData: Hex.from(receiptOwner),
+    }
+
+    await depositor.initializeDeposit(depositTx, 0, deposit)
+
+    const payload = axiosStub.getCall(0).args[1]
+    expect(payload.l2DepositOwner).to.equal(receiptOwner)
+    expect(payload.l2Sender).to.equal(receiptOwner)
   })
 
   it("should handle addresses without 0x prefix", () => {
@@ -209,6 +249,7 @@ describe("StarkNetDepositor Payload Format", () => {
     expect(payload).to.have.property("l2Sender")
   })
 
+<<<<<<< HEAD
   // The three exact-decimal expected values pinned below ("should calculate
   // deposit ID correctly", "should derive the canonical deposit ID for the
   // standard mock vectors (output index 0)", and "should pack the output
@@ -223,6 +264,9 @@ describe("StarkNetDepositor Payload Format", () => {
   // convention in deriveCanonicalDepositId's JSDoc.
   it("should calculate deposit ID correctly", async () => {
     // Mock console.log to capture deposit ID
+=======
+  it("should not log reveal request payloads", async () => {
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
     const consoleLogStub = sinon.stub(console, "log")
 
     axiosStub.resolves({
@@ -254,6 +298,7 @@ describe("StarkNetDepositor Payload Format", () => {
 
     await depositor.initializeDeposit(depositTx, 0, deposit)
 
+<<<<<<< HEAD
     // Verify the exact deposit ID was logged. The ID is derived with Bitcoin
     // SHA-256d over the serialized funding transaction (digest used directly,
     // NOT reversed) packed with the uint32 output index, matching the on-chain
@@ -267,6 +312,9 @@ describe("StarkNetDepositor Payload Format", () => {
       "Deposit initialized with ID: 84327574594609900513771153583252034476167624431248952116381071070685377716504"
     )
   })
+=======
+    expect(consoleLogStub.called).to.be.false
+>>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
   it("should derive the canonical deposit ID for the standard mock vectors (output index 0)", async () => {
     // Canonical vector: createMockDepositTx() with output index 0 must

--- a/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
@@ -249,7 +249,6 @@ describe("StarkNetDepositor Payload Format", () => {
     expect(payload).to.have.property("l2Sender")
   })
 
-<<<<<<< HEAD
   // The three exact-decimal expected values pinned below ("should calculate
   // deposit ID correctly", "should derive the canonical deposit ID for the
   // standard mock vectors (output index 0)", and "should pack the output
@@ -264,9 +263,6 @@ describe("StarkNetDepositor Payload Format", () => {
   // convention in deriveCanonicalDepositId's JSDoc.
   it("should calculate deposit ID correctly", async () => {
     // Mock console.log to capture deposit ID
-=======
-  it("should not log reveal request payloads", async () => {
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
     const consoleLogStub = sinon.stub(console, "log")
 
     axiosStub.resolves({
@@ -298,7 +294,6 @@ describe("StarkNetDepositor Payload Format", () => {
 
     await depositor.initializeDeposit(depositTx, 0, deposit)
 
-<<<<<<< HEAD
     // Verify the exact deposit ID was logged. The ID is derived with Bitcoin
     // SHA-256d over the serialized funding transaction (digest used directly,
     // NOT reversed) packed with the uint32 output index, matching the on-chain
@@ -312,9 +307,6 @@ describe("StarkNetDepositor Payload Format", () => {
       "Deposit initialized with ID: 84327574594609900513771153583252034476167624431248952116381071070685377716504"
     )
   })
-=======
-    expect(consoleLogStub.called).to.be.false
->>>>>>> 686d5e70 (fix(sdk): harden cross-chain depositor inputs)
 
   it("should derive the canonical deposit ID for the standard mock vectors (output index 0)", async () => {
     // Canonical vector: createMockDepositTx() with output index 0 must

--- a/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
@@ -130,7 +130,7 @@ describe("StarkNetDepositor Payload Format", () => {
     expect(payload.l2Sender).to.equal(testAddress.toLowerCase())
   })
 
-  it("should bind l2Sender to the owner encoded in deposit extra data", async () => {
+  it("should bind l2Sender to the connected deposit owner", async () => {
     axiosStub.resolves({
       data: {
         success: true,
@@ -165,7 +165,7 @@ describe("StarkNetDepositor Payload Format", () => {
 
     const payload = axiosStub.getCall(0).args[1]
     expect(payload.l2DepositOwner).to.equal(receiptOwner)
-    expect(payload.l2Sender).to.equal(receiptOwner)
+    expect(payload.l2Sender).to.equal(testAddress.toLowerCase())
   })
 
   it("should handle addresses without 0x prefix", () => {

--- a/typescript/test/lib/starknet/starknet-depositor.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor.test.ts
@@ -1,7 +1,6 @@
 import { expect } from "chai"
 import { StarkNetDepositor } from "../../../src/lib/starknet/starknet-depositor"
 import { StarkNetAddress } from "../../../src/lib/starknet/address"
-import { Chains } from "../../../src/lib/contracts/chain"
 import { createMockProvider } from "./test-helpers"
 
 describe("StarkNetDepositor", () => {
@@ -9,11 +8,7 @@ describe("StarkNetDepositor", () => {
     it("should initialize with provider", () => {
       // Arrange
       const mockProvider = createMockProvider()
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
       // Act
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
@@ -26,11 +21,7 @@ describe("StarkNetDepositor", () => {
     it("should store provider reference", () => {
       // Arrange
       const mockProvider = createMockProvider()
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
       // Act
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
@@ -41,11 +32,7 @@ describe("StarkNetDepositor", () => {
 
     it("should throw error if provider is undefined", () => {
       // Arrange
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
       // Act & Assert
       expect(
@@ -58,11 +45,7 @@ describe("StarkNetDepositor", () => {
     it("should return the chain name passed to constructor", () => {
       // Arrange
       const mockProvider = createMockProvider()
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
 
       // Act
@@ -77,11 +60,7 @@ describe("StarkNetDepositor", () => {
     it("should accept StarkNet address as deposit owner", () => {
       // Arrange
       const mockProvider = createMockProvider()
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
       const starknetAddress = StarkNetAddress.from("0x123456")
 
@@ -95,11 +74,7 @@ describe("StarkNetDepositor", () => {
     it("should throw error for non-StarkNet address", () => {
       // Arrange
       const mockProvider = createMockProvider()
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
       const invalidAddress = { identifierHex: "0x123" } as any
 
@@ -114,11 +89,7 @@ describe("StarkNetDepositor", () => {
     it("should provide access to extra data encoder", () => {
       // Arrange
       const mockProvider = createMockProvider()
-<<<<<<< HEAD
-      const config = { chainId: Chains.StarkNet.Mainnet }
-=======
       const config = { chainId: "0x534e5f4d41494e" }
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
       const starknetAddress = StarkNetAddress.from("0x123456")
 

--- a/typescript/test/lib/starknet/starknet-depositor.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor.test.ts
@@ -9,7 +9,11 @@ describe("StarkNetDepositor", () => {
     it("should initialize with provider", () => {
       // Arrange
       const mockProvider = createMockProvider()
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
       // Act
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
@@ -22,7 +26,11 @@ describe("StarkNetDepositor", () => {
     it("should store provider reference", () => {
       // Arrange
       const mockProvider = createMockProvider()
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
       // Act
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
@@ -33,7 +41,11 @@ describe("StarkNetDepositor", () => {
 
     it("should throw error if provider is undefined", () => {
       // Arrange
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
       // Act & Assert
       expect(
@@ -46,7 +58,11 @@ describe("StarkNetDepositor", () => {
     it("should return the chain name passed to constructor", () => {
       // Arrange
       const mockProvider = createMockProvider()
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
 
       // Act
@@ -61,7 +77,11 @@ describe("StarkNetDepositor", () => {
     it("should accept StarkNet address as deposit owner", () => {
       // Arrange
       const mockProvider = createMockProvider()
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
       const starknetAddress = StarkNetAddress.from("0x123456")
 
@@ -75,7 +95,11 @@ describe("StarkNetDepositor", () => {
     it("should throw error for non-StarkNet address", () => {
       // Arrange
       const mockProvider = createMockProvider()
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
       const invalidAddress = { identifierHex: "0x123" } as any
 
@@ -90,7 +114,11 @@ describe("StarkNetDepositor", () => {
     it("should provide access to extra data encoder", () => {
       // Arrange
       const mockProvider = createMockProvider()
+<<<<<<< HEAD
       const config = { chainId: Chains.StarkNet.Mainnet }
+=======
+      const config = { chainId: "0x534e5f4d41494e" }
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
       const depositor = new StarkNetDepositor(config, "StarkNet", mockProvider)
       const starknetAddress = StarkNetAddress.from("0x123456")
 

--- a/typescript/test/lib/starknet/test-helpers.ts
+++ b/typescript/test/lib/starknet/test-helpers.ts
@@ -21,6 +21,7 @@ export const STARKNET_ERROR_MESSAGES = {
   INVALID_ADDRESS_FORMAT: "Invalid StarkNet address format",
   ADDRESS_EXCEEDS_FIELD_SIZE:
     "StarkNet address exceeds maximum field element size",
+  ADDRESS_EXCEEDS_FIELD_PRIME: "StarkNet address exceeds field prime range",
 }
 
 /**
@@ -33,7 +34,8 @@ export const TEST_ADDRESSES = {
     "0xabcdef",
     "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
   ],
-  maxFieldElement: "0x" + "f".repeat(63),
+  maxFieldElement:
+    "0x0800000000000011000000000000000000000000000000000000000000000000",
   tooLong: "0x" + "f".repeat(65),
   invalid: [
     "xyz123", // Invalid hex
@@ -119,7 +121,7 @@ export async function testInvalidAddresses(
 export function createMockProvider(): any {
   return {
     // Mock Provider methods
-    getChainId: () => Promise.resolve("SN_MAIN"),
+    getChainId: () => Promise.resolve("SN_SEPOLIA"),
     callContract: () => Promise.resolve({ result: ["0x123"] }),
     getBalance: () => Promise.resolve({ balance: 1000n }),
 
@@ -141,7 +143,7 @@ export function createMockStarkNetProvider(): any {
   const sinon = require("sinon")
   return {
     // Mock Provider methods as stubs
-    getChainId: sinon.stub().resolves("SN_MAIN"),
+    getChainId: sinon.stub().resolves("SN_SEPOLIA"),
     callContract: sinon.stub().resolves({ result: ["0x123"] }),
     getBalance: sinon.stub().resolves({ balance: 1000n }),
     getTransactionReceipt: sinon.stub().resolves({ status: "ACCEPTED" }),

--- a/typescript/test/lib/sui/bitcoin-depositor.test.ts
+++ b/typescript/test/lib/sui/bitcoin-depositor.test.ts
@@ -276,5 +276,22 @@ describe("SUI Bitcoin Depositor", () => {
         "SUI deposit owner must be set before initializing deposit"
       )
     })
+
+    it("should reject transactions missing DepositInitialized event", async () => {
+      mockClient.waitForTransaction.resolves({
+        digest: "0xmocktransactiondigest123",
+        effects: {
+          status: { status: "success" },
+        },
+        events: [],
+      })
+
+      await expect(
+        depositor.initializeDeposit(depositTx, depositOutputIndex, deposit)
+      ).to.be.rejectedWith(
+        SuiError,
+        "DepositInitialized event not found in transaction"
+      )
+    })
   })
 })

--- a/typescript/test/lib/sui/bitcoin-depositor.test.ts
+++ b/typescript/test/lib/sui/bitcoin-depositor.test.ts
@@ -9,6 +9,7 @@ import { Chains } from "../../../src/lib/contracts"
 import { BitcoinRawTxVectors } from "../../../src/lib/bitcoin"
 import { DepositReceipt } from "../../../src/lib/contracts"
 import { Hex } from "../../../src/lib/utils"
+import { EthereumAddress } from "../../../src/lib/ethereum"
 
 // Create mock Transaction class
 class MockTransaction {
@@ -106,6 +107,25 @@ describe("SUI Bitcoin Depositor", () => {
 
       const retrievedOwner = depositor.getDepositOwner()
       expect(retrievedOwner).to.equal(owner)
+    })
+
+    it("should clear deposit owner", () => {
+      const owner = SuiAddress.from("0x" + "b".repeat(64))
+
+      depositor.setDepositOwner(owner)
+      depositor.setDepositOwner(undefined)
+
+      expect(depositor.getDepositOwner()).to.be.undefined
+    })
+
+    it("should reject non-SUI deposit owners", () => {
+      const ethereumAddress = EthereumAddress.from(
+        "0x1234567890123456789012345678901234567890"
+      )
+
+      expect(() => depositor.setDepositOwner(ethereumAddress)).to.throw(
+        "Deposit owner must be a SUI address"
+      )
     })
   })
 
@@ -244,6 +264,17 @@ describe("SUI Bitcoin Depositor", () => {
       // Verify vault is not included in the transaction
       const moveCallArg = mockTransaction.moveCall.getCall(0).args[0]
       expect(moveCallArg.arguments).to.have.length(3) // Only 3 args, no vault
+    })
+
+    it("should reject missing deposit owner before building transaction", async () => {
+      deposit.extraData = undefined
+
+      await expect(
+        depositor.initializeDeposit(depositTx, depositOutputIndex, deposit)
+      ).to.be.rejectedWith(
+        SuiError,
+        "SUI deposit owner must be set before initializing deposit"
+      )
     })
   })
 })

--- a/typescript/test/services/tbtc-refactored-init.test.ts
+++ b/typescript/test/services/tbtc-refactored-init.test.ts
@@ -1,16 +1,16 @@
 import { expect } from "chai"
-import { RpcProvider } from "starknet"
 import { TBTC } from "../../src/services/tbtc"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
+import { createMockProvider } from "../lib/starknet/test-helpers"
 
 describe("Refactored initializeCrossChain", () => {
   let tbtc: TBTC
   let mockTBTCContracts: MockTBTCContracts
   let mockBitcoinClient: MockBitcoinClient
   let mockCrossChainContractsLoader: MockCrossChainContractsLoader
-  let starknetProvider: RpcProvider
+  let starknetProvider: any
   let consoleWarnStub: any
 
   beforeEach(async () => {
@@ -26,10 +26,7 @@ describe("Refactored initializeCrossChain", () => {
       mockCrossChainContractsLoader
     )
 
-    // Mock StarkNet provider
-    starknetProvider = new RpcProvider({
-      nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-    })
+    starknetProvider = createMockProvider()
 
     // Stub console.warn
     consoleWarnStub = console.warn as any

--- a/typescript/test/services/tbtc-single-param.test.ts
+++ b/typescript/test/services/tbtc-single-param.test.ts
@@ -1,10 +1,26 @@
 import { expect } from "chai"
-import { RpcProvider, Account } from "starknet"
 import { TBTC } from "../../src/services/tbtc"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
 import { StarkNetProvider } from "../../src/lib/starknet/types"
+
+const STARKNET_ADDRESS =
+  "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+
+function createMockAccount(address = STARKNET_ADDRESS): any {
+  return {
+    address,
+    getChainId: async () => "SN_SEPOLIA",
+  }
+}
+
+function createProviderWithAccount(address = STARKNET_ADDRESS): any {
+  return {
+    account: { address },
+    getChainId: async () => "SN_SEPOLIA",
+  }
+}
 
 describe("TBTC Single-Parameter StarkNet Initialization", () => {
   let tbtc: TBTC
@@ -41,15 +57,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
 
   describe("TBTC.initializeCrossChain - Single Parameter Mode", () => {
     it("should detect single-parameter mode for StarkNet", async () => {
-      // Arrange
-      const mockProvider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const mockAccount = new Account(
-        mockProvider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const mockAccount = createMockAccount()
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", mockAccount)
@@ -75,15 +83,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
 
   describe("Success Scenarios", () => {
     it("should initialize with Account object", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockAccount()
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", account)
@@ -96,17 +96,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
     })
 
     it("should initialize with Provider + connected account", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      // Mock a provider with account property
-      const providerWithAccount = Object.assign(provider, {
-        account: {
-          address:
-            "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        },
-      })
+      const providerWithAccount = createProviderWithAccount()
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", providerWithAccount)
@@ -117,15 +107,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
     })
 
     it("should create proper cross-chain contracts", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockAccount()
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", account)
@@ -138,27 +120,20 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
   })
 
   describe("Error Scenarios", () => {
-    it("should accept Provider-only for backward compatibility", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+    it("should reject Provider-only without a connected account", async () => {
+      const provider = {
+        getChainId: async () => "SN_SEPOLIA",
+      }
 
-      // Act & Assert - should not throw
-      await expect(tbtc.initializeCrossChain("StarkNet", provider)).not.to.be
-        .rejected
-
-      // But should use placeholder address
-      const contracts = tbtc.crossChainContracts("StarkNet")
-      expect(contracts).to.exist
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", provider as any)
+      ).to.be.rejectedWith(
+        "StarkNet provider must be an Account object or Provider with connected account"
+      )
     })
 
     it("should fail with invalid address format", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const invalidAccount = new Account(provider, "invalid-address", "0x1")
+      const invalidAccount = createMockAccount("invalid-address")
 
       // Act & Assert
       await expect(tbtc.initializeCrossChain("StarkNet", invalidAccount)).to.be
@@ -175,15 +150,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
 
   describe("Deprecation Warnings", () => {
     it("should not warn for single-parameter", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockAccount()
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", account)
@@ -196,12 +163,8 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
   describe("Address Extraction", () => {
     it("should extract address from StarkNet Account", async () => {
       // Arrange
-      const expectedAddress =
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(provider, expectedAddress, "0x1")
+      const expectedAddress = STARKNET_ADDRESS
+      const account = createMockAccount(expectedAddress)
 
       // Act
       const extractedAddress = await TBTC.extractStarkNetAddress(account)
@@ -236,13 +199,8 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
       ]
 
       for (const addr of addresses) {
-        const provider = new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        })
-
-        // StarkNet Account constructor may normalize the address
         try {
-          const account = new Account(provider, addr, "0x1")
+          const account = createMockAccount(addr)
           // Should not throw
           await expect(tbtc.initializeCrossChain("StarkNet", account)).not.to.be
             .rejected
@@ -257,13 +215,10 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
       // Test with address that exceeds felt252 max
       const invalidAddress =
         "0x00049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7" // 65 chars
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
 
       // This should fail either in Account constructor or our validation
       try {
-        const account = new Account(provider, invalidAddress, "0x1")
+        const account = createMockAccount(invalidAddress)
         await expect(tbtc.initializeCrossChain("StarkNet", account)).to.be
           .rejected
       } catch (e: any) {
@@ -276,12 +231,8 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
   describe("Cross-Chain Contract Creation", () => {
     it("should pass correct parameters to loadStarkNetCrossChainContracts", async () => {
       // Arrange
-      const expectedAddress =
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(provider, expectedAddress, "0x1")
+      const expectedAddress = STARKNET_ADDRESS
+      const account = createMockAccount(expectedAddress)
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", account)
@@ -295,23 +246,14 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
 
     it("should reuse contracts on subsequent calls", async () => {
       // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockAccount()
 
       // Act
       await tbtc.initializeCrossChain("StarkNet", account)
 
       // Initialize again with different account
-      const account2 = new Account(
-        provider,
-        "0x06904a90dcc86f096c4f6daafa2d4e96cb926e5301bb5e6ed5cedc9981fa7064",
-        "0x1"
+      const account2 = createMockAccount(
+        "0x06904a90dcc86f096c4f6daafa2d4e96cb926e5301bb5e6ed5cedc9981fa7064"
       )
       await tbtc.initializeCrossChain("StarkNet", account2)
       const contracts2 = tbtc.crossChainContracts("StarkNet")
@@ -330,13 +272,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
         mockTBTCContracts,
         mockBitcoinClient
       )
-      const account = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockAccount()
 
       // Act & Assert
       await expect(
@@ -346,13 +282,7 @@ describe("TBTC Single-Parameter StarkNet Initialization", () => {
 
     it("should handle invalid chain name", async () => {
       // Arrange
-      const account = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockAccount()
 
       // Act & Assert
       await expect(

--- a/typescript/test/services/tbtc-starknet-address.test.ts
+++ b/typescript/test/services/tbtc-starknet-address.test.ts
@@ -64,6 +64,15 @@ describe("StarkNet address extraction", () => {
       ).to.be.rejectedWith("Invalid StarkNet address format")
     })
 
+    it("should reject Ethereum signers", async () => {
+      const { Wallet } = await import("ethers")
+      const ethereumSigner = Wallet.createRandom()
+
+      await expect(
+        TBTC.extractStarkNetAddress(ethereumSigner as any)
+      ).to.be.rejectedWith("Expected a StarkNet provider or account")
+    })
+
     it("should handle null or undefined provider", async () => {
       // Act & Assert
       await expect(TBTC.extractStarkNetAddress(null)).to.be.rejectedWith(

--- a/typescript/test/services/tbtc-starknet.test.ts
+++ b/typescript/test/services/tbtc-starknet.test.ts
@@ -1,26 +1,9 @@
 import { expect } from "chai"
-<<<<<<< HEAD
-import { RpcProvider, Account } from "starknet"
-import sinon from "sinon"
-=======
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 import { TBTC } from "../../src/services/tbtc"
-import { StarkNetBitcoinDepositor } from "../../src/lib/starknet/starknet-depositor"
-import { StarkNetAddress } from "../../src/lib/starknet/address"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
-<<<<<<< HEAD
-import {
-  createMockDepositTx,
-  createMockDeposit,
-} from "../lib/starknet/test-helpers"
-
-// Mock axios (same pattern as starknet-depositor-implementation.test.ts)
-const axios = require("axios")
-=======
 import { createMockProvider } from "../lib/starknet/test-helpers"
->>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
 describe("TBTC - StarkNet Provider Support", () => {
   let tbtc: TBTC
@@ -108,75 +91,6 @@ describe("TBTC - StarkNet Provider Support", () => {
       const contracts = tbtc.crossChainContracts("StarkNet")
       expect(contracts).to.not.be.undefined
       expect(contracts?.destinationChainBitcoinDepositor).to.not.be.undefined
-    })
-
-    it("should thread options.relayerStatusUrl through to the StarkNet depositor's status endpoint", async () => {
-      // Regression guard for the "relayerStatusUrl is unreachable via the
-      // primary entry point" finding: TBTC.initializeCrossChain's optional
-      // third `options` parameter must reach loadStarkNetCrossChainInterfaces
-      // and end up wired into the constructed depositor's relayerStatusUrl,
-      // not just be usable when calling the loader directly.
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const customStatusUrl = "http://custom-status.example/api/deposit"
-
-      await tbtc.initializeCrossChain("StarkNet", provider, {
-        relayerStatusUrl: customStatusUrl,
-      })
-
-      const contracts = tbtc.crossChainContracts("StarkNet")
-      const depositor = contracts!
-        .destinationChainBitcoinDepositor as StarkNetBitcoinDepositor
-      depositor.setDepositOwner(StarkNetAddress.from("0x123456"))
-
-      const originalPost = axios.post
-      const originalGet = axios.get
-      try {
-        type FakeAxiosConflictError = Error & {
-          isAxiosError: boolean
-          response: {
-            status: number
-            data: { success: boolean; error: string }
-          }
-        }
-        const conflictError: FakeAxiosConflictError = Object.assign(
-          new Error("Request failed with status code 409"),
-          {
-            isAxiosError: true,
-            response: {
-              status: 409,
-              data: { success: false, error: "Deposit already exists" },
-            },
-          }
-        )
-        axios.post = sinon.stub().rejects(conflictError)
-
-        let capturedStatusUrl = ""
-        axios.get = sinon.stub().callsFake((url: string) => {
-          capturedStatusUrl = url
-          return Promise.resolve({ data: { success: false } })
-        })
-
-        try {
-          await depositor.initializeDeposit(
-            createMockDepositTx(),
-            0,
-            createMockDeposit()
-          )
-        } catch {
-          // Expected: a 409 always rejects with
-          // StarkNetRelayerDepositConflictError; only the status GET target
-          // is under test here.
-        }
-
-        expect(capturedStatusUrl).to.satisfy((url: string) =>
-          url.startsWith(customStatusUrl)
-        )
-      } finally {
-        axios.post = originalPost
-        axios.get = originalGet
-      }
     })
   })
 })

--- a/typescript/test/services/tbtc-starknet.test.ts
+++ b/typescript/test/services/tbtc-starknet.test.ts
@@ -1,9 +1,18 @@
 import { expect } from "chai"
+import sinon from "sinon"
 import { TBTC } from "../../src/services/tbtc"
+import { StarkNetBitcoinDepositor } from "../../src/lib/starknet/starknet-depositor"
+import { StarkNetAddress } from "../../src/lib/starknet/address"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
-import { createMockProvider } from "../lib/starknet/test-helpers"
+import {
+  createMockProvider,
+  createMockDepositTx,
+  createMockDeposit,
+} from "../lib/starknet/test-helpers"
+
+const axios = require("axios")
 
 describe("TBTC - StarkNet Provider Support", () => {
   let tbtc: TBTC
@@ -16,8 +25,6 @@ describe("TBTC - StarkNet Provider Support", () => {
     mockBitcoinClient = new MockBitcoinClient()
     mockCrossChainContractsLoader = new MockCrossChainContractsLoader()
 
-    // Create TBTC instance with cross-chain support
-    // Using private constructor via reflection since initializeCustom doesn't support cross-chain loader
     const TBTCClass = TBTC as any
     tbtc = new TBTCClass(
       mockTBTCContracts,
@@ -36,7 +43,6 @@ describe("TBTC - StarkNet Provider Support", () => {
         getChainId: async () => "SN_SEPOLIA",
       }
 
-      // Act & Assert - should not throw
       await expect(
         tbtc.initializeCrossChain("StarkNet", starknetProvider as any)
       ).not.to.be.rejected
@@ -45,18 +51,15 @@ describe("TBTC - StarkNet Provider Support", () => {
     it("should accept StarkNet Account", async () => {
       const starknetAccount = createMockProvider()
 
-      // Act & Assert - should not throw
       await expect(
         tbtc.initializeCrossChain("StarkNet", starknetAccount as any)
       ).not.to.be.rejected
     })
 
     it("should reject Ethereum signer for StarkNet", async () => {
-      // Arrange - create a mock Ethereum signer
       const { Wallet } = await import("ethers")
       const mockEthereumSigner = Wallet.createRandom()
 
-      // Act & Assert
       await expect(
         tbtc.initializeCrossChain("StarkNet", mockEthereumSigner)
       ).to.be.rejectedWith("Expected a StarkNet provider or account")
@@ -65,18 +68,13 @@ describe("TBTC - StarkNet Provider Support", () => {
     it("should store StarkNet provider in _l2Signer property", async () => {
       const starknetProvider = createMockProvider()
 
-      // Act
       await tbtc.initializeCrossChain("StarkNet", starknetProvider as any)
 
-      // Assert - check internal _l2Signer property
-      // Note: This would require making _l2Signer accessible for testing
-      // or using a getter method
       const contracts = tbtc.crossChainContracts("StarkNet")
       expect(contracts).to.not.be.undefined
     })
 
     it("should extract wallet address from StarkNet Account", async () => {
-      // Arrange
       const walletAddress =
         "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
       const starknetAccount = {
@@ -84,13 +82,73 @@ describe("TBTC - StarkNet Provider Support", () => {
         getChainId: async () => "SN_SEPOLIA",
       }
 
-      // Act
       await tbtc.initializeCrossChain("StarkNet", starknetAccount as any)
 
-      // Assert
       const contracts = tbtc.crossChainContracts("StarkNet")
       expect(contracts).to.not.be.undefined
       expect(contracts?.destinationChainBitcoinDepositor).to.not.be.undefined
+    })
+
+    it("should thread options.relayerStatusUrl through to the StarkNet depositor's status endpoint", async () => {
+      const provider = createMockProvider()
+      const customStatusUrl = "http://custom-status.example/api/deposit"
+
+      await tbtc.initializeCrossChain("StarkNet", provider as any, {
+        relayerStatusUrl: customStatusUrl,
+      })
+
+      const contracts = tbtc.crossChainContracts("StarkNet")
+      const depositor = contracts!
+        .destinationChainBitcoinDepositor as StarkNetBitcoinDepositor
+      depositor.setDepositOwner(StarkNetAddress.from("0x123456"))
+
+      const originalPost = axios.post
+      const originalGet = axios.get
+      try {
+        type FakeAxiosConflictError = Error & {
+          isAxiosError: boolean
+          response: {
+            status: number
+            data: { success: boolean; error: string }
+          }
+        }
+        const conflictError: FakeAxiosConflictError = Object.assign(
+          new Error("Request failed with status code 409"),
+          {
+            isAxiosError: true,
+            response: {
+              status: 409,
+              data: { success: false, error: "Deposit already exists" },
+            },
+          }
+        )
+        axios.post = sinon.stub().rejects(conflictError)
+
+        let capturedStatusUrl = ""
+        axios.get = sinon.stub().callsFake((url: string) => {
+          capturedStatusUrl = url
+          return Promise.resolve({ data: { success: false } })
+        })
+
+        try {
+          await depositor.initializeDeposit(
+            createMockDepositTx(),
+            0,
+            createMockDeposit()
+          )
+        } catch {
+          // Expected: a 409 always rejects with
+          // StarkNetRelayerDepositConflictError; only the status GET target
+          // is under test here.
+        }
+
+        expect(capturedStatusUrl).to.satisfy((url: string) =>
+          url.startsWith(customStatusUrl)
+        )
+      } finally {
+        axios.post = originalPost
+        axios.get = originalGet
+      }
     })
   })
 })

--- a/typescript/test/services/tbtc-starknet.test.ts
+++ b/typescript/test/services/tbtc-starknet.test.ts
@@ -1,12 +1,16 @@
 import { expect } from "chai"
+<<<<<<< HEAD
 import { RpcProvider, Account } from "starknet"
 import sinon from "sinon"
+=======
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 import { TBTC } from "../../src/services/tbtc"
 import { StarkNetBitcoinDepositor } from "../../src/lib/starknet/starknet-depositor"
 import { StarkNetAddress } from "../../src/lib/starknet/address"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
+<<<<<<< HEAD
 import {
   createMockDepositTx,
   createMockDeposit,
@@ -14,6 +18,9 @@ import {
 
 // Mock axios (same pattern as starknet-depositor-implementation.test.ts)
 const axios = require("axios")
+=======
+import { createMockProvider } from "../lib/starknet/test-helpers"
+>>>>>>> 31d669ac (test(sdk): update StarkNet hardening coverage)
 
 describe("TBTC - StarkNet Provider Support", () => {
   let tbtc: TBTC
@@ -37,55 +44,46 @@ describe("TBTC - StarkNet Provider Support", () => {
   })
 
   describe("initializeCrossChain with StarkNet provider", () => {
-    it("should accept StarkNet RpcProvider", async () => {
-      // Arrange
-      const starknetProvider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+    it("should accept StarkNet provider with connected account", async () => {
+      const starknetProvider = {
+        account: {
+          address:
+            "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        },
+        getChainId: async () => "SN_SEPOLIA",
+      }
 
       // Act & Assert - should not throw
-      await expect(tbtc.initializeCrossChain("StarkNet", starknetProvider)).not
-        .to.be.rejected
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", starknetProvider as any)
+      ).not.to.be.rejected
     })
 
     it("should accept StarkNet Account", async () => {
-      // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const starknetAccount = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const starknetAccount = createMockProvider()
 
       // Act & Assert - should not throw
-      await expect(tbtc.initializeCrossChain("StarkNet", starknetAccount)).not
-        .to.be.rejected
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", starknetAccount as any)
+      ).not.to.be.rejected
     })
 
-    it("should maintain backward compatibility with Ethereum signer", async () => {
+    it("should reject Ethereum signer for StarkNet", async () => {
       // Arrange - create a mock Ethereum signer
       const { Wallet } = await import("ethers")
       const mockEthereumSigner = Wallet.createRandom()
 
-      // Act & Assert - should not throw and extract address
-      await expect(tbtc.initializeCrossChain("StarkNet", mockEthereumSigner))
-        .not.to.be.rejected
-
-      // Verify cross-chain contracts were initialized
-      const contracts = tbtc.crossChainContracts("StarkNet")
-      expect(contracts).to.not.be.undefined
+      // Act & Assert
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", mockEthereumSigner)
+      ).to.be.rejectedWith("Expected a StarkNet provider or account")
     })
 
     it("should store StarkNet provider in _l2Signer property", async () => {
-      // Arrange
-      const starknetProvider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const starknetProvider = createMockProvider()
 
       // Act
-      await tbtc.initializeCrossChain("StarkNet", starknetProvider)
+      await tbtc.initializeCrossChain("StarkNet", starknetProvider as any)
 
       // Assert - check internal _l2Signer property
       // Note: This would require making _l2Signer accessible for testing
@@ -96,15 +94,15 @@ describe("TBTC - StarkNet Provider Support", () => {
 
     it("should extract wallet address from StarkNet Account", async () => {
       // Arrange
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
       const walletAddress =
         "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      const starknetAccount = new Account(provider, walletAddress, "0x1")
+      const starknetAccount = {
+        address: walletAddress,
+        getChainId: async () => "SN_SEPOLIA",
+      }
 
       // Act
-      await tbtc.initializeCrossChain("StarkNet", starknetAccount)
+      await tbtc.initializeCrossChain("StarkNet", starknetAccount as any)
 
       // Assert
       const contracts = tbtc.crossChainContracts("StarkNet")

--- a/typescript/test/services/tbtc-t003-l2signer.test.ts
+++ b/typescript/test/services/tbtc-t003-l2signer.test.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai"
-import { RpcProvider, Account } from "starknet"
 import { Wallet } from "ethers"
 import { TBTC } from "../../src/services/tbtc"
 import { MockTBTCContracts } from "../utils/mock-tbtc-contracts"
 import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
+import { createMockProvider } from "../lib/starknet/test-helpers"
 
 describe("TBTC T-003: _l2Signer Storage Behavior", () => {
   let tbtc: TBTC
@@ -28,18 +28,10 @@ describe("TBTC T-003: _l2Signer Storage Behavior", () => {
 
   describe("Single-Parameter Mode", () => {
     it("should not store _l2Signer in single-parameter mode for StarkNet", async () => {
-      // Arrange
-      const mockProvider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const mockAccount = new Account(
-        mockProvider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const mockAccount = createMockProvider()
 
       // Act
-      await tbtc.initializeCrossChain("StarkNet", mockAccount)
+      await tbtc.initializeCrossChain("StarkNet", mockAccount as any)
 
       // Assert
       expect(tbtc._l2Signer).to.be.undefined
@@ -62,14 +54,18 @@ describe("TBTC T-003: _l2Signer Storage Behavior", () => {
       expect(tbtc._l2Signer).to.be.undefined
     })
 
-    it("should not store _l2Signer even with Provider-only (backward compatibility)", async () => {
+    it("should reject Provider-only and not store _l2Signer", async () => {
       // Arrange
       const mockProvider = {
         getChainId: async () => "0x534e5f5345504f4c4941", // SN_SEPOLIA
       }
 
-      // Act
-      await tbtc.initializeCrossChain("StarkNet", mockProvider as any)
+      // Act & Assert
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", mockProvider as any)
+      ).to.be.rejectedWith(
+        "StarkNet provider must be an Account object or Provider with connected account"
+      )
 
       // Assert
       expect(tbtc._l2Signer).to.be.undefined
@@ -112,17 +108,10 @@ describe("TBTC T-003: _l2Signer Storage Behavior", () => {
 
   describe("Isolation and Side Effects", () => {
     it("should not affect other functionality when _l2Signer is not stored", async () => {
-      // Arrange
-      const mockAccount = new Account(
-        new RpcProvider({
-          nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-        }),
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const mockAccount = createMockProvider()
 
       // Act
-      await tbtc.initializeCrossChain("StarkNet", mockAccount)
+      await tbtc.initializeCrossChain("StarkNet", mockAccount as any)
 
       // Assert
       const contracts = tbtc.crossChainContracts("StarkNet")

--- a/typescript/test/services/threshold-context-provider-compatibility.test.ts
+++ b/typescript/test/services/threshold-context-provider-compatibility.test.ts
@@ -6,6 +6,17 @@ import { MockBitcoinClient } from "../utils/mock-bitcoin-client"
 import { MockCrossChainContractsLoader } from "../utils/mock-cross-chain-contracts-loader"
 import { StarkNetProvider } from "../../src/lib/starknet/types"
 import { EthereumSigner } from "../../src/lib/ethereum"
+import { createMockProvider } from "../lib/starknet/test-helpers"
+
+const STARKNET_ADDRESS =
+  "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
+
+function createProviderWithAccount(address = STARKNET_ADDRESS): any {
+  return {
+    account: { address },
+    getChainId: async () => "SN_SEPOLIA",
+  }
+}
 
 describe("ThresholdContext Provider Compatibility - T-009", () => {
   let tbtc: TBTC
@@ -28,13 +39,9 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
   })
 
   describe("Provider Type Compatibility", () => {
-    it("should accept StarkNet Provider as parameter type", async () => {
-      // Test that the type system accepts StarkNet Provider
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-
-      const starknetProvider: StarkNetProvider = provider
+    it("should accept StarkNet provider with connected account as parameter type", async () => {
+      const starknetProvider: StarkNetProvider =
+        createProviderWithAccount() as StarkNetProvider
 
       // This should compile and not throw
       await expect(tbtc.initializeCrossChain("StarkNet", starknetProvider)).not
@@ -42,41 +49,30 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
     })
 
     it("should accept StarkNet Account as parameter type", async () => {
-      // Test that the type system accepts StarkNet Account
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
-
-      const starknetProvider: StarkNetProvider = account
+      const starknetProvider: StarkNetProvider =
+        createMockProvider() as StarkNetProvider
 
       // This should compile and not throw
       await expect(tbtc.initializeCrossChain("StarkNet", starknetProvider)).not
         .to.be.rejected
     })
 
-    it("should maintain backward compatibility with EthereumSigner", async () => {
+    it("should reject EthereumSigner for StarkNet", async () => {
       // Import ethers dynamically to avoid dependency issues
       const { Wallet } = await import("ethers")
       const ethereumSigner: EthereumSigner = Wallet.createRandom()
 
-      // This should still work for backward compatibility
-      await expect(tbtc.initializeCrossChain("StarkNet", ethereumSigner)).not.to
-        .be.rejected
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", ethereumSigner)
+      ).to.be.rejectedWith("Expected a StarkNet provider or account")
     })
   })
 
   describe("Provider Storage and Access", () => {
     it("should NOT store StarkNet provider in single-parameter mode", async () => {
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider = createProviderWithAccount()
 
-      await tbtc.initializeCrossChain("StarkNet", provider)
+      await tbtc.initializeCrossChain("StarkNet", provider as any)
 
       // In single-parameter mode, _l2Signer should NOT be stored
       const storedProvider = (tbtc as any)._l2Signer
@@ -84,16 +80,9 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
     })
 
     it("should NOT store StarkNet account in single-parameter mode", async () => {
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account = new Account(
-        provider,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
-      )
+      const account = createMockProvider()
 
-      await tbtc.initializeCrossChain("StarkNet", account)
+      await tbtc.initializeCrossChain("StarkNet", account as any)
 
       // In single-parameter mode, _l2Signer should NOT be stored
       const storedAccount = (tbtc as any)._l2Signer
@@ -102,24 +91,17 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
 
     it("should update cross-chain contracts on subsequent calls", async () => {
       // First initialization
-      const provider1 = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      await tbtc.initializeCrossChain("StarkNet", provider1)
+      const provider1 = createProviderWithAccount()
+      await tbtc.initializeCrossChain("StarkNet", provider1 as any)
 
       const contracts1 = tbtc.crossChainContracts("StarkNet")
       expect(contracts1).to.exist
 
       // Second initialization with different provider
-      const provider2 = new RpcProvider({
-        nodeUrl: "https://starknet-mainnet.public.blastapi.io/rpc/v0_6",
-      })
-      const account2 = new Account(
-        provider2,
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
-        "0x1"
+      const account2 = createProviderWithAccount(
+        "0x06904a90dcc86f096c4f6daafa2d4e96cb926e5301bb5e6ed5cedc9981fa7064"
       )
-      await tbtc.initializeCrossChain("StarkNet", account2)
+      await tbtc.initializeCrossChain("StarkNet", account2 as any)
 
       // Should update contracts but NOT store _l2Signer
       const contracts2 = tbtc.crossChainContracts("StarkNet")
@@ -133,42 +115,38 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
 
   describe("Address Extraction", () => {
     it("should extract address from StarkNet Account", async () => {
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
-      const expectedAddress =
-        "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7"
-      const account = new Account(provider, expectedAddress, "0x1")
+      const expectedAddress = STARKNET_ADDRESS
+      const account = {
+        address: expectedAddress,
+        getChainId: async () => "SN_SEPOLIA",
+      }
 
-      await tbtc.initializeCrossChain("StarkNet", account)
+      await tbtc.initializeCrossChain("StarkNet", account as any)
 
       // The address should be properly extracted in the initializeCrossChain method
       const contracts = tbtc.crossChainContracts("StarkNet")
       expect(contracts).to.not.be.undefined
     })
 
-    it("should handle StarkNet Provider without address", async () => {
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+    it("should reject StarkNet Provider without address", async () => {
+      const provider = {
+        getChainId: async () => "SN_SEPOLIA",
+      }
 
-      // Provider doesn't have an address property, so it should use placeholder
-      await expect(tbtc.initializeCrossChain("StarkNet", provider)).not.to.be
-        .rejected
-
-      const contracts = tbtc.crossChainContracts("StarkNet")
-      expect(contracts).to.not.be.undefined
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", provider as any)
+      ).to.be.rejectedWith(
+        "StarkNet provider must be an Account object or Provider with connected account"
+      )
     })
 
-    it("should extract address from Ethereum signer for backward compatibility", async () => {
+    it("should reject Ethereum signer for address extraction", async () => {
       const { Wallet } = await import("ethers")
       const ethereumSigner = Wallet.createRandom()
 
-      await expect(tbtc.initializeCrossChain("StarkNet", ethereumSigner)).not.to
-        .be.rejected
-
-      const contracts = tbtc.crossChainContracts("StarkNet")
-      expect(contracts).to.not.be.undefined
+      await expect(
+        tbtc.initializeCrossChain("StarkNet", ethereumSigner)
+      ).to.be.rejectedWith("Expected a StarkNet provider or account")
     })
   })
 
@@ -208,12 +186,10 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
         mockBitcoinClient
       )) as TBTC
 
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider = createProviderWithAccount()
 
       await expect(
-        tbtcNoCrossChain.initializeCrossChain("StarkNet", provider)
+        tbtcNoCrossChain.initializeCrossChain("StarkNet", provider as any)
       ).to.be.rejectedWith(
         "Cross-chain contracts loader not available for this instance"
       )
@@ -223,12 +199,10 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
       // Mock loader that returns undefined chain mapping
       mockCrossChainContractsLoader.loadChainMapping = () => undefined
 
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider = createProviderWithAccount()
 
       await expect(
-        tbtc.initializeCrossChain("StarkNet", provider)
+        tbtc.initializeCrossChain("StarkNet", provider as any)
       ).to.be.rejectedWith("Chain mapping between L1 and L2 chains not defined")
     })
 
@@ -240,12 +214,10 @@ describe("ThresholdContext Provider Compatibility - T-009", () => {
           arbitrum: "0xa4b1",
         } as any)
 
-      const provider = new RpcProvider({
-        nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0_6",
-      })
+      const provider = createProviderWithAccount()
 
       await expect(
-        tbtc.initializeCrossChain("StarkNet", provider)
+        tbtc.initializeCrossChain("StarkNet", provider as any)
       ).to.be.rejectedWith("StarkNet chain ID not available in chain mapping")
     })
   })


### PR DESCRIPTION
## Summary
- Bind Solana interface loading to the expected genesis hash from chain mapping
- Reject Electrum raw transaction responses that do not decode to the requested transaction hash
- Use HTTPS for the Solana reveal relayer, require a configured deposit owner, and validate relayer receipt shape

## Validation
- Added focused regression coverage for Solana genesis mismatch and Electrum transaction hash mismatch
- CI passes: TypeScript format, build/test, and docs
- `git diff --check` passed locally for the safe-fix batch

## Notes
This is public-safe client hardening only and does not include any private deployment mitigation. StarkNet provider-chain binding remains a follow-up because the first implementation made existing tests depend on a retired live RPC endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced StarkNet address validation against field-prime bounds
  * Solana cross-chain interfaces now validate genesis hash
  * StarkNet cross-chain operations now require an explicit provider

* **Bug Fixes**
  * Stronger Electrum transaction hash verification
  * Detect and reject provider chain ID mismatches
  * Enforced deposit-owner presence and stricter relayer response validation
  * Relayer requests use HTTPS

* **Documentation**
  * Updated API reference source links

* **Tests**
  * Added/expanded tests covering provider/genesis/hash/address validation and integration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/threshold-network/tbtc-v2/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->