### PR TITLE
Monitoring: fail closed on undelivered events

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Test
+        run: yarn test
+
   monitoring-docker:
     needs: [monitoring-detect-changes, monitoring-build]
     if: github.event_name == 'workflow_dispatch'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 *.DS_Store
 
 dist/
+dist-test/
 
 .vscode/
 .envrc

--- a/monitoring/.eslintignore
+++ b/monitoring/.eslintignore
@@ -1,3 +1,4 @@
 dist/
+dist-test/
 external/
 node_modules/

--- a/monitoring/.prettierignore
+++ b/monitoring/.prettierignore
@@ -1,3 +1,4 @@
 dist/
+dist-test/
 external/
 node_modules/

--- a/monitoring/README.adoc
+++ b/monitoring/README.adoc
@@ -77,9 +77,9 @@ determined based on the previous run's end block held by the *Persistence*
 component (the so-called checkpoint block). The starting block is also
 decremented by a constant factor of 12 to cover possible chain reorganizations.
 The window's ending block is the latest mined block (i.e. the chain tip) unless
-the backlog is larger than the maximum block range processed in a single run. In
-that case, the ending block is capped and the checkpoint advances only to the
-last block that was actually scanned. For example, assuming that initial
+the backlog is larger than the maximum block range (10,000 blocks) processed in
+a single run. In that case, the ending block is capped and the checkpoint
+advances only to the last block that was actually scanned. For example, assuming that initial
 checkpoint block is 100, the loop will look as follows:
 
 - Run 1: Start block 100 - 12 = 88, end block 150
@@ -119,6 +119,26 @@ delivery recovers. Operators should:
 - rerun or wait for the monitoring loop after Sentry recovers, and
 - expect catch-up to proceed in capped block-range increments if the checkpoint
   is stale.
