### PR TITLE
Sui: clarify minter capability revocation docs

### DIFF
--- a/cross-chain/sui/deploy_l2/docs/tbtc.md
+++ b/cross-chain/sui/deploy_l2/docs/tbtc.md
@@ -34,7 +34,7 @@ The contract is initialized with:
 
 ## Administrative Methods
 
-### `add_minter`
+### `add_minter_with_cap`
 **Purpose:** Add a new address with minting permissions
 
 **Parameters:**
@@ -46,7 +46,7 @@ The contract is initialized with:
 **Behavior:**
 - Ensures the address is not already a minter
 - Adds the address to the minters list
-- Creates and transfers a `MinterCap` to the new minter
+- Creates and returns a `MinterCap` for the caller to store or pass onward
 - Emits a `MinterAdded` event
 
 ### `remove_minter`
@@ -61,6 +61,9 @@ The contract is initialized with:
 **Behavior:**
 - Verifies the address is currently a minter
 - Removes the address from the minters list
+- Does not destroy previously issued `MinterCap` objects; live minting also
+  requires the `TreasuryCap`, and gateway minting can be stopped by pausing the
+  gateway/token path
 - Emits a `MinterRemoved` event
 
 ### `add_guardian`

--- a/cross-chain/sui/deploy_l2/sources/token/tbtc.move
+++ b/cross-chain/sui/deploy_l2/sources/token/tbtc.move
@@ -145,8 +145,10 @@ module l2_tbtc::TBTC {
 
         vector::remove(&mut state.minters, index);
 
-        // Note: We cannot delete the MinterCap that was previously transferred,
-        // but it will no longer be valid as we've removed the minter from the state
+        // Note: This removes the minter from TokenState bookkeeping but does
+        // not destroy any previously issued MinterCap. Live minting still
+        // requires the TreasuryCap, and governance can stop gateway minting by
+        // pausing the gateway/token path.
 
         event::emit(MinterRemoved { minter });
     }


### PR DESCRIPTION
## Summary
- Clarify that `remove_minter` updates TokenState bookkeeping but does not destroy outstanding MinterCap objects
- Clarify that live minting also requires TreasuryCap access and can be stopped through the gateway/token pause path
- Align the Move comment and markdown docs with the live architecture

## Validation
- Documentation/comment-only change
- `git diff --check` passed for the safe-fix batch

## Notes
This is public-safe documentation cleanup for an already-duplicated report and does not include any private deployment mitigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for adding and removing minters.
  * Clarified that removing a minter does not destroy existing capabilities.
  * Documented that minting requires the treasury capability and can be halted through pausing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->