+
+=== Dispatch coverage failures
+
+The monitoring manager is fail-closed on dispatch coverage. A run fails if a
+system event produced by a monitor is not accepted (handled or deduplicated) by
+any receiver that attempted delivery. When that happens, the checkpoint block is
+not advanced and the next run will rescan the same block range.
+
+Events explicitly ignored by all registered receivers do not trigger a coverage
+failure. This is expected in partial-receiver deployments -- for example, if
+only the Sentry receiver is configured, informational events will not produce
+coverage errors because Sentry only accepts warning and critical events.
+
+If monitoring halts with a coverage failure, check that:
+
+- all active receivers are healthy (dispatch errors will appear earlier in the
+  same run's log),
+- the receiver configuration covers every event type emitted by active
+  monitors, and
+- no new monitor event types were recently added without a matching receiver.
 
 == Build and deployment
 

--- a/monitoring/README.adoc
+++ b/monitoring/README.adoc
@@ -76,9 +76,11 @@ focuses on a specific chain block window. The window's starting block is
 determined based on the previous run's end block held by the *Persistence*
 component (the so-called checkpoint block). The starting block is also
 decremented by a constant factor of 12 to cover possible chain reorganizations.
-The window's ending block is always the latest mined block (i.e. the chain tip).
-For example, assuming that initial checkpoint block is 100, the loop will look
-as follows:
+The window's ending block is the latest mined block (i.e. the chain tip) unless
+the backlog is larger than the maximum block range processed in a single run. In
+that case, the ending block is capped and the checkpoint advances only to the
+last block that was actually scanned. For example, assuming that initial
+checkpoint block is 100, the loop will look as follows:
 
 - Run 1: Start block 100 - 12 = 88, end block 150
 - Run 2: Start block 150 - 12 = 138, end block 155
@@ -99,6 +101,24 @@ This way the monitoring tool guarantees to not miss any system events.
 However, such a solution can produce duplicated system events. To prevent
 that, the *Manager* component contains a deduplication logic that leverages
 the *Persistence* component to filter out already handled system events.
+
+=== Sentry delivery failures
+
+The Sentry receiver is intentionally fail-closed. A run fails if Sentry does not
+accept a warning or critical system event, or if the event is not flushed before
+the receiver returns. When that happens, the checkpoint block is not advanced
+and the next run will rescan the same block range.
+
+This behavior prevents silent alert loss but means a Sentry outage, disabled
+Sentry project, invalid DSN, or rate limit can halt monitoring progress until
+delivery recovers. Operators should:
+
+- confirm the Sentry DSN and project are enabled,
+- check Sentry rate limits and network reachability from the monitoring
+  environment,
+- rerun or wait for the monitoring loop after Sentry recovers, and
+- expect catch-up to proceed in capped block-range increments if the checkpoint
+  is stale.
 
 == Build and deployment
 

--- a/monitoring/package.json
+++ b/monitoring/package.json
@@ -9,7 +9,8 @@
     "format": "yarn run lint && prettier --check .",
     "format:fix": "yarn run lint:fix && prettier --write .",
     "lint": "eslint . --ext .js,.ts",
-    "lint:fix": "eslint . --ext .js,.ts --fix"
+    "lint:fix": "eslint . --ext .js,.ts --fix",
+    "test": "tsc --project tsconfig.test.json && node dist-test/test/run.js"
   },
   "dependencies": {
     "@keep-network/tbtc-v2.ts": "v2.5.0-dev.5",

--- a/monitoring/src/file-persistence.ts
+++ b/monitoring/src/file-persistence.ts
@@ -9,6 +9,8 @@ import type {
   SystemEvent,
 } from "./system-event"
 
+const maxHandledSystemEventsPerReceiver = 5000
+
 export class SystemEventFilePersistence implements SystemEventPersistence {
   private readonly checkpointBlockPath = "/checkpointBlock"
 
@@ -46,7 +48,6 @@ export class SystemEventFilePersistence implements SystemEventPersistence {
     )
   }
 
-  // TODO: Consider deleting old events to optimize database file size.
   async storeHandledSystemEvents(
     systemEvents: Record<SystemEventReceiverId, SystemEvent[]>
   ): Promise<void> {
@@ -55,6 +56,9 @@ export class SystemEventFilePersistence implements SystemEventPersistence {
     Object.keys(systemEvents).forEach((receiverId) => {
       handledSystemEvents[receiverId] = handledSystemEvents[receiverId] ?? []
       handledSystemEvents[receiverId].push(...systemEvents[receiverId])
+      handledSystemEvents[receiverId] = handledSystemEvents[receiverId].slice(
+        -maxHandledSystemEventsPerReceiver
+      )
     })
 
     await this.db.push(this.handledSystemEventsPath, handledSystemEvents)

--- a/monitoring/src/sentry-receiver.ts
+++ b/monitoring/src/sentry-receiver.ts
@@ -31,6 +31,8 @@ export class SentryReceiver extends BaseSystemEventReceiver {
   }
 
   async handle(systemEvent: SystemEvent): Promise<void> {
+    let eventId: string | undefined
+
     Sentry.withScope((scope) => {
       scope.setExtras(systemEvent.data)
       scope.setExtra("block", systemEvent.block)
@@ -43,8 +45,16 @@ export class SentryReceiver extends BaseSystemEventReceiver {
         .update(JSON.stringify(systemEvent))
         .digest("base64")
 
-      Sentry.captureMessage(`${systemEvent.title} [${hash}]`)
+      eventId = Sentry.captureMessage(`${systemEvent.title} [${hash}]`)
     })
+
+    if (!eventId) {
+      throw new Error("Sentry did not accept the system event")
+    }
+
+    if (!(await Sentry.flush(2000))) {
+      throw new Error("Sentry event was not flushed")
+    }
   }
 
   private resolveSeverityLevel(

--- a/monitoring/src/system-event.ts
+++ b/monitoring/src/system-event.ts
@@ -228,15 +228,10 @@ export class Manager {
     )
 
     checks.forEach((result) => {
-      switch (result.status) {
-        case "fulfilled": {
-          systemEvents.push(...result.value)
-          break
-        }
-        case "rejected": {
-          errors.push(`cannot check system events monitor: ${result.reason}`)
-          break
-        }
+      if (result.status === "fulfilled") {
+        systemEvents.push(...result.value)
+      } else {
+        errors.push(`cannot check system events monitor: ${result.reason}`)
       }
     })
 
@@ -251,15 +246,10 @@ export class Manager {
     const systemEventsAcks: SystemEventAck[] = []
 
     dispatches.forEach((result) => {
-      switch (result.status) {
-        case "fulfilled": {
-          systemEventsAcks.push(result.value)
-          break
-        }
-        case "rejected": {
-          errors.push(`cannot dispatch system event: ${result.reason}`)
-          break
-        }
+      if (result.status === "fulfilled") {
+        systemEventsAcks.push(result.value)
+      } else {
+        errors.push(`cannot dispatch system event: ${result.reason}`)
       }
     })
 
@@ -269,14 +259,31 @@ export class Manager {
         .map((ack) => Deduplicator.systemEventKey(ack.systemEvent))
     )
 
+    // Index ack statuses by event key to detect partial-deployment cases.
+    const ackStatusesByKey = new Map<string, Set<SystemEventAck["status"]>>()
+    systemEventsAcks.forEach((ack) => {
+      const key = Deduplicator.systemEventKey(ack.systemEvent)
+      const statuses =
+        ackStatusesByKey.get(key) ?? new Set<SystemEventAck["status"]>()
+      statuses.add(ack.status)
+      ackStatusesByKey.set(key, statuses)
+    })
+
     systemEvents.forEach((systemEvent) => {
+      const key = Deduplicator.systemEventKey(systemEvent)
+      if (dispatchedSystemEventKeys.has(key)) return
+      const statuses = ackStatusesByKey.get(key) ?? new Set()
+      // Skip if every receiver ignored this event (no receiver is configured
+      // for this event type -- valid in partial-receiver deployments) or if all
+      // dispatches were rejected and already recorded as errors above.
       if (
-        !dispatchedSystemEventKeys.has(Deduplicator.systemEventKey(systemEvent))
-      ) {
-        errors.push(
-          `system event was not handled by any receiver: ${systemEvent.title}`
-        )
-      }
+        statuses.size === 0 ||
+        (statuses.size === 1 && statuses.has("ignored"))
+      )
+        return
+      errors.push(
+        `system event was not handled by any receiver: ${systemEvent.title}`
+      )
     })
 
     return {

--- a/monitoring/src/system-event.ts
+++ b/monitoring/src/system-event.ts
@@ -23,7 +23,7 @@ export type ReceiverId = string
 export interface SystemEventAck {
   receiverId: ReceiverId
   systemEvent: SystemEvent
-  status: "handled" | "ignored"
+  status: "handled" | "ignored" | "duplicate"
 }
 
 export interface Receiver {
@@ -96,7 +96,7 @@ class Deduplicator implements Receiver {
       return {
         receiverId: this.id(),
         systemEvent,
-        status: "ignored",
+        status: "duplicate",
       }
     }
 
@@ -125,6 +125,10 @@ export interface ManagerReport {
 
 // Our expectation on how deep can chain reorganization be.
 const reorgDepthBlocks = 12
+
+// Limit a single catch-up pass to keep stale checkpoints from producing
+// unbounded node queries and alert fanout.
+const maxBlockRange = 10000
 
 export class Manager {
   private monitors: Monitor[]
@@ -158,7 +162,7 @@ export class Manager {
       fromBlock =
         fromBlock - reorgDepthBlocks > 0 ? fromBlock - reorgDepthBlocks : 0
 
-      const toBlock = latestBlock
+      const toBlock = Math.min(latestBlock, fromBlock + maxBlockRange)
 
       const { systemEventsAcks, errors } = await this.check(fromBlock, toBlock)
 
@@ -189,7 +193,7 @@ export class Manager {
 
       if (errors.length === 0) {
         try {
-          await this.persistence.updateCheckpointBlock(latestBlock)
+          await this.persistence.updateCheckpointBlock(toBlock)
         } catch (error) {
           errors.push(`cannot update checkpoint block: ${error}`)
         }
@@ -256,6 +260,22 @@ export class Manager {
           errors.push(`cannot dispatch system event: ${result.reason}`)
           break
         }
+      }
+    })
+
+    const dispatchedSystemEventKeys = new Set(
+      systemEventsAcks
+        .filter((ack) => ack.status === "handled" || ack.status === "duplicate")
+        .map((ack) => Deduplicator.systemEventKey(ack.systemEvent))
+    )
+
+    systemEvents.forEach((systemEvent) => {
+      if (
+        !dispatchedSystemEventKeys.has(Deduplicator.systemEventKey(systemEvent))
+      ) {
+        errors.push(
+          `system event was not handled by any receiver: ${systemEvent.title}`
+        )
       }
     })
 

--- a/monitoring/test/run.ts
+++ b/monitoring/test/run.ts
@@ -1,0 +1,18 @@
+import { runTests } from "./test-runner"
+
+process.env.ENVIRONMENT = process.env.ENVIRONMENT ?? "testnet"
+process.env.ETHEREUM_URL = process.env.ETHEREUM_URL ?? "http://localhost:8545"
+process.env.ELECTRUM_URL = process.env.ELECTRUM_URL ?? "tcp://localhost:50001"
+
+async function main() {
+  await import("./sentry-receiver.test")
+  await import("./system-event-manager.test")
+
+  await runTests()
+}
+
+main().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(error)
+  process.exitCode = 1
+})

--- a/monitoring/test/sentry-receiver.test.ts
+++ b/monitoring/test/sentry-receiver.test.ts
@@ -3,9 +3,11 @@ import assert from "assert"
 import * as Sentry from "@sentry/node"
 
 import { SentryReceiver } from "../src/sentry-receiver"
-import { SystemEvent, SystemEventType } from "../src/system-event"
+import { SystemEventType } from "../src/system-event"
 
 import { test } from "./test-runner"
+
+import type { SystemEvent } from "../src/system-event"
 
 type ScopeStub = {
   setExtras: (extras: Record<string, string>) => void

--- a/monitoring/test/sentry-receiver.test.ts
+++ b/monitoring/test/sentry-receiver.test.ts
@@ -1,0 +1,93 @@
+import assert from "assert"
+
+import * as Sentry from "@sentry/node"
+
+import { SentryReceiver } from "../src/sentry-receiver"
+import { SystemEvent, SystemEventType } from "../src/system-event"
+
+import { test } from "./test-runner"
+
+type ScopeStub = {
+  setExtras: (extras: Record<string, string>) => void
+  setExtra: (key: string, value: unknown) => void
+  setLevel: (level: Sentry.SeverityLevel) => void
+}
+
+type MutableSentry = {
+  captureMessage: (message: string) => string | undefined
+  flush: (timeout?: number) => Promise<boolean>
+  init: (options?: Sentry.NodeOptions) => void
+  withScope: (callback: (scope: ScopeStub) => void) => void
+}
+
+const systemEvent: SystemEvent = {
+  title: "wallet balance below threshold",
+  type: SystemEventType.Warning,
+  data: {
+    wallet: "0x1234",
+  },
+  block: 100,
+}
+
+function stubSentry(overrides: Partial<MutableSentry>): () => void {
+  const sentry = Sentry as unknown as MutableSentry
+  const original = {
+    captureMessage: sentry.captureMessage,
+    flush: sentry.flush,
+    init: sentry.init,
+    withScope: sentry.withScope,
+  }
+
+  sentry.init = overrides.init ?? (() => undefined)
+  sentry.withScope =
+    overrides.withScope ??
+    ((callback: (scope: ScopeStub) => void) =>
+      callback({
+        setExtras: () => undefined,
+        setExtra: () => undefined,
+        setLevel: () => undefined,
+      }))
+  sentry.captureMessage = overrides.captureMessage ?? (() => "event-id")
+  sentry.flush = overrides.flush ?? (async () => true)
+
+  return () => {
+    sentry.captureMessage = original.captureMessage
+    sentry.flush = original.flush
+    sentry.init = original.init
+    sentry.withScope = original.withScope
+  }
+}
+
+test("SentryReceiver fails closed when Sentry rejects an event", async () => {
+  const restore = stubSentry({
+    captureMessage: () => undefined,
+  })
+
+  try {
+    const receiver = new SentryReceiver("https://example.com/sentry")
+
+    await assert.rejects(
+      () => receiver.receive(systemEvent),
+      /Sentry did not accept the system event/
+    )
+  } finally {
+    restore()
+  }
+})
+
+test("SentryReceiver fails closed when an event is not flushed", async () => {
+  const restore = stubSentry({
+    flush: async () => false,
+  })
+
+  try {
+    const receiver = new SentryReceiver("https://example.com/sentry")
+
+    await assert.rejects(
+      () => receiver.receive(systemEvent),
+      /Sentry event was not flushed/
+    )
+  } finally {
+    restore()
+  }
+})

--- a/monitoring/test/system-event-manager.test.ts
+++ b/monitoring/test/system-event-manager.test.ts
@@ -1,0 +1,83 @@
+import assert from "assert"
+
+import {
+  Manager,
+  Monitor,
+  Persistence,
+  Receiver,
+  SystemEvent,
+  SystemEventType,
+} from "../src/system-event"
+
+import { test } from "./test-runner"
+
+const systemEvent: SystemEvent = {
+  title: "wallet is moving funds",
+  type: SystemEventType.Warning,
+  data: {
+    wallet: "0xabcd",
+  },
+  block: 120,
+}
+
+const monitor: Monitor = {
+  check: async () => [systemEvent],
+}
+
+function persistence(
+  handledSystemEvents: Awaited<ReturnType<Persistence["handledSystemEvents"]>>
+): Persistence {
+  return {
+    checkpointBlock: async () => 0,
+    updateCheckpointBlock: async () => undefined,
+    handledSystemEvents: async () => handledSystemEvents,
+    storeHandledSystemEvents: async () => undefined,
+  }
+}
+
+test("Manager reports a system event ignored by every receiver", async () => {
+  const receiver: Receiver = {
+    id: () => "Noop",
+    receive: async (receivedEvent) => ({
+      receiverId: "Noop",
+      systemEvent: receivedEvent,
+      status: "ignored",
+    }),
+  }
+
+  const manager = new Manager([monitor], [receiver], persistence({}))
+  const report = await manager.check(100, 200)
+
+  assert.deepStrictEqual(report.errors, [
+    "system event was not handled by any receiver: wallet is moving funds",
+  ])
+})
+
+test("Manager treats duplicate system events as already covered", async () => {
+  let receiverCalled = false
+  const receiver: Receiver = {
+    id: () => "Noop",
+    receive: async (receivedEvent) => {
+      receiverCalled = true
+
+      return {
+        receiverId: "Noop",
+        systemEvent: receivedEvent,
+        status: "ignored",
+      }
+    },
+  }
+
+  const manager = new Manager(
+    [monitor],
+    [receiver],
+    persistence({
+      Noop: [systemEvent],
+    })
+  )
+  const report = await manager.check(100, 200)
+
+  assert.deepStrictEqual(report.errors, [])
+  assert.strictEqual(report.systemEventsAcks[0].status, "duplicate")
+  assert.strictEqual(receiverCalled, false)
+})

--- a/monitoring/test/system-event-manager.test.ts
+++ b/monitoring/test/system-event-manager.test.ts
@@ -35,7 +35,7 @@ function persistence(
   }
 }
 
-test("Manager reports a system event ignored by every receiver", async () => {
+test("Manager does not error when all receivers ignore a system event (partial-receiver deployment)", async () => {
   const receiver: Receiver = {
     id: () => "Noop",
     receive: async (receivedEvent) => ({
@@ -48,9 +48,22 @@ test("Manager reports a system event ignored by every receiver", async () => {
   const manager = new Manager([monitor], [receiver], persistence({}))
   const report = await manager.check(100, 200)
 
-  assert.deepStrictEqual(report.errors, [
-    "system event was not handled by any receiver: wallet is moving funds",
-  ])
+  assert.deepStrictEqual(report.errors, [])
+})
+
+test("Manager reports dispatch error without coverage error when receiver throws", async () => {
+  const receiver: Receiver = {
+    id: () => "Throws",
+    receive: async () => {
+      throw new Error("delivery failed")
+    },
+  }
+
+  const manager = new Manager([monitor], [receiver], persistence({}))
+  const report = await manager.check(100, 200)
+
+  assert.strictEqual(report.errors.length, 1)
+  assert.ok(report.errors[0].includes("cannot dispatch system event"))
 })
 
 test("Manager treats duplicate system events as already covered", async () => {

--- a/monitoring/test/system-event-manager.test.ts
+++ b/monitoring/test/system-event-manager.test.ts
@@ -1,15 +1,15 @@
 import assert from "assert"
 
-import {
-  Manager,
+import { Manager, SystemEventType } from "../src/system-event"
+
+import { test } from "./test-runner"
+
+import type {
   Monitor,
   Persistence,
   Receiver,
   SystemEvent,
-  SystemEventType,
 } from "../src/system-event"
-
-import { test } from "./test-runner"
 
 const systemEvent: SystemEvent = {
   title: "wallet is moving funds",

--- a/monitoring/test/test-runner.ts
+++ b/monitoring/test/test-runner.ts
@@ -10,9 +10,10 @@ export function test(name: string, run: TestCase["run"]): void {
 }
 
 export async function runTests(): Promise<void> {
-  for (const testCase of tests) {
+  await tests.reduce(async (previousTest, testCase) => {
+    await previousTest
+
     try {
-      // eslint-disable-next-line no-await-in-loop
       await testCase.run()
       // eslint-disable-next-line no-console
       console.log(`ok - ${testCase.name}`)
@@ -21,5 +22,5 @@ export async function runTests(): Promise<void> {
       console.error(`not ok - ${testCase.name}`)
       throw error
     }
-  }
+  }, Promise.resolve())
 }

--- a/monitoring/test/test-runner.ts
+++ b/monitoring/test/test-runner.ts
@@ -1,0 +1,25 @@
+type TestCase = {
+  name: string
+  run: () => Promise<void> | void
+}
+
+const tests: TestCase[] = []
+
+export function test(name: string, run: TestCase["run"]): void {
+  tests.push({ name, run })
+}
+
+export async function runTests(): Promise<void> {
+  for (const testCase of tests) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      await testCase.run()
+      // eslint-disable-next-line no-console
+      console.log(`ok - ${testCase.name}`)
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(`not ok - ${testCase.name}`)
+      throw error
+    }
+  }
+}

--- a/monitoring/test/test-runner.ts
+++ b/monitoring/test/test-runner.ts
@@ -10,10 +10,10 @@ export function test(name: string, run: TestCase["run"]): void {
 }
 
 export async function runTests(): Promise<void> {
-  await tests.reduce(async (previousTest, testCase) => {
-    await previousTest
-
+  // eslint-disable-next-line no-restricted-syntax
+  for (const testCase of tests) {
     try {
+      // eslint-disable-next-line no-await-in-loop
       await testCase.run()
       // eslint-disable-next-line no-console
       console.log(`ok - ${testCase.name}`)
@@ -22,5 +22,5 @@ export async function runTests(): Promise<void> {
       console.error(`not ok - ${testCase.name}`)
       throw error
     }
-  }, Promise.resolve())
+  }
 }

--- a/monitoring/tsconfig.test.json
+++ b/monitoring/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "outDir": "./dist-test",
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "rootDirs": ["src", "test"]
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Summary
- Treat missing Sentry event IDs and failed flushes as receiver failures
- Allow duplicate acknowledgements while preventing unhandled system events from checkpointing silently
- Cap trigger block ranges and checkpoint only the processed range
- Bound persisted handled-event history per receiver

## Validation
- CI passes: monitoring format and monitoring build
- `git diff --check` passed locally for the safe-fix batch

## Notes
This is public-safe operational hardening only and does not include any private deployment mitigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Monitoring catch-up runs are capped at 10,000 blocks to improve stability during large backlogs.
  * Sentry delivery failures now fail safely and are clearly reported.
  * Duplicate events are recognized and prevented from being redelivered.
  * Event history is limited to the 5,000 most recent events per receiver.

* **Documentation**
  * Added operator guidance for delivery and dispatch failures.

* **Tests**
  * Added automated coverage for event deduplication, dispatch failures, and Sentry delivery outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->