### PR TITLE
Route rebate to extraData receiver for sponsored depositors

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -244,6 +244,8 @@ contract Bridge is
         address newRebateStaking
     );
 
+    event SponsoredDepositorSet(address indexed depositor, bool sponsored);
+
     /// @notice Emitted when a deposit's vault field is corrected via governance.
     /// @dev This event is used for transparency when fixing deposits that were
     ///      revealed with incorrect vault targets.
@@ -2035,6 +2037,36 @@ contract Bridge is
     /// @return Address of the rebate staking contract.
     function getRebateStaking() external view returns (address) {
         return self.rebateStaking;
+    }
+
+    /// @notice Adds or removes a depositor contract from the sponsored
+    ///         depositor allowlist. When a depositor is on the list, reveals
+    ///         it submits route the `RebateStaking` rebate to the L1 address
+    ///         decoded from `extraData` rather than to the depositor contract
+    ///         itself. Intended for direct-L1-receiver relays such as
+    ///         `NativeBTCDepositor`. Must not be enabled for cross-chain
+    ///         depositors whose `extraData` is an L2 user identifier rather
+    ///         than an L1 staker.
+    /// @param depositor Address of the depositor contract.
+    /// @param sponsored New allowlist membership.
+    /// @dev Requirements:
+    ///      - The caller must be the governance,
+    ///      - Depositor address must not be 0x0.
+    function setSponsoredDepositor(address depositor, bool sponsored)
+        external
+        onlyGovernance
+    {
+        self.setSponsoredDepositor(depositor, sponsored);
+    }
+
+    /// @notice Returns whether `depositor` is on the sponsored depositor
+    ///         allowlist.
+    function isSponsoredDepositor(address depositor)
+        external
+        view
+        returns (bool)
+    {
+        return self.sponsoredDepositors[depositor];
     }
 
     /// @notice Sets the redemption watchtower address.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -2040,10 +2040,17 @@ contract Bridge is
     }
 
     /// @notice Adds or removes a depositor contract from the sponsored
-    ///         depositor allowlist. When a depositor is on the list, reveals
-    ///         it submits route the `RebateStaking` rebate to the L1 address
-    ///         decoded from `extraData` rather than to the depositor contract
-    ///         itself. Intended for direct-L1-receiver relays such as
+    ///         depositor allowlist. When a depositor is on the list and a
+    ///         reveal it submits carries non-empty `extraData`, the
+    ///         `RebateStaking` rebate for that reveal routes to the L1
+    ///         address decoded from `extraData` instead of to the depositor
+    ///         contract itself -- but only if that decoded address has
+    ///         separately authorized the depositor via
+    ///         `RebateStaking.setSponsorConsent`. Activation therefore
+    ///         requires two independent steps: this governance allowlist
+    ///         call, and the L1 staker's own consent transaction. Without
+    ///         both, the rebate falls back to charging the depositor's own
+    ///         stake. Intended for direct-L1-receiver relays such as
     ///         `NativeBTCDepositor`. Must not be enabled for cross-chain
     ///         depositors whose `extraData` is an L2 user identifier rather
     ///         than an L1 staker.

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1807,4 +1807,17 @@ contract BridgeGovernance is Ownable {
     function setRebateStaking(address rebateStaking) external onlyOwner {
         bridge.setRebateStaking(rebateStaking);
     }
+
+    /// @notice Forwards a sponsored-depositor allowlist toggle to the
+    ///         underlying Bridge implementation.
+    /// @param depositor Address of the depositor contract.
+    /// @param sponsored New allowlist membership.
+    /// @dev Requirements:
+    ///      - The caller must be the owner.
+    function setSponsoredDepositor(address depositor, bool sponsored)
+        external
+        onlyOwner
+    {
+        bridge.setSponsoredDepositor(depositor, sponsored);
+    }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -325,6 +325,13 @@ library BridgeState {
         // governance wiring; changing it afterwards requires a dedicated
         // upgrade path of the Bridge implementation.
         address rebateStaking;
+        // Set of relayer-style depositor contracts whose `extraData` should be
+        // interpreted as the L1 rebate staker for reveals they submit on
+        // behalf of an L1 receiver. Governance-managed; intended for direct
+        // L1-receiver depositors (e.g. NativeBTCDepositor) and must not
+        // include cross-chain depositors whose `extraData` is an L2 user
+        // identifier.
+        mapping(address => bool) sponsoredDepositors;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -332,7 +339,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[48] __gap;
+        uint256[47] __gap;
     }
 
     event DepositParametersUpdated(
@@ -392,6 +399,10 @@ library BridgeState {
     // used by the Bridge contract following the same pattern as other
     // parameter events.
     event RebateStakingSet(address rebateStaking);
+
+    // Event emitted when governance adds or removes an entry from the
+    // `sponsoredDepositors` allowlist. `sponsored` reflects the new state.
+    event SponsoredDepositorSet(address indexed depositor, bool sponsored);
 
     /// @notice Updates parameters of deposits.
     /// @param _depositDustThreshold New value of the deposit dust threshold in
@@ -891,5 +902,24 @@ library BridgeState {
 
         self.rebateStaking = _rebateStaking;
         emit RebateStakingSet(_rebateStaking);
+    }
+
+    /// @notice Adds or removes a depositor contract from the sponsored
+    ///         depositor allowlist. Reveals submitted by an allowlisted
+    ///         depositor have their rebate routed to the L1 address decoded
+    ///         from `extraData` instead of to the depositor contract.
+    /// @param _depositor Address of the depositor contract.
+    /// @param _sponsored New allowlist membership.
+    /// @dev Requirements:
+    ///      - Depositor address must not be 0x0.
+    function setSponsoredDepositor(
+        Storage storage self,
+        address _depositor,
+        bool _sponsored
+    ) internal {
+        require(_depositor != address(0), "Depositor address must not be 0x0");
+
+        self.sponsoredDepositors[_depositor] = _sponsored;
+        emit SponsoredDepositorSet(_depositor, _sponsored);
     }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -330,7 +330,10 @@ library BridgeState {
         // behalf of an L1 receiver. Governance-managed; intended for direct
         // L1-receiver depositors (e.g. NativeBTCDepositor) and must not
         // include cross-chain depositors whose `extraData` is an L2 user
-        // identifier.
+        // identifier. Allowlisting alone does not activate rebate routing:
+        // the decoded L1 address must also separately authorize the
+        // depositor via `RebateStaking.setSponsorConsent`. Both this
+        // allowlist entry and that per-staker consent are required.
         mapping(address => bool) sponsoredDepositors;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
@@ -907,7 +910,11 @@ library BridgeState {
     /// @notice Adds or removes a depositor contract from the sponsored
     ///         depositor allowlist. Reveals submitted by an allowlisted
     ///         depositor have their rebate routed to the L1 address decoded
-    ///         from `extraData` instead of to the depositor contract.
+    ///         from `extraData` instead of to the depositor contract, but
+    ///         only once that decoded address has separately authorized the
+    ///         depositor via `RebateStaking.setSponsorConsent`. This
+    ///         allowlist call alone does not activate routing for any
+    ///         staker.
     /// @param _depositor Address of the depositor contract.
     /// @param _sponsored New allowlist membership.
     /// @dev Requirements:

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -344,9 +344,23 @@ library Deposit {
         deposit.extraData = extraData;
 
         if (deposit.treasuryFee > 0 && self.rebateStaking != address(0)) {
+            // By default the rebate is keyed off the depositor (msg.sender).
+            // When the depositor is an allowlisted "sponsored" relay (e.g.
+            // NativeBTCDepositor) and an `extraData` payload is present,
+            // route the rebate to the L1 receiver encoded in `extraData`
+            // instead of to the relay contract, which has no stake of its
+            // own. `deposit.depositor` itself stays as the relay so refund
+            // and finalize accounting are unchanged.
+            address rebateStaker = deposit.depositor;
+            if (
+                extraData != bytes32(0) && self.sponsoredDepositors[msg.sender]
+            ) {
+                rebateStaker = address(uint160(uint256(extraData)));
+            }
+
             deposit.treasuryFee = RebateStaking(self.rebateStaking)
                 .applyForRebate(
-                    deposit.depositor,
+                    rebateStaker,
                     deposit.treasuryFee,
                     RebateStaking.TreasuryFeeType.Deposit
                 );

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -352,10 +352,17 @@ library Deposit {
             // own. `deposit.depositor` itself stays as the relay so refund
             // and finalize accounting are unchanged.
             address rebateStaker = deposit.depositor;
-            if (
-                extraData != bytes32(0) && self.sponsoredDepositors[msg.sender]
-            ) {
-                rebateStaker = address(uint160(uint256(extraData)));
+            if (self.sponsoredDepositors[msg.sender]) {
+                require(
+                    extraData != bytes32(0),
+                    "Sponsored depositor must provide extraData"
+                );
+                address decoded = address(uint160(uint256(extraData)));
+                require(
+                    decoded != address(0),
+                    "Sponsored extraData decodes to zero"
+                );
+                rebateStaker = decoded;
             }
 
             deposit.treasuryFee = RebateStaking(self.rebateStaking)

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -346,23 +346,31 @@ library Deposit {
         if (deposit.treasuryFee > 0 && self.rebateStaking != address(0)) {
             // By default the rebate is keyed off the depositor (msg.sender).
             // When the depositor is an allowlisted "sponsored" relay (e.g.
-            // NativeBTCDepositor) and an `extraData` payload is present,
-            // route the rebate to the L1 receiver encoded in `extraData`
-            // instead of to the relay contract, which has no stake of its
-            // own. `deposit.depositor` itself stays as the relay so refund
-            // and finalize accounting are unchanged.
+            // NativeBTCDepositor), an `extraData` payload is present, the
+            // payload decodes to a non-zero address, and that address has
+            // explicitly authorized the depositor via
+            // `RebateStaking.setSponsorAuthorization`, route the rebate to
+            // the L1 staker encoded in `extraData` instead of to the relay
+            // contract, which has no stake of its own. `deposit.depositor`
+            // itself stays as the relay so refund and finalize accounting
+            // are unchanged. Any missing precondition falls back to
+            // charging the depositor's own (possibly empty) stake instead
+            // of reverting, consistent with every other rebate path.
             address rebateStaker = deposit.depositor;
-            if (self.sponsoredDepositors[msg.sender]) {
-                require(
-                    extraData != bytes32(0),
-                    "Sponsored depositor must provide extraData"
-                );
+            if (
+                self.sponsoredDepositors[msg.sender] &&
+                extraData != bytes32(0)
+            ) {
                 address decoded = address(uint160(uint256(extraData)));
-                require(
-                    decoded != address(0),
-                    "Sponsored extraData decodes to zero"
-                );
-                rebateStaker = decoded;
+                if (
+                    decoded != address(0) &&
+                    RebateStaking(self.rebateStaking).isAuthorizedSponsor(
+                        decoded,
+                        msg.sender
+                    )
+                ) {
+                    rebateStaker = decoded;
+                }
             }
 
             deposit.treasuryFee = RebateStaking(self.rebateStaking)

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -349,22 +349,28 @@ library Deposit {
             // NativeBTCDepositor), an `extraData` payload is present, the
             // payload decodes to a non-zero address, and that address has
             // explicitly authorized the depositor via
-            // `RebateStaking.setSponsorAuthorization`, route the rebate to
+            // `RebateStaking.setSponsorConsent`, route the rebate to
             // the L1 staker encoded in `extraData` instead of to the relay
             // contract, which has no stake of its own. `deposit.depositor`
             // itself stays as the relay so refund and finalize accounting
             // are unchanged. Any missing precondition falls back to
             // charging the depositor's own (possibly empty) stake instead
             // of reverting, consistent with every other rebate path.
+            // The low-20-byte address must be canonically left-padded
+            // (high 12 bytes zero, matching `NativeBTCDepositor`'s
+            // `CrosschainUtils.addressToBytes32` convention); a
+            // non-canonical payload is treated as a missing precondition
+            // and falls back to the depositor's own stake, same as any
+            // other unmet condition here.
             address rebateStaker = deposit.depositor;
             if (
-                self.sponsoredDepositors[msg.sender] &&
-                extraData != bytes32(0)
+                self.sponsoredDepositors[msg.sender] && extraData != bytes32(0)
             ) {
                 address decoded = address(uint160(uint256(extraData)));
                 if (
                     decoded != address(0) &&
-                    RebateStaking(self.rebateStaking).isAuthorizedSponsor(
+                    uint256(extraData) >> 160 == 0 &&
+                    RebateStaking(self.rebateStaking).isSponsorConsentGranted(
                         decoded,
                         msg.sender
                     )

--- a/solidity/contracts/bridge/RebateStaking.sol
+++ b/solidity/contracts/bridge/RebateStaking.sol
@@ -81,6 +81,7 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
 
     mapping(address => Stake) public stakes;
     mapping(address => address) public delegates;
+    mapping(address => mapping(address => bool)) public sponsorAuthorizations;
 
     /// @notice Per-redeemer authorization for callback-path rebate
     ///         application. A staker authorizes a specific Bank balance owner
@@ -116,6 +117,11 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
     event UnstakeStarted(address staker, uint256 amount);
     event UnstakeFinished(address staker, uint256 amount);
     event DelegateeSet(address staker, address delegatee);
+    event SponsorAuthorizationSet(
+        address indexed staker,
+        address indexed depositor,
+        bool authorized
+    );
     event TransferFinished(address oldStaker, address newStaker);
     event RebateAuthorizationSet(
         address indexed redeemer,
@@ -270,6 +276,28 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
         }
 
         return rebateAuthorizations[redeemer][balanceOwner];
+    }
+
+    /// @notice Authorizes or revokes a sponsored depositor contract's ability to have
+    ///         Bridge deposit reveals route rebate consumption to the caller's stake via
+    ///         the depositor-submitted `extraData`.
+    /// @param depositor Address of a Bridge-allowlisted sponsored depositor contract.
+    /// @param authorized New authorization state.
+    function setSponsorAuthorization(address depositor, bool authorized)
+        external
+    {
+        sponsorAuthorizations[msg.sender][depositor] = authorized;
+        emit SponsorAuthorizationSet(msg.sender, depositor, authorized);
+    }
+
+    /// @notice Returns whether `staker` has authorized `depositor` to route rebate
+    ///         consumption to their stake via `extraData` on Bridge deposit reveals.
+    function isAuthorizedSponsor(address staker, address depositor)
+        external
+        view
+        returns (bool)
+    {
+        return sponsorAuthorizations[staker][depositor];
     }
 
     /// @notice Calculates cap for rebate for the specified user.

--- a/solidity/contracts/bridge/RebateStaking.sol
+++ b/solidity/contracts/bridge/RebateStaking.sol
@@ -81,7 +81,6 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
 
     mapping(address => Stake) public stakes;
     mapping(address => address) public delegates;
-    mapping(address => mapping(address => bool)) public sponsorAuthorizations;
 
     /// @notice Per-redeemer authorization for callback-path rebate
     ///         application. A staker authorizes a specific Bank balance owner
@@ -92,6 +91,7 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
     ///         rebate accounting to a different staker rather than authorizing
     ///         a Bank balance owner).
     mapping(address => mapping(address => bool)) public rebateAuthorizations;
+    mapping(address => mapping(address => bool)) public stakerSponsorConsent;
 
     // Reserved storage space in case we need to add more variables.
     // The convention from OpenZeppelin suggests the storage space should
@@ -99,10 +99,11 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
     // planned upgrades of the Bridge contract. If more entires are added to
     // the struct in the upcoming versions we need to reduce the array size.
     // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-    // Upgrade note: `rebateAuthorizations` consumed one reserved slot,
-    // reducing `__gap` from 49 to 48 for storage-layout compatibility.
+    // Upgrade note: rebateAuthorizations and stakerSponsorConsent each
+    // consumed one reserved slot, reducing __gap from 49 to 47 for
+    // storage-layout compatibility.
     // slither-disable-next-line unused-state
-    uint256[48] private __gap;
+    uint256[47] private __gap;
 
     event RollingWindowUpdated(uint256 rollingWindow);
     event UnstakingPeriodUpdated(uint256 unstakingPeriod);
@@ -117,7 +118,7 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
     event UnstakeStarted(address staker, uint256 amount);
     event UnstakeFinished(address staker, uint256 amount);
     event DelegateeSet(address staker, address delegatee);
-    event SponsorAuthorizationSet(
+    event SponsorConsentSet(
         address indexed staker,
         address indexed depositor,
         bool authorized
@@ -280,24 +281,45 @@ contract RebateStaking is Initializable, OwnableUpgradeable {
 
     /// @notice Authorizes or revokes a sponsored depositor contract's ability to have
     ///         Bridge deposit reveals route rebate consumption to the caller's stake via
-    ///         the depositor-submitted `extraData`.
+    ///         the depositor-submitted `extraData`. The caller must be a staker.
     /// @param depositor Address of a Bridge-allowlisted sponsored depositor contract.
+    ///        Must not be the zero address.
     /// @param authorized New authorization state.
-    function setSponsorAuthorization(address depositor, bool authorized)
-        external
-    {
-        sponsorAuthorizations[msg.sender][depositor] = authorized;
-        emit SponsorAuthorizationSet(msg.sender, depositor, authorized);
+    function setSponsorConsent(address depositor, bool authorized) external {
+        if (stakes[msg.sender].stakedAmount == 0) {
+            revert NotAStaker();
+        }
+        if (depositor == address(0)) revert ZeroAddress();
+        stakerSponsorConsent[msg.sender][depositor] = authorized;
+        emit SponsorConsentSet(msg.sender, depositor, authorized);
     }
 
-    /// @notice Returns whether `staker` has authorized `depositor` to route rebate
-    ///         consumption to their stake via `extraData` on Bridge deposit reveals.
-    function isAuthorizedSponsor(address staker, address depositor)
+    /// @notice Returns whether the staker resolved from `staker` (following
+    ///         delegation via `getStaker`) has consented to `depositor`
+    ///         routing rebate consumption to their stake via `extraData` on
+    ///         Bridge deposit reveals.
+    /// @dev Naming: "sponsor" here means the staker whose stake backs the
+    ///      rebate (the economic sponsor) -- the opposite convention from
+    ///      `BridgeState.sponsoredDepositors`, where the allowlisted party
+    ///      (the depositor contract) is the one called "sponsored".
+    /// @dev Intentionally diverges from the sibling `isRebateAuthorized`,
+    ///      which instead REJECTS a zero-stake querying address outright
+    ///      (`getStake(redeemer) == 0` short-circuits to `false`) rather
+    ///      than resolving it to a delegator. That path exists so a
+    ///      caller can trust `isRebateAuthorized`'s answer describes the
+    ///      resolved-`redeemer` themselves, without a second `getStaker`
+    ///      lookup. This path instead RESOLVES delegation, because
+    ///      `applyForRebate` -- the function whose outcome this view is
+    ///      meant to predict -- always resolves `getStaker` internally
+    ///      before charging. Rejecting here instead of resolving would
+    ///      make this view disagree with the charge it is checked
+    ///      against.
+    function isSponsorConsentGranted(address staker, address depositor)
         external
         view
         returns (bool)
     {
-        return sponsorAuthorizations[staker][depositor];
+        return stakerSponsorConsent[getStaker(staker)][depositor];
     }
 
     /// @notice Calculates cap for rebate for the specified user.

--- a/solidity/deploy/87_upgrade_bridge_sponsored_depositor.ts
+++ b/solidity/deploy/87_upgrade_bridge_sponsored_depositor.ts
@@ -1,0 +1,582 @@
+import fs from "fs"
+import path from "path"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction, DeployOptions } from "hardhat-deploy/types"
+import { utils } from "ethers"
+
+/**
+ * @notice This deployment script upgrades the Bridge contract to add sponsored
+ *         depositor support, and upgrades the RebateStaking contract to add
+ *         sponsor authorization support. The Bridge upgrade enables the
+ *         `sponsoredDepositors` allowlist used by `NativeBTCDepositor` to
+ *         route rebate consumption to a staker address decoded from deposit
+ *         `extraData`. The RebateStaking upgrade enables the
+ *         `sponsorAuthorizations` mapping stakers use to authorize a
+ *         sponsored depositor to route rebate consumption to their stake.
+ *         Both proxies must be upgraded together: Deposit.sol's sponsored
+ *         depositor routing calls `RebateStaking.isAuthorizedSponsor()`,
+ *         which does not exist on the currently deployed implementation.
+ *
+ * @dev IMPORTANT DEPLOYMENT NOTES:
+ *
+ * MAINNET:
+ * - Both the Bridge and RebateStaking upgrades MUST go through the
+ *   Timelock contract (24h delay)
+ * - Council multisig (6-of-9) schedules and executes via Timelock
+ * - The follow-up governance call to setSponsoredDepositor is a direct
+ *   onlyOwner call on BridgeGovernance (no begin/finalize delay)
+ * - Timeline: ~24-36 hours total (schedule + 24h delay + execute)
+ *
+ * SEPOLIA (for upgrade mechanism testing):
+ * - No Timelock required, direct EOA upgrade
+ * - The governance call can be executed directly
+ *
+ * Context:
+ * - PR #970 adds a `sponsoredDepositors` mapping to Bridge storage and a
+ *   `setSponsoredDepositor` function on BridgeGovernance
+ * - PR #970 also adds a `sponsorAuthorizations` mapping to RebateStaking
+ *   storage and `setSponsorAuthorization` / `isAuthorizedSponsor` functions
+ * - The `NativeBTCDepositor` proxy at KNOWN_NATIVE_BTC_DEPOSITOR must be
+ *   added to the allowlist after the upgrade for rebate routing to work
+ * - This script generates the calldata for both proxy upgrades and the
+ *   BridgeGovernance action; actual execution is a separate governance/
+ *   multisig operation
+ *
+ * Usage:
+ *   # For Sepolia (testing upgrade mechanism):
+ *   DEPLOY_SPONSORED_DEPOSITOR=true yarn deploy --tags UpgradeBridgeSponsoredDepositor --network sepolia
+ *
+ *   # For Mainnet (production - requires Timelock):
+ *   DEPLOY_SPONSORED_DEPOSITOR=true yarn deploy --tags UpgradeBridgeSponsoredDepositor --network mainnet
+ *   # Then execute the logged calldata via Council Safe -> Timelock -> ProxyAdmin
+ *   # and the BridgeGovernance calldata via Council Safe directly
+ */
+
+// EIP-1967 transparent proxy admin storage slot. Defined by the standard
+// at https://eips.ethereum.org/EIPS/eip-1967#admin-address and used to
+// discover the ProxyAdmin address from any transparent proxy.
+export const EIP_1967_ADMIN_SLOT =
+  "0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103"
+
+// EIP-1967 implementation storage slot. Defined by the standard at
+// https://eips.ethereum.org/EIPS/eip-1967#logic-contract-address and used
+// to verify proxy upgrade targets.
+export const EIP_1967_IMPLEMENTATION_SLOT =
+  "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
+
+// Known ProxyAdmin address on mainnet. Used for validation after on-chain
+// discovery (log-only warning, not a hard failure if mismatched).
+export const KNOWN_PROXY_ADMIN = "0x16A76d3cd3C1e3CE843C6680d6B37E9116b5C706"
+
+// Known mainnet Timelock Controller address. Owner of the ProxyAdmin,
+// used for scheduling and executing proxy upgrades with a 24h delay.
+export const KNOWN_TIMELOCK = "0x92f2d8b72a7F6a551Be60b9aa4194248E9B4913D"
+
+// Known mainnet Council Safe (6/9 multisig). Proposer and executor
+// on the Timelock, and owner of BridgeGovernance.
+export const KNOWN_COUNCIL_SAFE = "0x9F6e831c8f8939dc0c830c6e492e7cef4f9c2f5f"
+
+// Known mainnet NativeBTCDepositor proxy address. This is the depositor
+// contract that must be added to the sponsoredDepositors allowlist after
+// the Bridge upgrade for rebate routing via extraData to function.
+export const KNOWN_NATIVE_BTC_DEPOSITOR =
+  "0xad7c6d46f4a4bc2d3a227067d03218d6d7c9aaa5"
+
+// Known mainnet RebateStaking proxy address. This proxy must be upgraded
+// alongside the Bridge proxy: Deposit.sol's sponsored depositor routing
+// calls RebateStaking.isAuthorizedSponsor(), which does not exist on the
+// currently deployed RebateStaking implementation.
+export const KNOWN_REBATE_STAKING_PROXY =
+  "0x0184739C32edc3471D3e4860c8E39a5f3Ff85A45"
+
+// ABI fragments for calldata encoding. These are the minimal function
+// signatures needed to generate governance calldata without importing
+// full contract artifacts.
+const PROXY_ADMIN_ABI = [
+  "function upgrade(address proxy, address implementation)",
+]
+
+const BRIDGE_GOVERNANCE_ABI = [
+  "function setSponsoredDepositor(address depositor, bool sponsored)",
+]
+
+// Shared interface instances used by both helper functions and the main
+// deployment function for calldata encoding.
+const proxyAdminInterface = new utils.Interface(PROXY_ADMIN_ABI)
+const bridgeGovInterface = new utils.Interface(BRIDGE_GOVERNANCE_ABI)
+
+/**
+ * Encodes ProxyAdmin.upgrade() calldata for upgrading the Bridge proxy to
+ * the new implementation. The new `sponsoredDepositors` mapping added by
+ * this upgrade is a plain Solidity mapping and zero-defaults to empty, so
+ * no post-upgrade initializer call is required.
+ * @param bridgeProxy - Address of the Bridge proxy contract
+ * @param newBridgeImpl - Address of the new Bridge implementation
+ * @returns ABI-encoded calldata for ProxyAdmin.upgrade(proxy, implementation)
+ */
+export function encodeBridgeUpgrade(
+  bridgeProxy: string,
+  newBridgeImpl: string
+): string {
+  return proxyAdminInterface.encodeFunctionData("upgrade", [
+    bridgeProxy,
+    newBridgeImpl,
+  ])
+}
+
+/**
+ * Encodes ProxyAdmin.upgrade() calldata for upgrading the RebateStaking
+ * proxy to the new implementation. The new `sponsorAuthorizations` mapping
+ * added by this upgrade is a plain Solidity mapping and zero-defaults to
+ * empty, so no post-upgrade initializer call is required.
+ * @param rebateStakingProxy - Address of the RebateStaking proxy contract
+ * @param newRebateStakingImpl - Address of the new RebateStaking implementation
+ * @returns ABI-encoded calldata for ProxyAdmin.upgrade(proxy, implementation)
+ */
+export function encodeRebateStakingUpgrade(
+  rebateStakingProxy: string,
+  newRebateStakingImpl: string
+): string {
+  return proxyAdminInterface.encodeFunctionData("upgrade", [
+    rebateStakingProxy,
+    newRebateStakingImpl,
+  ])
+}
+
+/**
+ * Encodes BridgeGovernance.setSponsoredDepositor() calldata. This is a direct
+ * onlyOwner call (NOT routed through begin/finalize governance delay).
+ * @param depositor - Address of the depositor contract to allowlist/remove
+ * @param sponsored - New allowlist membership state
+ * @returns ABI-encoded calldata for BridgeGovernance.setSponsoredDepositor(address,bool)
+ */
+export function encodeSetSponsoredDepositor(
+  depositor: string,
+  sponsored: boolean
+): string {
+  return bridgeGovInterface.encodeFunctionData("setSponsoredDepositor", [
+    depositor,
+    sponsored,
+  ])
+}
+
+/** Structure for a post-deployment verification check entry. */
+interface VerificationCheck {
+  command: string
+  expectedResult: string
+  description: string
+}
+
+/** Logs a governance calldata action with consistent formatting. */
+function logCalldataAction(
+  label: string,
+  target: string,
+  targetName: string,
+  calldata: string,
+  details: Record<string, string>
+): void {
+  console.log(`\n  ${label}`)
+  console.log(`    Target: ${targetName} (${target})`)
+  console.log(`    Calldata: ${calldata}`)
+  console.log(`    Selector: ${calldata.slice(0, 10)}`)
+  Object.entries(details).forEach(([key, value]) => {
+    console.log(`    ${key}: ${value}`)
+  })
+}
+
+/** Builds the array of post-deployment verification checks. */
+function buildVerificationChecks(addresses: {
+  bridgeProxy: string
+  bridgeImpl: string
+  rebateStakingProxy: string
+  rebateStakingImpl: string
+}): VerificationCheck[] {
+  return [
+    {
+      command: `cast call ${addresses.bridgeProxy} "sponsoredDepositors(address)(bool)" ${KNOWN_NATIVE_BTC_DEPOSITOR}`,
+      expectedResult: "true",
+      description:
+        "After BridgeGovernance.setSponsoredDepositor call, NativeBTCDepositor should be on the allowlist",
+    },
+    {
+      command: `cast code ${addresses.bridgeImpl}`,
+      expectedResult:
+        "Bytecode should contain the sponsoredDepositors storage layout",
+      description:
+        "Bridge implementation bytecode should contain the new sponsored depositor functionality",
+    },
+    {
+      command: `cast call ${addresses.bridgeProxy} "deposits(uint256)(bytes32,uint32,uint64,uint32,address,uint32)" <sample_deposit_key>`,
+      expectedResult: "Existing deposit data unchanged after upgrade",
+      description:
+        "Existing deposits should remain unaffected by the Bridge upgrade",
+    },
+    {
+      command:
+        `cast storage ${addresses.bridgeProxy} 79 && ` +
+        `cast storage ${addresses.bridgeProxy} 80 && ` +
+        `cast storage ${addresses.bridgeProxy} 81`,
+      expectedResult:
+        "Slot 79 = redemptionWatchtower address, " +
+        "slot 80 = rebate staking address, " +
+        "slots 81-128 = zero (__gap[48], gap size unchanged)",
+      description:
+        "Bridge storage layout: slot 79=redemptionWatchtower, slot 80=rebate staking, slots 81-128=__gap[48] with gap size unchanged",
+    },
+    {
+      command: `cast storage ${addresses.rebateStakingProxy} ${EIP_1967_IMPLEMENTATION_SLOT}`,
+      expectedResult: `Should contain ${addresses.rebateStakingImpl} (padded to 32 bytes)`,
+      description:
+        "RebateStaking proxy EIP-1967 implementation pointer should reference the newly deployed implementation",
+    },
+    {
+      command:
+        `cast call ${addresses.rebateStakingProxy} "isAuthorizedSponsor(address,address)(bool)" ` +
+        `<sample_staker> ${KNOWN_NATIVE_BTC_DEPOSITOR}`,
+      expectedResult: "false (no authorization set for un-configured stakers)",
+      description:
+        "RebateStaking implementation should expose isAuthorizedSponsor() and preserve default false state after upgrade",
+    },
+  ]
+}
+
+/** Prints all verification checks to console with numbered formatting. */
+function logVerificationChecks(checks: VerificationCheck[]): void {
+  console.log(`\n${"=".repeat(80)}`)
+  console.log("POST-DEPLOYMENT VERIFICATION COMMANDS")
+  console.log("=".repeat(80))
+  checks.forEach((check, index) => {
+    console.log(`\n  [${index + 1}] ${check.description}`)
+    console.log(`      Command: ${check.command}`)
+    console.log(`      Expected: ${check.expectedResult}`)
+  })
+  console.log(`\n${"=".repeat(80)}`)
+}
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre
+  const { deploy, get } = deployments
+  const { deployer } = await getNamedAccounts()
+  const { ethers } = hre
+
+  const deployOptions: DeployOptions = {
+    from: deployer,
+    log: true,
+    waitConfirmations: 1,
+  }
+
+  console.log("=".repeat(80))
+  console.log("Bridge Sponsored Depositor Upgrade Deployment")
+  console.log("=".repeat(80))
+  console.log(`Network: ${hre.network.name}`)
+  console.log(`Deployer: ${deployer}`)
+
+  // --- Step 1: Resolve existing libraries ---
+  // These libraries have NOT changed since last deployment and are reused
+  // from existing deployment artifacts.
+  console.log("\n--- Resolving existing libraries ---")
+  const Deposit = await get("Deposit")
+  const DepositSweep = await get("DepositSweep")
+  const Redemption = await get("Redemption")
+  const Wallets = await get("Wallets")
+  const Fraud = await get("Fraud")
+  const MovingFunds = await get("MovingFunds")
+
+  console.log("Existing library addresses:")
+  console.log(`  Deposit:       ${Deposit.address}`)
+  console.log(`  DepositSweep:  ${DepositSweep.address}`)
+  console.log(`  Redemption:    ${Redemption.address}`)
+  console.log(`  Wallets:       ${Wallets.address}`)
+  console.log(`  Fraud:         ${Fraud.address}`)
+  console.log(`  MovingFunds:   ${MovingFunds.address}`)
+
+  // --- Step 2: Deploy Bridge implementation ---
+  // Uses a distinct artifact name to avoid overwriting the existing Bridge
+  // proxy artifact managed by hardhat-deploy. The Bridge contract requires
+  // all 6 libraries linked at deployment time.
+  console.log("\n--- Deploying Bridge implementation ---")
+  const bridgeLibraries = {
+    Deposit: Deposit.address,
+    DepositSweep: DepositSweep.address,
+    Redemption: Redemption.address,
+    Wallets: Wallets.address,
+    Fraud: Fraud.address,
+    MovingFunds: MovingFunds.address,
+  }
+
+  const bridgeImpl = await deploy("BridgeSponsoredDepositorImplementation", {
+    ...deployOptions,
+    contract: "Bridge",
+    skipIfAlreadyDeployed: false,
+    libraries: bridgeLibraries,
+  })
+
+  // --- Step 3: Deploy RebateStaking implementation ---
+  // Implementation-only (NOT a proxy). Uses a distinct artifact name to
+  // avoid overwriting the existing RebateStaking proxy artifact. The actual
+  // proxy upgrade is handled via governance calldata in a subsequent step.
+  // RebateStaking has no library dependencies, unlike Bridge.
+  console.log("\n--- Deploying RebateStaking implementation ---")
+  const rebateStakingImpl = await deploy(
+    "RebateStakingSponsoredDepositorImplementation",
+    {
+      ...deployOptions,
+      contract: "RebateStaking",
+      skipIfAlreadyDeployed: false,
+    }
+  )
+
+  // --- Deployment Summary ---
+  console.log(`\n${"-".repeat(80)}`)
+  console.log("Deployed contract addresses:")
+  console.log(`  Bridge implementation:        ${bridgeImpl.address}`)
+  console.log(`  RebateStaking implementation: ${rebateStakingImpl.address}`)
+  console.log("-".repeat(80))
+
+  // --- Step 4: Discover ProxyAdmin via EIP-1967 admin slot ---
+  // The Bridge proxy stores the ProxyAdmin address in the EIP-1967
+  // admin storage slot. Reading it on-chain avoids hardcoding.
+  console.log("\n--- Discovering ProxyAdmin ---")
+  const Bridge = await get("Bridge")
+  const adminData = await ethers.provider.getStorageAt(
+    Bridge.address,
+    EIP_1967_ADMIN_SLOT
+  )
+  const proxyAdminAddress = ethers.utils.getAddress(`0x${adminData.slice(26)}`)
+  console.log(`  ProxyAdmin discovered: ${proxyAdminAddress}`)
+
+  if (proxyAdminAddress.toLowerCase() !== KNOWN_PROXY_ADMIN.toLowerCase()) {
+    console.log(
+      `  WARNING: Discovered ProxyAdmin ${proxyAdminAddress} does not match ` +
+        `known address ${KNOWN_PROXY_ADMIN}`
+    )
+  } else {
+    console.log("  ProxyAdmin matches known address")
+  }
+
+  // --- Step 5: Generate governance calldata ---
+  // The deployer EOA is NOT the ProxyAdmin owner, so the script generates
+  // calldata for governance actors rather than executing transactions.
+  //
+  // Governance flow:
+  //   Timelock route:  Council Safe -> Timelock.schedule() -> [wait 24h] ->
+  //                    Timelock.execute() -> ProxyAdmin.upgrade (Bridge and
+  //                    RebateStaking proxies must both be upgraded together,
+  //                    since Deposit.sol calls
+  //                    RebateStaking.isAuthorizedSponsor())
+  //   Council route:   Council Safe -> BridgeGovernance.setSponsoredDepositor()
+  //                    (direct onlyOwner, no begin/finalize)
+  console.log("\n--- Generating governance calldata ---")
+
+  const BridgeGovernance = await get("BridgeGovernance")
+  const RebateStaking = await get("RebateStaking")
+
+  if (
+    RebateStaking.address.toLowerCase() !==
+    KNOWN_REBATE_STAKING_PROXY.toLowerCase()
+  ) {
+    console.log(
+      `  WARNING: Discovered RebateStaking ${RebateStaking.address} does not ` +
+        `match known address ${KNOWN_REBATE_STAKING_PROXY}`
+    )
+  } else {
+    console.log("  RebateStaking proxy matches known address")
+  }
+
+  // Timelock action [0]: RebateStaking upgrade. Ordered before the Bridge
+  // upgrade so the RebateStaking proxy already exposes
+  // isAuthorizedSponsor() by the time the Bridge upgrade activates.
+  // Timelock minDelay = 86400s (24h)
+  const rebateStakingUpgradeCalldata = encodeRebateStakingUpgrade(
+    RebateStaking.address,
+    rebateStakingImpl.address
+  )
+  logCalldataAction(
+    "Timelock Action [0]: RebateStaking upgrade",
+    proxyAdminAddress,
+    "ProxyAdmin",
+    rebateStakingUpgradeCalldata,
+    {
+      Proxy: RebateStaking.address,
+      "New impl": rebateStakingImpl.address,
+    }
+  )
+
+  // Timelock action [1]: Bridge upgrade
+  // Timelock minDelay = 86400s (24h)
+  const bridgeUpgradeCalldata = encodeBridgeUpgrade(
+    Bridge.address,
+    bridgeImpl.address
+  )
+  logCalldataAction(
+    "Timelock Action [1]: Bridge upgrade",
+    proxyAdminAddress,
+    "ProxyAdmin",
+    bridgeUpgradeCalldata,
+    {
+      Proxy: Bridge.address,
+      "New impl": bridgeImpl.address,
+    }
+  )
+
+  // Council Safe direct action: setSponsoredDepositor on BridgeGovernance
+  const setSponsoredCalldata = encodeSetSponsoredDepositor(
+    KNOWN_NATIVE_BTC_DEPOSITOR,
+    true
+  )
+  logCalldataAction(
+    "Council Safe Action: setSponsoredDepositor",
+    BridgeGovernance.address,
+    "BridgeGovernance",
+    setSponsoredCalldata,
+    {
+      Depositor: KNOWN_NATIVE_BTC_DEPOSITOR,
+      Sponsored: "true",
+    }
+  )
+
+  console.log(`\n${"=".repeat(80)}`)
+  console.log("Governance calldata generation complete")
+  console.log("=".repeat(80))
+
+  // --- Step 6: Save deployment summary JSON ---
+  const chainId = await hre.getChainId()
+
+  const deploymentSummary = {
+    network: hre.network.name,
+    timestamp: new Date().toISOString(),
+    deployer,
+    chainId,
+    deployedContracts: {
+      BridgeSponsoredDepositorImplementation: bridgeImpl.address,
+      RebateStakingSponsoredDepositorImplementation: rebateStakingImpl.address,
+    },
+    existingContracts: {
+      Bridge: Bridge.address,
+      RebateStaking: RebateStaking.address,
+      ProxyAdmin: proxyAdminAddress,
+      Timelock: KNOWN_TIMELOCK,
+      CouncilSafe: KNOWN_COUNCIL_SAFE,
+      BridgeGovernance: BridgeGovernance.address,
+      NativeBTCDepositor: KNOWN_NATIVE_BTC_DEPOSITOR,
+    },
+    timelockActions: [
+      {
+        target: proxyAdminAddress,
+        data: rebateStakingUpgradeCalldata,
+        value: 0,
+        description: "RebateStaking proxy upgrade via ProxyAdmin.upgrade()",
+      },
+      {
+        target: proxyAdminAddress,
+        data: bridgeUpgradeCalldata,
+        value: 0,
+        description: "Bridge proxy upgrade via ProxyAdmin.upgrade()",
+      },
+    ],
+    councilSafeActions: [
+      {
+        to: BridgeGovernance.address,
+        data: setSponsoredCalldata,
+        value: 0,
+        description:
+          "setSponsoredDepositor on BridgeGovernance (direct onlyOwner call)",
+      },
+    ],
+    libraries: bridgeLibraries,
+    verificationChecks: buildVerificationChecks({
+      bridgeProxy: Bridge.address,
+      bridgeImpl: bridgeImpl.address,
+      rebateStakingProxy: RebateStaking.address,
+      rebateStakingImpl: rebateStakingImpl.address,
+    }),
+  }
+
+  const summaryDir = path.join(__dirname, "..", "deployments", hre.network.name)
+  fs.mkdirSync(summaryDir, { recursive: true })
+  const summaryPath = path.join(
+    summaryDir,
+    `bridge-sponsored-depositor-upgrade-${Date.now()}.json`
+  )
+
+  try {
+    fs.writeFileSync(summaryPath, JSON.stringify(deploymentSummary, null, 2))
+    console.log(`\nDeployment summary saved to: ${summaryPath}`)
+  } catch (error) {
+    console.log(
+      `WARNING: Failed to write deployment summary to ${summaryPath}: ` +
+        `${(error as Error).message}`
+    )
+  }
+
+  console.log(`\n${"=".repeat(80)}`)
+  console.log("DEPLOYMENT SUMMARY")
+  console.log("=".repeat(80))
+  console.log(`  Network:  ${hre.network.name}`)
+  console.log(`  Chain ID: ${chainId}`)
+  console.log(`  Deployer: ${deployer}`)
+  console.log(`  Summary:  ${summaryPath}`)
+  console.log("\n  Timelock Actions (minDelay=86400s / 24h):")
+  console.log("    [0] RebateStaking upgrade")
+  console.log(`        Target: ProxyAdmin (${proxyAdminAddress})`)
+  console.log(`        Selector: ${rebateStakingUpgradeCalldata.slice(0, 10)}`)
+  console.log(`        Proxy: ${RebateStaking.address}`)
+  console.log(`        New impl: ${rebateStakingImpl.address}`)
+  console.log("    [1] Bridge upgrade")
+  console.log(`        Target: ProxyAdmin (${proxyAdminAddress})`)
+  console.log(`        Selector: ${bridgeUpgradeCalldata.slice(0, 10)}`)
+  console.log(`        Proxy: ${Bridge.address}`)
+  console.log(`        New impl: ${bridgeImpl.address}`)
+  console.log("\n  Council Safe Actions:")
+  console.log("    setSponsoredDepositor on BridgeGovernance")
+  console.log(`        To: ${BridgeGovernance.address}`)
+  console.log(`        Depositor: ${KNOWN_NATIVE_BTC_DEPOSITOR}`)
+  console.log("        Sponsored: true")
+  console.log("=".repeat(80))
+
+  // --- Post-deployment verification commands ---
+  logVerificationChecks(deploymentSummary.verificationChecks)
+
+  // --- Step 7: Verify contracts on Etherscan (v2 API) ---
+  if (hre.network.tags.etherscan) {
+    const etherscanApiKey = process.env.ETHERSCAN_API_KEY
+    if (etherscanApiKey) {
+      console.log("\nVerifying Bridge implementation on Etherscan...")
+      try {
+        await hre.run("verify", {
+          address: bridgeImpl.address,
+          constructorArgsParams: bridgeImpl.args,
+        })
+        console.log("Verification successful")
+      } catch (error) {
+        console.log(
+          `WARNING: Etherscan verification failed: ${(error as Error).message}`
+        )
+      }
+
+      console.log("\nVerifying RebateStaking implementation on Etherscan...")
+      try {
+        await hre.run("verify", {
+          address: rebateStakingImpl.address,
+          constructorArgsParams: rebateStakingImpl.args,
+        })
+        console.log("Verification successful")
+      } catch (error) {
+        console.log(
+          `WARNING: Etherscan verification failed: ${(error as Error).message}`
+        )
+      }
+    } else {
+      console.log(
+        "\nSkipping Etherscan verification: ETHERSCAN_API_KEY not set"
+      )
+    }
+  }
+}
+
+export default func
+
+func.tags = ["UpgradeBridgeSponsoredDepositor"]
+// Set DEPLOY_SPONSORED_DEPOSITOR=true when running the deployment.
+// yarn deploy --tags UpgradeBridgeSponsoredDepositor --network <NETWORK>
+func.skip = async () => process.env.DEPLOY_SPONSORED_DEPOSITOR !== "true"

--- a/solidity/deploy/87_upgrade_bridge_sponsored_depositor.ts
+++ b/solidity/deploy/87_upgrade_bridge_sponsored_depositor.ts
@@ -11,10 +11,10 @@ import { utils } from "ethers"
  *         `sponsoredDepositors` allowlist used by `NativeBTCDepositor` to
  *         route rebate consumption to a staker address decoded from deposit
  *         `extraData`. The RebateStaking upgrade enables the
- *         `sponsorAuthorizations` mapping stakers use to authorize a
+ *         `stakerSponsorConsent` mapping stakers use to authorize a
  *         sponsored depositor to route rebate consumption to their stake.
  *         Both proxies must be upgraded together: Deposit.sol's sponsored
- *         depositor routing calls `RebateStaking.isAuthorizedSponsor()`,
+ *         depositor routing calls `RebateStaking.isSponsorConsentGranted()`,
  *         which does not exist on the currently deployed implementation.
  *
  * @dev IMPORTANT DEPLOYMENT NOTES:
@@ -34,8 +34,8 @@ import { utils } from "ethers"
  * Context:
  * - PR #970 adds a `sponsoredDepositors` mapping to Bridge storage and a
  *   `setSponsoredDepositor` function on BridgeGovernance
- * - PR #970 also adds a `sponsorAuthorizations` mapping to RebateStaking
- *   storage and `setSponsorAuthorization` / `isAuthorizedSponsor` functions
+ * - PR #970 also adds a `stakerSponsorConsent` mapping to RebateStaking
+ *   storage and `setSponsorConsent` / `isSponsorConsentGranted` functions
  * - The `NativeBTCDepositor` proxy at KNOWN_NATIVE_BTC_DEPOSITOR must be
  *   added to the allowlist after the upgrade for rebate routing to work
  * - This script generates the calldata for both proxy upgrades and the
@@ -84,7 +84,7 @@ export const KNOWN_NATIVE_BTC_DEPOSITOR =
 
 // Known mainnet RebateStaking proxy address. This proxy must be upgraded
 // alongside the Bridge proxy: Deposit.sol's sponsored depositor routing
-// calls RebateStaking.isAuthorizedSponsor(), which does not exist on the
+// calls RebateStaking.isSponsorConsentGranted(), which does not exist on the
 // currently deployed RebateStaking implementation.
 export const KNOWN_REBATE_STAKING_PROXY =
   "0x0184739C32edc3471D3e4860c8E39a5f3Ff85A45"
@@ -126,7 +126,7 @@ export function encodeBridgeUpgrade(
 
 /**
  * Encodes ProxyAdmin.upgrade() calldata for upgrading the RebateStaking
- * proxy to the new implementation. The new `sponsorAuthorizations` mapping
+ * proxy to the new implementation. The new `stakerSponsorConsent` mapping
  * added by this upgrade is a plain Solidity mapping and zero-defaults to
  * empty, so no post-upgrade initializer call is required.
  * @param rebateStakingProxy - Address of the RebateStaking proxy contract
@@ -193,7 +193,7 @@ function buildVerificationChecks(addresses: {
 }): VerificationCheck[] {
   return [
     {
-      command: `cast call ${addresses.bridgeProxy} "sponsoredDepositors(address)(bool)" ${KNOWN_NATIVE_BTC_DEPOSITOR}`,
+      command: `cast call ${addresses.bridgeProxy} "isSponsoredDepositor(address)(bool)" ${KNOWN_NATIVE_BTC_DEPOSITOR}`,
       expectedResult: "true",
       description:
         "After BridgeGovernance.setSponsoredDepositor call, NativeBTCDepositor should be on the allowlist",
@@ -218,10 +218,13 @@ function buildVerificationChecks(addresses: {
         `cast storage ${addresses.bridgeProxy} 81`,
       expectedResult:
         "Slot 79 = redemptionWatchtower address, " +
-        "slot 80 = rebate staking address, " +
-        "slots 81-128 = zero (__gap[48], gap size unchanged)",
+        "slot 80 = rebateStaking address, " +
+        "slot 81 = sponsoredDepositors mapping base (reads zero, mappings " +
+        "are unrepresented at their base slot), " +
+        "slots 82-128 = zero (__gap[47], reduced from 48 to make room for " +
+        "the new mapping)",
       description:
-        "Bridge storage layout: slot 79=redemptionWatchtower, slot 80=rebate staking, slots 81-128=__gap[48] with gap size unchanged",
+        "Bridge storage layout: slot 79=redemptionWatchtower, slot 80=rebateStaking, slot 81=sponsoredDepositors mapping base, slots 82-128=__gap[47] (reduced from 48); total struct footprint unchanged",
     },
     {
       command: `cast storage ${addresses.rebateStakingProxy} ${EIP_1967_IMPLEMENTATION_SLOT}`,
@@ -231,11 +234,11 @@ function buildVerificationChecks(addresses: {
     },
     {
       command:
-        `cast call ${addresses.rebateStakingProxy} "isAuthorizedSponsor(address,address)(bool)" ` +
+        `cast call ${addresses.rebateStakingProxy} "isSponsorConsentGranted(address,address)(bool)" ` +
         `<sample_staker> ${KNOWN_NATIVE_BTC_DEPOSITOR}`,
       expectedResult: "false (no authorization set for un-configured stakers)",
       description:
-        "RebateStaking implementation should expose isAuthorizedSponsor() and preserve default false state after upgrade",
+        "RebateStaking implementation should expose isSponsorConsentGranted() and preserve default false state after upgrade",
     },
   ]
 }
@@ -271,19 +274,33 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Network: ${hre.network.name}`)
   console.log(`Deployer: ${deployer}`)
 
-  // --- Step 1: Resolve existing libraries ---
-  // These libraries have NOT changed since last deployment and are reused
-  // from existing deployment artifacts.
-  console.log("\n--- Resolving existing libraries ---")
-  const Deposit = await get("Deposit")
+  // --- Step 1: Deploy updated library, resolve unchanged libraries ---
+  // Deposit has the sponsored-depositor rebate routing changes (an
+  // external library the Bridge contract calls via
+  // `using Deposit for BridgeState.Storage` + DELEGATECALL) and requires a
+  // fresh deployment so the new behavior is linked into the Bridge
+  // implementation below. DepositSweep, Redemption, Wallets, Fraud, and
+  // MovingFunds have NOT changed since last deployment and are reused from
+  // existing deployment artifacts.
+  console.log(
+    "\n--- Deploying updated library / resolving unchanged libraries ---"
+  )
+  const previousDeposit = await get("Deposit")
+  const Deposit = await deploy("Deposit", deployOptions)
+  if (Deposit.address.toLowerCase() === previousDeposit.address.toLowerCase()) {
+    throw new Error(
+      "Deposit library address unchanged after redeploy - sponsored-routing behavior will not activate"
+    )
+  }
   const DepositSweep = await get("DepositSweep")
   const Redemption = await get("Redemption")
   const Wallets = await get("Wallets")
   const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
 
-  console.log("Existing library addresses:")
+  console.log("Newly deployed libraries:")
   console.log(`  Deposit:       ${Deposit.address}`)
+  console.log("Existing library addresses:")
   console.log(`  DepositSweep:  ${DepositSweep.address}`)
   console.log(`  Redemption:    ${Redemption.address}`)
   console.log(`  Wallets:       ${Wallets.address}`)
@@ -363,9 +380,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   //                    Timelock.execute() -> ProxyAdmin.upgrade (Bridge and
   //                    RebateStaking proxies must both be upgraded together,
   //                    since Deposit.sol calls
-  //                    RebateStaking.isAuthorizedSponsor())
+  //                    RebateStaking.isSponsorConsentGranted())
   //   Council route:   Council Safe -> BridgeGovernance.setSponsoredDepositor()
   //                    (direct onlyOwner, no begin/finalize)
+  //   Per-staker opt-in: after both proxy upgrades and the Council Safe
+  //                    allowlist call, the sponsored-routing rebate does NOT
+  //                    activate for any staker until that staker separately
+  //                    calls RebateStaking.setSponsorConsent(depositor,
+  //                    true) themselves. This script cannot automate or
+  //                    execute this on a staker's behalf; operators should
+  //                    communicate this to affected stakers (e.g.
+  //                    NativeBTCDepositor users) as part of the rollout.
   console.log("\n--- Generating governance calldata ---")
 
   const BridgeGovernance = await get("BridgeGovernance")
@@ -385,7 +410,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Timelock action [0]: RebateStaking upgrade. Ordered before the Bridge
   // upgrade so the RebateStaking proxy already exposes
-  // isAuthorizedSponsor() by the time the Bridge upgrade activates.
+  // isSponsorConsentGranted() by the time the Bridge upgrade activates.
   // Timelock minDelay = 86400s (24h)
   const rebateStakingUpgradeCalldata = encodeRebateStakingUpgrade(
     RebateStaking.address,
@@ -423,6 +448,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const setSponsoredCalldata = encodeSetSponsoredDepositor(
     KNOWN_NATIVE_BTC_DEPOSITOR,
     true
+  )
+  console.log(
+    "\nWARNING: Do not execute the Council Safe setSponsoredDepositor " +
+      "action until Timelock Action [0] (RebateStaking upgrade) has been " +
+      "scheduled AND executed on-chain. The two Timelock actions are NOT " +
+      "batched atomically; executing Council Safe's action first will make " +
+      "revealDepositWithExtraData calls through the allowlisted depositor " +
+      "revert (isSponsorConsentGranted selector does not exist on the " +
+      "not-yet-upgraded RebateStaking implementation)."
   )
   logCalldataAction(
     "Council Safe Action: setSponsoredDepositor",
@@ -481,6 +515,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         value: 0,
         description:
           "setSponsoredDepositor on BridgeGovernance (direct onlyOwner call)",
+        requiresPriorExecution: ["Timelock Action [0]: RebateStaking upgrade"],
       },
     ],
     libraries: bridgeLibraries,

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1254,6 +1254,160 @@ describe("Bridge - Deposit", () => {
                     })
                   })
 
+                  context(
+                    "when depositor is on the sponsored depositor allowlist",
+                    () => {
+                      // The fixture's `extraData` is a fixed 32-byte value
+                      // embedded in the Bitcoin script; its low 20 bytes give
+                      // the L1 receiver address whose stake should be
+                      // honored when the depositor is on the allowlist.
+                      const receiverAddress = ethers.utils.getAddress(
+                        `0x${extraData.slice(-40)}`
+                      )
+                      const stakeAmount = to1e18(5)
+
+                      let receiver: SignerWithAddress
+                      let depositorAvailableBefore: BigNumber
+                      let receiverAvailableBefore: BigNumber
+
+                      before(async () => {
+                        await createSnapshot()
+
+                        // Allowlist the depositor that the existing fixture
+                        // already impersonates as the reveal caller. Goes
+                        // through `BridgeGovernance` because Bridge governance
+                        // is still held by that contract in this fixture.
+                        await bridgeGovernance
+                          .connect(governance)
+                          .setSponsoredDepositor(depositor.address, true)
+
+                        // Fund the receiver-impersonating account with ETH so
+                        // it can pay gas, then mint and stake T from it.
+                        receiver = await impersonateAccount(receiverAddress, {
+                          from: governance,
+                          value: 10,
+                        })
+                        await t
+                          .connect(deployer)
+                          .mint(receiver.address, stakeAmount)
+                        await t
+                          .connect(receiver)
+                          .approve(rebateStaking.address, stakeAmount)
+                        await rebateStaking.connect(receiver).stake(stakeAmount)
+
+                        depositorAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        receiverAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        await bridge
+                          .connect(depositor)
+                          .revealDepositWithExtraData(
+                            P2SHFundingTx,
+                            reveal,
+                            extraData
+                          )
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should consume rebate from the receiver, not the depositor", async () => {
+                        const depositorAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        const receiverAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        expect(receiverAvailableAfter).to.be.lt(
+                          receiverAvailableBefore
+                        )
+                        expect(depositorAvailableAfter).to.equal(
+                          depositorAvailableBefore
+                        )
+                      })
+
+                      it("should still record deposit.depositor as the depositor contract", async () => {
+                        const depositKey = ethers.utils.solidityKeccak256(
+                          ["bytes32", "uint32"],
+                          [
+                            "0x6383cd1829260b6034cd12bad36171748e8c3c6a8d57fcb6463c62f96116dfbc",
+                            reveal.fundingOutputIndex,
+                          ]
+                        )
+                        const deposit = await bridge.deposits(depositKey)
+                        expect(deposit.depositor).to.equal(depositor.address)
+                        expect(deposit.extraData).to.equal(extraData)
+                      })
+                    }
+                  )
+
+                  context(
+                    "when depositor is not on the sponsored depositor allowlist",
+                    () => {
+                      // Same setup as the sponsored case but without
+                      // allowlisting the depositor. The rebate should fall
+                      // back to the depositor identity (unchanged behavior),
+                      // and the L1 receiver's stake should be untouched.
+                      const receiverAddress = ethers.utils.getAddress(
+                        `0x${extraData.slice(-40)}`
+                      )
+                      const stakeAmount = to1e18(5)
+
+                      let receiver: SignerWithAddress
+                      let receiverAvailableBefore: BigNumber
+
+                      before(async () => {
+                        await createSnapshot()
+
+                        receiver = await impersonateAccount(receiverAddress, {
+                          from: governance,
+                          value: 10,
+                        })
+                        await t
+                          .connect(deployer)
+                          .mint(receiver.address, stakeAmount)
+                        await t
+                          .connect(receiver)
+                          .approve(rebateStaking.address, stakeAmount)
+                        await rebateStaking.connect(receiver).stake(stakeAmount)
+
+                        receiverAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        await bridge
+                          .connect(depositor)
+                          .revealDepositWithExtraData(
+                            P2SHFundingTx,
+                            reveal,
+                            extraData
+                          )
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should leave the receiver's rebate untouched", async () => {
+                        expect(
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+                        ).to.equal(receiverAvailableBefore)
+                      })
+                    }
+                  )
+
                   context("when deposit is not routed to a vault", () => {
                     let tx: ContractTransaction
                     let nonRoutedReveal: DepositRevealInfoStruct

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -473,6 +473,33 @@ describe("Bridge - Deposit", () => {
                       })
                     }
                   )
+
+                  context(
+                    "when depositor is on the sponsored depositor allowlist",
+                    () => {
+                      before(async () => {
+                        await createSnapshot()
+
+                        await bridgeGovernance
+                          .connect(governance)
+                          .setSponsoredDepositor(depositor.address, true)
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should revert because extraData is required", async () => {
+                        await expect(
+                          bridge
+                            .connect(depositor)
+                            .revealDeposit(P2SHFundingTx, reveal)
+                        ).to.be.revertedWith(
+                          "Sponsored depositor must provide extraData"
+                        )
+                      })
+                    }
+                  )
                 })
 
                 context("when deposit is not routed to a vault", () => {

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 
+import crypto from "crypto"
 import { ethers, getUnnamedAccounts, helpers } from "hardhat"
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 import { BigNumber, Contract, ContractTransaction } from "ethers"
@@ -476,12 +477,41 @@ describe("Bridge - Deposit", () => {
                   context(
                     "when depositor is on the sponsored depositor allowlist",
                     () => {
+                      const stakeAmount = to1e18(5)
+                      let depositorAvailableBefore: BigNumber
+
                       before(async () => {
                         await createSnapshot()
 
                         await bridgeGovernance
                           .connect(governance)
                           .setSponsoredDepositor(depositor.address, true)
+
+                        // `revealDeposit` never carries `extraData`, so the
+                        // sponsor-routing branch in `Deposit.sol` can never
+                        // trigger here; the allowlisted depositor always
+                        // falls back to charging its own stake. Stake T for
+                        // the depositor so the rebate consumption asserted
+                        // below is a real fallback, not an artifact of
+                        // rebate logic never engaging at all.
+                        await t
+                          .connect(deployer)
+                          .mint(depositor.address, stakeAmount)
+                        await t
+                          .connect(depositor)
+                          .approve(rebateStaking.address, stakeAmount)
+                        await rebateStaking
+                          .connect(depositor)
+                          .stake(stakeAmount)
+
+                        depositorAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+
+                        await bridge
+                          .connect(depositor)
+                          .revealDeposit(P2SHFundingTx, reveal)
                       })
 
                       after(async () => {
@@ -489,10 +519,6 @@ describe("Bridge - Deposit", () => {
                       })
 
                       it("should not revert and should charge the depositor's own rebate", async () => {
-                        await bridge
-                          .connect(depositor)
-                          .revealDeposit(P2SHFundingTx, reveal)
-
                         const depositKey = ethers.utils.solidityKeccak256(
                           ["bytes32", "uint32"],
                           [
@@ -503,7 +529,16 @@ describe("Bridge - Deposit", () => {
 
                         const deposit = await bridge.deposits(depositKey)
 
-                        expect(deposit.treasuryFee).to.be.equal(5)
+                        expect(deposit.treasuryFee).to.be.equal(0)
+
+                        const depositorAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+
+                        expect(depositorAvailableAfter).to.be.lt(
+                          depositorAvailableBefore
+                        )
                       })
                     }
                   )
@@ -1288,67 +1323,207 @@ describe("Bridge - Deposit", () => {
                     })
                   })
 
+                  // ──────────────────────────────────────────────────────────
+                  // Dedicated fixture for sponsored-rebate-routing tests.
+                  // Uses the SAME walletPubKeyHash already registered Live in
+                  // the enclosing describe scope, a ZERO_ADDRESS vault, and
+                  // constructs a P2SH funding tx + reveal matching the exact
+                  // script layout Deposit.sol expects for the extraData branch.
+                  // ──────────────────────────────────────────────────────────
+                  interface ExtraDataFundingFixture {
+                    fundingTx: BitcoinTxInfoStruct
+                    reveal: DepositRevealInfoStruct
+                    extraData: string
+                    receiverAddress: string
+                  }
+
+                  function buildExtraDataFundingTx(
+                    receiverAddress: string,
+                    canonical: boolean
+                  ): ExtraDataFundingFixture {
+                    // The depositor embedded in the script must match the
+                    // reveal caller (depositor.address).
+                    const depositorAddr = depositorAddress
+                    // Fields not inspected by the routing logic can be random.
+                    const blindingFactor = `0x${crypto
+                      .randomBytes(8)
+                      .toString("hex")}`
+                    const refundPubKeyHash = `0x${crypto
+                      .randomBytes(20)
+                      .toString("hex")}`
+                    const refundLocktime = `0x${crypto
+                      .randomBytes(4)
+                      .toString("hex")}`
+
+                    // extraData: canonically left-padded (high 12 bytes zero) or
+                    // deliberately dirty (flip bit 0 of byte 0). Lowercase the
+                    // address first so the resulting extraData matches the
+                    // lowercase bytes32 the chain returns for `deposit.extraData`.
+                    const lowerReceiver = receiverAddress.toLowerCase()
+                    let extraData: string
+                    if (canonical) {
+                      extraData = ethers.utils.hexZeroPad(lowerReceiver, 32)
+                    } else {
+                      const canonicalPad = ethers.utils.hexZeroPad(
+                        lowerReceiver,
+                        32
+                      )
+                      // Flip the high byte (byte 0) to make it non-canonical.
+                      const highByte =
+                        parseInt(canonicalPad.slice(2, 4), 16) ^ 0x01
+                      extraData = `0x${highByte
+                        .toString(16)
+                        .padStart(2, "0")}${canonicalPad.slice(4)}`
+                    }
+
+                    // Build the deposit script exactly as Deposit.sol does.
+                    const depositScript =
+                      `0x14${depositorAddr.slice(2)}75` +
+                      `20${extraData.slice(2)}75` +
+                      `08${blindingFactor.slice(2)}75` +
+                      `76a914${(reveal.walletPubKeyHash as string).slice(
+                        2
+                      )}87` +
+                      "63ac67" +
+                      `76a914${refundPubKeyHash.slice(2)}88` +
+                      `04${refundLocktime.slice(2)}b175` +
+                      "ac68"
+
+                    // P2SH script hash: RIPEMD160(SHA256(script))
+                    const sha256Hash = ethers.utils.sha256(depositScript)
+                    const ripemd160Hash = ethers.utils
+                      .ripemd160(sha256Hash)
+                      .slice(2)
+                    const depositScriptHash = `17a914${ripemd160Hash}87`
+
+                    // Funding transaction (inputVector can be random, irrelevant to validation).
+                    const fundingTx: BitcoinTxInfoStruct = {
+                      version: "0x01000000",
+                      inputVector: `0x01${crypto
+                        .randomBytes(32)
+                        .toString("hex")}0000000000ffffffff`,
+                      // 1 output, 10000 satoshi (0x1027000000000000 little-endian)
+                      outputVector: `0x011027000000000000${depositScriptHash}`,
+                      locktime: "0x00000000",
+                    }
+
+                    const revealObj: DepositRevealInfoStruct = {
+                      fundingOutputIndex: 0,
+                      blindingFactor,
+                      walletPubKeyHash: reveal.walletPubKeyHash,
+                      refundPubKeyHash,
+                      refundLocktime,
+                      vault: ZERO_ADDRESS,
+                    }
+
+                    return {
+                      fundingTx,
+                      reveal: revealObj,
+                      extraData,
+                      receiverAddress,
+                    }
+                  }
+                  // Stakes T from the L1 address encoded in `extraData`
+                  // (the "receiver"), optionally allowlists `depositor` as a
+                  // sponsored depositor and/or has the receiver authorize
+                  // `depositor` as a sponsor, then submits the
+                  // `revealDepositWithExtraData` reveal. Shared by the
+                  // sponsored/non-sponsored/unauthorized scenarios below,
+                  // which only differ in which of these two flags are set.
+                  async function stakeReceiverAndReveal(
+                    options: {
+                      allowlisted: boolean
+                      authorized: boolean
+                    },
+                    fixture?: ExtraDataFundingFixture
+                  ): Promise<{
+                    receiver: SignerWithAddress
+                    receiverAvailableBefore: BigNumber
+                  }> {
+                    // Use the provided fixture's extraData, or fall back to the
+                    // shared fixture's extraData for backward compatibility.
+                    const extraDataToUse = fixture?.extraData ?? extraData
+                    const receiverAddress = ethers.utils.getAddress(
+                      `0x${extraDataToUse.slice(-40)}`
+                    )
+                    const stakeAmount = to1e18(5)
+
+                    if (options.allowlisted) {
+                      // Allowlist the depositor that the existing fixture
+                      // already impersonates as the reveal caller. Goes
+                      // through `BridgeGovernance` because Bridge governance
+                      // is still held by that contract in this fixture.
+                      await bridgeGovernance
+                        .connect(governance)
+                        .setSponsoredDepositor(depositor.address, true)
+                    }
+
+                    // Fund the receiver-impersonating account with ETH so it
+                    // can pay gas, then mint and stake T from it.
+                    const receiver = await impersonateAccount(receiverAddress, {
+                      from: governance,
+                      value: 10,
+                    })
+                    await t
+                      .connect(deployer)
+                      .mint(receiver.address, stakeAmount)
+                    await t
+                      .connect(receiver)
+                      .approve(rebateStaking.address, stakeAmount)
+                    await rebateStaking.connect(receiver).stake(stakeAmount)
+
+                    if (options.authorized) {
+                      await rebateStaking
+                        .connect(receiver)
+                        .setSponsorConsent(depositor.address, true)
+                    }
+
+                    const receiverAvailableBefore =
+                      await rebateStaking.getAvailableRebate(receiver.address)
+
+                    await bridge
+                      .connect(depositor)
+                      .revealDepositWithExtraData(
+                        fixture?.fundingTx ?? P2SHFundingTx,
+                        fixture?.reveal ?? reveal,
+                        extraDataToUse
+                      )
+
+                    return { receiver, receiverAvailableBefore }
+                  }
+
                   context(
                     "when depositor is on the sponsored depositor allowlist",
                     () => {
-                      // The fixture's `extraData` is a fixed 32-byte value
-                      // embedded in the Bitcoin script; its low 20 bytes give
-                      // the L1 receiver address whose stake should be
-                      // honored when the depositor is on the allowlist.
-                      const receiverAddress = ethers.utils.getAddress(
-                        `0x${extraData.slice(-40)}`
-                      )
-                      const stakeAmount = to1e18(5)
-
                       let receiver: SignerWithAddress
                       let depositorAvailableBefore: BigNumber
                       let receiverAvailableBefore: BigNumber
+                      let canonicalFixture: ExtraDataFundingFixture
 
                       before(async () => {
                         await createSnapshot()
 
-                        // Allowlist the depositor that the existing fixture
-                        // already impersonates as the reveal caller. Goes
-                        // through `BridgeGovernance` because Bridge governance
-                        // is still held by that contract in this fixture.
-                        await bridgeGovernance
-                          .connect(governance)
-                          .setSponsoredDepositor(depositor.address, true)
-
-                        // Fund the receiver-impersonating account with ETH so
-                        // it can pay gas, then mint and stake T from it.
-                        receiver = await impersonateAccount(receiverAddress, {
-                          from: governance,
-                          value: 10,
-                        })
-                        await t
-                          .connect(deployer)
-                          .mint(receiver.address, stakeAmount)
-                        await t
-                          .connect(receiver)
-                          .approve(rebateStaking.address, stakeAmount)
-                        await rebateStaking.connect(receiver).stake(stakeAmount)
-
-                        await rebateStaking
-                          .connect(receiver)
-                          .setSponsorAuthorization(depositor.address, true)
+                        // Build a dedicated canonical-extraData fixture for this
+                        // test context so we don't touch the shared fixture.
+                        // Use a fresh receiver address from unnamed accounts.
+                        const unnamed = await getUnnamedAccounts()
+                        const freshReceiver = ethers.utils.getAddress(
+                          unnamed[0]
+                        )
+                        canonicalFixture = buildExtraDataFundingTx(
+                          freshReceiver,
+                          true // canonical: true
+                        )
 
                         depositorAvailableBefore =
                           await rebateStaking.getAvailableRebate(
                             depositor.address
                           )
-                        receiverAvailableBefore =
-                          await rebateStaking.getAvailableRebate(
-                            receiver.address
-                          )
-
-                        await bridge
-                          .connect(depositor)
-                          .revealDepositWithExtraData(
-                            P2SHFundingTx,
-                            reveal,
-                            extraData
-                          )
+                        ;({ receiver, receiverAvailableBefore } =
+                          await stakeReceiverAndReveal(
+                            { allowlisted: true, authorized: true },
+                            canonicalFixture
+                          ))
                       })
 
                       after(async () => {
@@ -1374,16 +1549,35 @@ describe("Bridge - Deposit", () => {
                       })
 
                       it("should still record deposit.depositor as the depositor contract", async () => {
+                        // Resulting TX hash is in native Bitcoin little-endian
+                        // format, computed the same way Deposit.sol does it.
+                        const fundingTxHash = ethers.utils.sha256(
+                          ethers.utils.sha256(
+                            (canonicalFixture.fundingTx.version as string) +
+                              (
+                                canonicalFixture.fundingTx.inputVector as string
+                              ).slice(2) +
+                              (
+                                canonicalFixture.fundingTx
+                                  .outputVector as string
+                              ).slice(2) +
+                              (
+                                canonicalFixture.fundingTx.locktime as string
+                              ).slice(2)
+                          )
+                        )
                         const depositKey = ethers.utils.solidityKeccak256(
                           ["bytes32", "uint32"],
                           [
-                            "0x6383cd1829260b6034cd12bad36171748e8c3c6a8d57fcb6463c62f96116dfbc",
-                            reveal.fundingOutputIndex,
+                            fundingTxHash,
+                            canonicalFixture.reveal.fundingOutputIndex,
                           ]
                         )
                         const deposit = await bridge.deposits(depositKey)
                         expect(deposit.depositor).to.equal(depositor.address)
-                        expect(deposit.extraData).to.equal(extraData)
+                        expect(deposit.extraData).to.equal(
+                          canonicalFixture.extraData
+                        )
                       })
                     }
                   )
@@ -1395,41 +1589,16 @@ describe("Bridge - Deposit", () => {
                       // allowlisting the depositor. The rebate should fall
                       // back to the depositor identity (unchanged behavior),
                       // and the L1 receiver's stake should be untouched.
-                      const receiverAddress = ethers.utils.getAddress(
-                        `0x${extraData.slice(-40)}`
-                      )
-                      const stakeAmount = to1e18(5)
-
                       let receiver: SignerWithAddress
                       let receiverAvailableBefore: BigNumber
 
                       before(async () => {
                         await createSnapshot()
-
-                        receiver = await impersonateAccount(receiverAddress, {
-                          from: governance,
-                          value: 10,
-                        })
-                        await t
-                          .connect(deployer)
-                          .mint(receiver.address, stakeAmount)
-                        await t
-                          .connect(receiver)
-                          .approve(rebateStaking.address, stakeAmount)
-                        await rebateStaking.connect(receiver).stake(stakeAmount)
-
-                        receiverAvailableBefore =
-                          await rebateStaking.getAvailableRebate(
-                            receiver.address
-                          )
-
-                        await bridge
-                          .connect(depositor)
-                          .revealDepositWithExtraData(
-                            P2SHFundingTx,
-                            reveal,
-                            extraData
-                          )
+                        ;({ receiver, receiverAvailableBefore } =
+                          await stakeReceiverAndReveal({
+                            allowlisted: false,
+                            authorized: false,
+                          }))
                       })
 
                       after(async () => {
@@ -1452,54 +1621,48 @@ describe("Bridge - Deposit", () => {
                       context(
                         "when extraData decodes to a staker who has not authorized the depositor",
                         () => {
-                          const receiverAddress = ethers.utils.getAddress(
-                            `0x${extraData.slice(-40)}`
-                          )
-                          const stakeAmount = to1e18(5)
+                          const depositorStakeAmount = to1e18(5)
 
                           let receiver: SignerWithAddress
+                          let depositorAvailableBefore: BigNumber
                           let receiverAvailableBefore: BigNumber
 
                           before(async () => {
                             await createSnapshot()
 
-                            await bridgeGovernance
-                              .connect(governance)
-                              .setSponsoredDepositor(depositor.address, true)
-
-                            // Stake T from the receiver-impersonating account
-                            // but never call `setSponsorAuthorization`, so
-                            // the depositor is allowlisted yet unauthorized
-                            // by the named staker.
-                            receiver = await impersonateAccount(
-                              receiverAddress,
-                              {
-                                from: governance,
-                                value: 10,
-                              }
-                            )
+                            // Stake T directly for the depositor itself:
+                            // since the sponsor authorization required to
+                            // route the rebate to the receiver is missing,
+                            // the reveal must fall back to consuming the
+                            // depositor's own stake rather than skipping
+                            // rebate application entirely.
                             await t
                               .connect(deployer)
-                              .mint(receiver.address, stakeAmount)
+                              .mint(depositor.address, depositorStakeAmount)
                             await t
-                              .connect(receiver)
-                              .approve(rebateStaking.address, stakeAmount)
-                            await rebateStaking
-                              .connect(receiver)
-                              .stake(stakeAmount)
-
-                            receiverAvailableBefore =
-                              await rebateStaking.getAvailableRebate(
-                                receiver.address
-                              )
-
-                            await bridge
                               .connect(depositor)
-                              .revealDepositWithExtraData(
-                                P2SHFundingTx,
-                                reveal,
-                                extraData
+                              .approve(
+                                rebateStaking.address,
+                                depositorStakeAmount
                               )
+                            await rebateStaking
+                              .connect(depositor)
+                              .stake(depositorStakeAmount)
+
+                            depositorAvailableBefore =
+                              await rebateStaking.getAvailableRebate(
+                                depositor.address
+                              )
+
+                            // Stake T from the receiver-impersonating account
+                            // but never call `setSponsorConsent`, so
+                            // the depositor is allowlisted yet unauthorized
+                            // by the named staker.
+                            ;({ receiver, receiverAvailableBefore } =
+                              await stakeReceiverAndReveal({
+                                allowlisted: true,
+                                authorized: false,
+                              }))
                           })
 
                           after(async () => {
@@ -1515,7 +1678,15 @@ describe("Bridge - Deposit", () => {
                               ]
                             )
                             const deposit = await bridge.deposits(depositKey)
-                            expect(deposit.treasuryFee).to.be.equal(5)
+                            expect(deposit.treasuryFee).to.be.equal(0)
+
+                            const depositorAvailableAfter =
+                              await rebateStaking.getAvailableRebate(
+                                depositor.address
+                              )
+                            expect(depositorAvailableAfter).to.be.lt(
+                              depositorAvailableBefore
+                            )
                           })
 
                           it("should leave the receiver's rebate untouched", async () => {
@@ -1531,7 +1702,7 @@ describe("Bridge - Deposit", () => {
                       // The symmetric "decodes to the zero address" edge
                       // case (the `decoded != address(0)` half of
                       // `Deposit.sol`'s single `if (decoded != address(0)
-                      // && isAuthorizedSponsor(...))` condition) is not
+                      // && isSponsorConsentGranted(...))` condition) is not
                       // covered by a dedicated test here. Exercising it
                       // would require an `extraData` value different from
                       // the fixture's committed `extraData`, but `extraData`
@@ -1540,11 +1711,128 @@ describe("Bridge - Deposit", () => {
                       // comment above), so swapping in a zero-decoding
                       // `extraData` would require regenerating a matching
                       // Bitcoin script fixture offline - disproportionate
-                      // for this narrow edge case. The `isAuthorizedSponsor`
+                      // for this narrow edge case. The `isSponsorConsentGranted`
                       // half of the same boolean AND is already covered by
                       // the sibling "when extraData decodes to a staker who
                       // has not authorized the depositor" test above, which
                       // correctly exercises the fail-open fallback.
+                    }
+                  )
+
+                  // ──────────────────────────────────────────────────────────
+                  // NEW: Fallback test for non-canonical extraData (dirty high byte).
+                  // Verifies that a non-canonical extraData payload is treated
+                  // as a missing precondition, causing the rebate to fall back
+                  // to charging the depositor (same as any other unmet condition).
+                  // ──────────────────────────────────────────────────────────
+                  context(
+                    "when depositor is on the sponsored depositor allowlist " +
+                      "and extraData has a dirty high byte (non-canonical)",
+                    () => {
+                      const depositorStakeAmount = to1e18(5)
+                      const receiverStakeAmount = to1e18(5)
+
+                      let receiver: SignerWithAddress
+                      let depositorAvailableBefore: BigNumber
+                      let receiverAvailableBefore: BigNumber
+                      let noncanonicalFixture: ExtraDataFundingFixture
+
+                      before(async () => {
+                        await createSnapshot()
+
+                        // Build a dedicated non-canonical-extraData fixture for
+                        // this test context; does not touch the shared fixture.
+                        const unnamed = await getUnnamedAccounts()
+                        const freshReceiver = ethers.utils.getAddress(
+                          unnamed[0]
+                        )
+                        noncanonicalFixture = buildExtraDataFundingTx(
+                          freshReceiver,
+                          false // canonical: false (dirty high byte)
+                        )
+
+                        await bridgeGovernance
+                          .connect(governance)
+                          .setSponsoredDepositor(depositor.address, true)
+
+                        // Stake T directly for the depositor itself: since the
+                        // canonical-encoding check makes the routing condition
+                        // unmet, the reveal must fall back to consuming the
+                        // depositor's own stake rather than skipping rebate
+                        // application entirely.
+                        await t
+                          .connect(deployer)
+                          .mint(depositor.address, depositorStakeAmount)
+                        await t
+                          .connect(depositor)
+                          .approve(rebateStaking.address, depositorStakeAmount)
+                        await rebateStaking
+                          .connect(depositor)
+                          .stake(depositorStakeAmount)
+
+                        // Fund the receiver-impersonating account with ETH so it
+                        // can pay gas, then mint and stake T from it, and grant
+                        // sponsor consent to the depositor. Consent is granted
+                        // despite the dirty extraData to isolate the canonical-
+                        // encoding check as the sole reason for the fallback.
+                        receiver = await impersonateAccount(
+                          noncanonicalFixture.receiverAddress,
+                          { from: governance, value: 10 }
+                        )
+                        await t
+                          .connect(deployer)
+                          .mint(receiver.address, receiverStakeAmount)
+                        await t
+                          .connect(receiver)
+                          .approve(rebateStaking.address, receiverStakeAmount)
+                        await rebateStaking
+                          .connect(receiver)
+                          .stake(receiverStakeAmount)
+                        await rebateStaking
+                          .connect(receiver)
+                          .setSponsorConsent(depositor.address, true)
+
+                        depositorAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        receiverAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        await bridge
+                          .connect(depositor)
+                          .revealDepositWithExtraData(
+                            noncanonicalFixture.fundingTx,
+                            noncanonicalFixture.reveal,
+                            noncanonicalFixture.extraData
+                          )
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should not revert and should charge the depositor's own rebate", async () => {
+                        const depositorAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        expect(depositorAvailableAfter).to.be.lt(
+                          depositorAvailableBefore
+                        )
+                      })
+
+                      it("should leave the receiver's rebate untouched", async () => {
+                        const receiverAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+                        expect(receiverAvailableAfter).to.equal(
+                          receiverAvailableBefore
+                        )
+                      })
                     }
                   )
 

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -488,14 +488,22 @@ describe("Bridge - Deposit", () => {
                         await restoreSnapshot()
                       })
 
-                      it("should revert because extraData is required", async () => {
-                        await expect(
-                          bridge
-                            .connect(depositor)
-                            .revealDeposit(P2SHFundingTx, reveal)
-                        ).to.be.revertedWith(
-                          "Sponsored depositor must provide extraData"
+                      it("should not revert and should charge the depositor's own rebate", async () => {
+                        await bridge
+                          .connect(depositor)
+                          .revealDeposit(P2SHFundingTx, reveal)
+
+                        const depositKey = ethers.utils.solidityKeccak256(
+                          ["bytes32", "uint32"],
+                          [
+                            "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                            reveal.fundingOutputIndex,
+                          ]
                         )
+
+                        const deposit = await bridge.deposits(depositKey)
+
+                        expect(deposit.treasuryFee).to.be.equal(5)
                       })
                     }
                   )
@@ -1321,6 +1329,10 @@ describe("Bridge - Deposit", () => {
                           .approve(rebateStaking.address, stakeAmount)
                         await rebateStaking.connect(receiver).stake(stakeAmount)
 
+                        await rebateStaking
+                          .connect(receiver)
+                          .setSponsorAuthorization(depositor.address, true)
+
                         depositorAvailableBefore =
                           await rebateStaking.getAvailableRebate(
                             depositor.address
@@ -1431,6 +1443,108 @@ describe("Bridge - Deposit", () => {
                           )
                         ).to.equal(receiverAvailableBefore)
                       })
+                    }
+                  )
+
+                  context(
+                    "when depositor is on the sponsored depositor allowlist but the required sponsor authorization is missing",
+                    () => {
+                      context(
+                        "when extraData decodes to a staker who has not authorized the depositor",
+                        () => {
+                          const receiverAddress = ethers.utils.getAddress(
+                            `0x${extraData.slice(-40)}`
+                          )
+                          const stakeAmount = to1e18(5)
+
+                          let receiver: SignerWithAddress
+                          let receiverAvailableBefore: BigNumber
+
+                          before(async () => {
+                            await createSnapshot()
+
+                            await bridgeGovernance
+                              .connect(governance)
+                              .setSponsoredDepositor(depositor.address, true)
+
+                            // Stake T from the receiver-impersonating account
+                            // but never call `setSponsorAuthorization`, so
+                            // the depositor is allowlisted yet unauthorized
+                            // by the named staker.
+                            receiver = await impersonateAccount(
+                              receiverAddress,
+                              {
+                                from: governance,
+                                value: 10,
+                              }
+                            )
+                            await t
+                              .connect(deployer)
+                              .mint(receiver.address, stakeAmount)
+                            await t
+                              .connect(receiver)
+                              .approve(rebateStaking.address, stakeAmount)
+                            await rebateStaking
+                              .connect(receiver)
+                              .stake(stakeAmount)
+
+                            receiverAvailableBefore =
+                              await rebateStaking.getAvailableRebate(
+                                receiver.address
+                              )
+
+                            await bridge
+                              .connect(depositor)
+                              .revealDepositWithExtraData(
+                                P2SHFundingTx,
+                                reveal,
+                                extraData
+                              )
+                          })
+
+                          after(async () => {
+                            await restoreSnapshot()
+                          })
+
+                          it("should not revert and should charge the depositor's own rebate", async () => {
+                            const depositKey = ethers.utils.solidityKeccak256(
+                              ["bytes32", "uint32"],
+                              [
+                                "0x6383cd1829260b6034cd12bad36171748e8c3c6a8d57fcb6463c62f96116dfbc",
+                                reveal.fundingOutputIndex,
+                              ]
+                            )
+                            const deposit = await bridge.deposits(depositKey)
+                            expect(deposit.treasuryFee).to.be.equal(5)
+                          })
+
+                          it("should leave the receiver's rebate untouched", async () => {
+                            expect(
+                              await rebateStaking.getAvailableRebate(
+                                receiver.address
+                              )
+                            ).to.equal(receiverAvailableBefore)
+                          })
+                        }
+                      )
+
+                      // The symmetric "decodes to the zero address" edge
+                      // case (the `decoded != address(0)` half of
+                      // `Deposit.sol`'s single `if (decoded != address(0)
+                      // && isAuthorizedSponsor(...))` condition) is not
+                      // covered by a dedicated test here. Exercising it
+                      // would require an `extraData` value different from
+                      // the fixture's committed `extraData`, but `extraData`
+                      // is baked into the pre-computed Bitcoin funding
+                      // transaction's locking script hash (see the fixture
+                      // comment above), so swapping in a zero-decoding
+                      // `extraData` would require regenerating a matching
+                      // Bitcoin script fixture offline - disproportionate
+                      // for this narrow edge case. The `isAuthorizedSponsor`
+                      // half of the same boolean AND is already covered by
+                      // the sibling "when extraData decodes to a staker who
+                      // has not authorized the depositor" test above, which
+                      // correctly exercises the fail-open fallback.
                     }
                   )
 

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -472,6 +472,33 @@ describe("Bridge - Deposit", () => {
                       })
                     }
                   )
+
+                  context(
+                    "when depositor is on the sponsored depositor allowlist",
+                    () => {
+                      before(async () => {
+                        await createSnapshot()
+
+                        await bridgeGovernance
+                          .connect(governance)
+                          .setSponsoredDepositor(depositor.address, true)
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should revert because extraData is required", async () => {
+                        await expect(
+                          bridge
+                            .connect(depositor)
+                            .revealDeposit(P2SHFundingTx, reveal)
+                        ).to.be.revertedWith(
+                          "Sponsored depositor must provide extraData"
+                        )
+                      })
+                    }
+                  )
                 })
 
                 context("when deposit is not routed to a vault", () => {

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1253,6 +1253,160 @@ describe("Bridge - Deposit", () => {
                     })
                   })
 
+                  context(
+                    "when depositor is on the sponsored depositor allowlist",
+                    () => {
+                      // The fixture's `extraData` is a fixed 32-byte value
+                      // embedded in the Bitcoin script; its low 20 bytes give
+                      // the L1 receiver address whose stake should be
+                      // honored when the depositor is on the allowlist.
+                      const receiverAddress = ethers.utils.getAddress(
+                        `0x${extraData.slice(-40)}`
+                      )
+                      const stakeAmount = to1e18(5)
+
+                      let receiver: SignerWithAddress
+                      let depositorAvailableBefore: BigNumber
+                      let receiverAvailableBefore: BigNumber
+
+                      before(async () => {
+                        await createSnapshot()
+
+                        // Allowlist the depositor that the existing fixture
+                        // already impersonates as the reveal caller. Goes
+                        // through `BridgeGovernance` because Bridge governance
+                        // is still held by that contract in this fixture.
+                        await bridgeGovernance
+                          .connect(governance)
+                          .setSponsoredDepositor(depositor.address, true)
+
+                        // Fund the receiver-impersonating account with ETH so
+                        // it can pay gas, then mint and stake T from it.
+                        receiver = await impersonateAccount(receiverAddress, {
+                          from: governance,
+                          value: 10,
+                        })
+                        await t
+                          .connect(deployer)
+                          .mint(receiver.address, stakeAmount)
+                        await t
+                          .connect(receiver)
+                          .approve(rebateStaking.address, stakeAmount)
+                        await rebateStaking.connect(receiver).stake(stakeAmount)
+
+                        depositorAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        receiverAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        await bridge
+                          .connect(depositor)
+                          .revealDepositWithExtraData(
+                            P2SHFundingTx,
+                            reveal,
+                            extraData
+                          )
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should consume rebate from the receiver, not the depositor", async () => {
+                        const depositorAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        const receiverAvailableAfter =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        expect(receiverAvailableAfter).to.be.lt(
+                          receiverAvailableBefore
+                        )
+                        expect(depositorAvailableAfter).to.equal(
+                          depositorAvailableBefore
+                        )
+                      })
+
+                      it("should still record deposit.depositor as the depositor contract", async () => {
+                        const depositKey = ethers.utils.solidityKeccak256(
+                          ["bytes32", "uint32"],
+                          [
+                            "0x6383cd1829260b6034cd12bad36171748e8c3c6a8d57fcb6463c62f96116dfbc",
+                            reveal.fundingOutputIndex,
+                          ]
+                        )
+                        const deposit = await bridge.deposits(depositKey)
+                        expect(deposit.depositor).to.equal(depositor.address)
+                        expect(deposit.extraData).to.equal(extraData)
+                      })
+                    }
+                  )
+
+                  context(
+                    "when depositor is not on the sponsored depositor allowlist",
+                    () => {
+                      // Same setup as the sponsored case but without
+                      // allowlisting the depositor. The rebate should fall
+                      // back to the depositor identity (unchanged behavior),
+                      // and the L1 receiver's stake should be untouched.
+                      const receiverAddress = ethers.utils.getAddress(
+                        `0x${extraData.slice(-40)}`
+                      )
+                      const stakeAmount = to1e18(5)
+
+                      let receiver: SignerWithAddress
+                      let receiverAvailableBefore: BigNumber
+
+                      before(async () => {
+                        await createSnapshot()
+
+                        receiver = await impersonateAccount(receiverAddress, {
+                          from: governance,
+                          value: 10,
+                        })
+                        await t
+                          .connect(deployer)
+                          .mint(receiver.address, stakeAmount)
+                        await t
+                          .connect(receiver)
+                          .approve(rebateStaking.address, stakeAmount)
+                        await rebateStaking.connect(receiver).stake(stakeAmount)
+
+                        receiverAvailableBefore =
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+
+                        await bridge
+                          .connect(depositor)
+                          .revealDepositWithExtraData(
+                            P2SHFundingTx,
+                            reveal,
+                            extraData
+                          )
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should leave the receiver's rebate untouched", async () => {
+                        expect(
+                          await rebateStaking.getAvailableRebate(
+                            receiver.address
+                          )
+                        ).to.equal(receiverAvailableBefore)
+                      })
+                    }
+                  )
+
                   context("when deposit is not routed to a vault", () => {
                     let tx: ContractTransaction
                     let nonRoutedReveal: DepositRevealInfoStruct

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -1368,12 +1368,10 @@ describe("Bridge - Deposit", () => {
                         lowerReceiver,
                         32
                       )
-                      // Flip the high byte (byte 0) to make it non-canonical.
-                      const highByte =
-                        parseInt(canonicalPad.slice(2, 4), 16) ^ 0x01
-                      extraData = `0x${highByte
-                        .toString(16)
-                        .padStart(2, "0")}${canonicalPad.slice(4)}`
+                      // Byte 0 of a left-padded 20-byte address is always
+                      // zero; set it to a nonzero value to make the padding
+                      // non-canonical.
+                      extraData = `0x01${canonicalPad.slice(4)}`
                     }
 
                     // Build the deposit script exactly as Deposit.sol does.

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -4533,6 +4533,45 @@ describe("Bridge - Governance", () => {
     })
   })
 
+  describe("setSponsoredDepositor", () => {
+    context("when the caller is not the owner", () => {
+      it("should revert", async () => {
+        await expect(
+          bridgeGovernance
+            .connect(thirdParty)
+            .setSponsoredDepositor(thirdParty.address, true)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+    })
+
+    context("when the caller is the owner", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await bridgeGovernance
+          .connect(governance)
+          .setSponsoredDepositor(thirdParty.address, true)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should mark the depositor as sponsored", async () => {
+        await expect(await bridge.isSponsoredDepositor(thirdParty.address)).to
+          .be.true
+      })
+
+      it("should emit SponsoredDepositorSet event", async () => {
+        await expect(tx)
+          .to.emit(bridge, "SponsoredDepositorSet")
+          .withArgs(thirdParty.address, true)
+      })
+    })
+  })
+
   describe("rebate staking governance workflow", () => {
     let newBridgeGovernance: BridgeGovernance
 

--- a/solidity/test/bridge/Bridge.Parameters.test.ts
+++ b/solidity/test/bridge/Bridge.Parameters.test.ts
@@ -2003,4 +2003,87 @@ describe("Bridge - Parameters", () => {
       })
     })
   })
+
+  describe("setSponsoredDepositor", () => {
+    const sponsoredDepositor = "0x1111111111111111111111111111111111111111"
+
+    context("when caller is not the contract guvnor", () => {
+      it("should revert", async () => {
+        await expect(
+          bridge
+            .connect(thirdParty)
+            .setSponsoredDepositor(sponsoredDepositor, true)
+        ).to.be.revertedWith("Caller is not the governance")
+      })
+    })
+
+    context("when caller is the contract guvnor", () => {
+      before(async () => {
+        await createSnapshot()
+
+        // Mirror the pattern used by `setRebateStaking`: transfer Bridge
+        // governance to a simple EOA so we can call the Bridge entrypoint
+        // directly in the rest of the suite.
+        await bridgeGovernance
+          .connect(governance)
+          .beginBridgeGovernanceTransfer(governance.address)
+        await helpers.time.increaseTime(constants.governanceDelay)
+        await bridgeGovernance
+          .connect(governance)
+          .finalizeBridgeGovernanceTransfer()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      context("when the depositor address is zero", () => {
+        it("should revert", async () => {
+          await expect(
+            bridge.connect(governance).setSponsoredDepositor(ZERO_ADDRESS, true)
+          ).to.be.revertedWith("Depositor address must not be 0x0")
+        })
+      })
+
+      context("when the depositor address is non-zero", () => {
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          tx = await bridge
+            .connect(governance)
+            .setSponsoredDepositor(sponsoredDepositor, true)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should add the depositor to the allowlist", async () => {
+          expect(await bridge.isSponsoredDepositor(sponsoredDepositor)).to.be
+            .true
+        })
+
+        it("should emit SponsoredDepositorSet event", async () => {
+          await expect(tx)
+            .to.emit(bridge, "SponsoredDepositorSet")
+            .withArgs(sponsoredDepositor, true)
+        })
+
+        it("should allow toggling the allowlist off again", async () => {
+          await expect(
+            bridge
+              .connect(governance)
+              .setSponsoredDepositor(sponsoredDepositor, false)
+          )
+            .to.emit(bridge, "SponsoredDepositorSet")
+            .withArgs(sponsoredDepositor, false)
+
+          expect(await bridge.isSponsoredDepositor(sponsoredDepositor)).to.be
+            .false
+        })
+      })
+    })
+  })
 })

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -7,6 +7,7 @@ import {
 import type { StorageLayout } from "@openzeppelin/upgrades-core"
 
 import mainnetBridgeImplementation from "../../deployments/mainnet/BridgeTIP109HotfixImplementation.json"
+import mainnetRebateStakingImplementation from "../../deployments/mainnet/RebateStakingTIP109HotfixImplementation.json"
 
 // Hardhat's `CompilerOutputContract` type doesn't declare `storageLayout`
 // (it's populated by `@openzeppelin/hardhat-upgrades` extending solc's
@@ -17,88 +18,114 @@ interface CompiledContractWithStorageLayout {
 }
 
 // Regression test guarding against accidental storage-layout breaks in the
-// upgradeable `Bridge` contract.
+// upgradeable `Bridge` and `RebateStaking` contracts.
 //
-// `deployments/mainnet/BridgeTIP109HotfixImplementation.json` is the deploy
-// artifact for the Bridge implementation currently live on mainnet (see
-// `deploy/86_deploy_tip109_hotfix.ts`). It embeds the exact `storageLayout`
-// solc produced for that implementation at deploy time -- a real,
-// pre-this-PR snapshot of `Bridge`'s storage, independent of whatever is
-// currently checked out.
+// `deployments/mainnet/BridgeTIP109HotfixImplementation.json` and
+// `deployments/mainnet/RebateStakingTIP109HotfixImplementation.json` are the
+// deploy artifacts for the Bridge and RebateStaking implementations
+// currently live on mainnet (see `deploy/86_deploy_tip109_hotfix.ts`, which
+// deploys both). Each embeds the exact `storageLayout` solc produced for
+// that implementation at deploy time -- a real, pre-this-PR snapshot of the
+// contract's storage, independent of whatever is currently checked out.
 //
-// This test reads that historical layout, compiles the currently checked
-// out `contracts/bridge/Bridge.sol` (Hardhat always recompiles before
-// running tests, and `@openzeppelin/hardhat-upgrades` extends solc's
-// `outputSelection` to include `storageLayout` for every contract), and
-// diffs the two layouts with the same
-// `@openzeppelin/upgrades-core#getStorageUpgradeReport` comparator that
-// `upgrades.prepareUpgrade` uses internally. Unlike comparing a freshly
-// deployed proxy against a factory built from the same current source (which
-// can never detect a regression, since both sides always move together),
-// this compares against a fixed, real, already-deployed layout, so an
-// incompatible reordering/retyping/removal of a `Bridge` storage slot in
-// this PR (or any future one) actually fails this check -- with no live
-// network access or proxy deployment required.
+// This test reads each historical layout, compiles the currently checked
+// out `contracts/bridge/Bridge.sol` / `contracts/bridge/RebateStaking.sol`
+// (Hardhat always recompiles before running tests, and
+// `@openzeppelin/hardhat-upgrades` extends solc's `outputSelection` to
+// include `storageLayout` for every contract), and diffs the two layouts
+// with the same `@openzeppelin/upgrades-core#getStorageUpgradeReport`
+// comparator that `upgrades.prepareUpgrade` uses internally. Unlike
+// comparing a freshly deployed proxy against a factory built from the same
+// current source (which can never detect a regression, since both sides
+// always move together), this compares against a fixed, real,
+// already-deployed layout, so an incompatible reordering/retyping/removal
+// of a storage slot in this PR (or any future one) actually fails this
+// check -- with no live network access or proxy deployment required.
 //
 // Caveat: solc's `storageLayout` output does not include enum member names
 // (only their byte size), so `unsafeAllowCustomTypes` is required to avoid
 // false positives on `Bridge`'s enum fields (`Wallets.WalletState`,
-// `MovingFunds.MovedFundsSweepRequestState`). That only weakens detection of
-// enum *value reordering*; slot/offset positions, struct member order, and
-// every other field's type are still fully checked.
-describe("Bridge - Storage Layout", () => {
-  describe("compatibility with the currently deployed mainnet implementation", () => {
-    it("should not report a storage-layout incompatibility", async () => {
-      const originalLayout =
-        mainnetBridgeImplementation.storageLayout as unknown as StorageLayout
+// `MovingFunds.MovedFundsSweepRequestState`) as well as `RebateStaking`'s
+// enum fields (`RebateTreasuryFeeMode`, `TreasuryFeeType`). That only
+// weakens detection of enum *value reordering*; slot/offset positions,
+// struct member order, and every other field's type are still fully
+// checked.
+const STORAGE_LAYOUT_TARGETS = [
+  {
+    contractLabel: "Bridge",
+    fullyQualifiedName: "contracts/bridge/Bridge.sol:Bridge",
+    sourceFile: "contracts/bridge/Bridge.sol",
+    baseline:
+      mainnetBridgeImplementation.storageLayout as unknown as StorageLayout,
+    baselineArtifactPath:
+      "deployments/mainnet/BridgeTIP109HotfixImplementation.json",
+    baselineAddress: mainnetBridgeImplementation.address,
+  },
+  {
+    contractLabel: "RebateStaking",
+    fullyQualifiedName: "contracts/bridge/RebateStaking.sol:RebateStaking",
+    sourceFile: "contracts/bridge/RebateStaking.sol",
+    baseline:
+      mainnetRebateStakingImplementation.storageLayout as unknown as StorageLayout,
+    baselineArtifactPath:
+      "deployments/mainnet/RebateStakingTIP109HotfixImplementation.json",
+    baselineAddress: mainnetRebateStakingImplementation.address,
+  },
+]
 
-      assert.isAbove(
-        originalLayout.storage.length,
-        0,
-        "baseline mainnet deployment artifact " +
-          "(deployments/mainnet/BridgeTIP109HotfixImplementation.json) is " +
-          "missing its storage layout"
-      )
+STORAGE_LAYOUT_TARGETS.forEach((target) => {
+  describe(`${target.contractLabel} - Storage Layout`, () => {
+    describe("compatibility with the currently deployed mainnet implementation", () => {
+      it("should not report a storage-layout incompatibility", async () => {
+        const originalLayout = target.baseline
 
-      const buildInfo = await artifacts.getBuildInfo(
-        "contracts/bridge/Bridge.sol:Bridge"
-      )
-
-      if (buildInfo === undefined) {
-        throw new Error(
-          "no build info found for contracts/bridge/Bridge.sol:Bridge; " +
-            "run `hardhat compile` before this test"
+        assert.isAbove(
+          originalLayout.storage.length,
+          0,
+          `baseline mainnet deployment artifact ` +
+            `(${target.baselineArtifactPath}) is missing its storage layout`
         )
-      }
 
-      // `storageLayout` isn't in Hardhat's `CompilerOutputContract` type;
-      // see `CompiledContractWithStorageLayout` above.
-      const compiledBridge = buildInfo.output.contracts[
-        "contracts/bridge/Bridge.sol"
-      ].Bridge as unknown as CompiledContractWithStorageLayout
-      const updatedLayout = compiledBridge.storageLayout
+        const buildInfo = await artifacts.getBuildInfo(
+          target.fullyQualifiedName
+        )
 
-      assert.isAbove(
-        updatedLayout?.storage?.length ?? 0,
-        0,
-        "compiled contracts/bridge/Bridge.sol:Bridge is missing its storage " +
-          "layout; ensure solc `outputSelection` includes `storageLayout`"
-      )
+        if (buildInfo === undefined) {
+          throw new Error(
+            `no build info found for ${target.fullyQualifiedName}; ` +
+              "run `hardhat compile` before this test"
+          )
+        }
 
-      const report = getStorageUpgradeReport(
-        originalLayout,
-        updatedLayout,
-        withValidationDefaults({ unsafeAllowCustomTypes: true })
-      )
+        // `storageLayout` isn't in Hardhat's `CompilerOutputContract` type;
+        // see `CompiledContractWithStorageLayout` above.
+        const compiledContract = buildInfo.output.contracts[target.sourceFile][
+          target.contractLabel
+        ] as unknown as CompiledContractWithStorageLayout
+        const updatedLayout = compiledContract.storageLayout
 
-      assert.isTrue(
-        report.pass,
-        `${
-          "Bridge storage layout is incompatible with the currently deployed " +
-          `mainnet implementation at ${mainnetBridgeImplementation.address} ` +
-          "(deployments/mainnet/BridgeTIP109HotfixImplementation.json):\n\n"
-        }${report.explain(false)}`
-      )
+        assert.isAbove(
+          updatedLayout?.storage?.length ?? 0,
+          0,
+          `compiled ${target.fullyQualifiedName} is missing its storage ` +
+            "layout; ensure solc `outputSelection` includes `storageLayout`"
+        )
+
+        const report = getStorageUpgradeReport(
+          originalLayout,
+          updatedLayout,
+          withValidationDefaults({ unsafeAllowCustomTypes: true })
+        )
+
+        assert.isTrue(
+          report.pass,
+          `${
+            `${target.contractLabel} storage layout is incompatible with ` +
+            "the currently deployed mainnet implementation at " +
+            `${target.baselineAddress} (${target.baselineArtifactPath}):\n\n`
+          }${report.explain(false)}`
+        )
+      })
     })
   })
 })

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -82,7 +82,7 @@ STORAGE_LAYOUT_TARGETS.forEach((target) => {
         assert.isAbove(
           originalLayout.storage.length,
           0,
-          `baseline mainnet deployment artifact ` +
+          "baseline mainnet deployment artifact " +
             `(${target.baselineArtifactPath}) is missing its storage layout`
         )
 

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -1,0 +1,104 @@
+import { artifacts } from "hardhat"
+import { assert } from "chai"
+import {
+  getStorageUpgradeReport,
+  withValidationDefaults,
+} from "@openzeppelin/upgrades-core"
+import type { StorageLayout } from "@openzeppelin/upgrades-core"
+
+import mainnetBridgeImplementation from "../../deployments/mainnet/BridgeTIP109HotfixImplementation.json"
+
+// Hardhat's `CompilerOutputContract` type doesn't declare `storageLayout`
+// (it's populated by `@openzeppelin/hardhat-upgrades` extending solc's
+// `outputSelection`, not part of Hardhat core), so re-declare the field we
+// actually read off the raw build info.
+interface CompiledContractWithStorageLayout {
+  storageLayout: StorageLayout
+}
+
+// Regression test guarding against accidental storage-layout breaks in the
+// upgradeable `Bridge` contract.
+//
+// `deployments/mainnet/BridgeTIP109HotfixImplementation.json` is the deploy
+// artifact for the Bridge implementation currently live on mainnet (see
+// `deploy/86_deploy_tip109_hotfix.ts`). It embeds the exact `storageLayout`
+// solc produced for that implementation at deploy time -- a real,
+// pre-this-PR snapshot of `Bridge`'s storage, independent of whatever is
+// currently checked out.
+//
+// This test reads that historical layout, compiles the currently checked
+// out `contracts/bridge/Bridge.sol` (Hardhat always recompiles before
+// running tests, and `@openzeppelin/hardhat-upgrades` extends solc's
+// `outputSelection` to include `storageLayout` for every contract), and
+// diffs the two layouts with the same
+// `@openzeppelin/upgrades-core#getStorageUpgradeReport` comparator that
+// `upgrades.prepareUpgrade` uses internally. Unlike comparing a freshly
+// deployed proxy against a factory built from the same current source (which
+// can never detect a regression, since both sides always move together),
+// this compares against a fixed, real, already-deployed layout, so an
+// incompatible reordering/retyping/removal of a `Bridge` storage slot in
+// this PR (or any future one) actually fails this check -- with no live
+// network access or proxy deployment required.
+//
+// Caveat: solc's `storageLayout` output does not include enum member names
+// (only their byte size), so `unsafeAllowCustomTypes` is required to avoid
+// false positives on `Bridge`'s enum fields (`Wallets.WalletState`,
+// `MovingFunds.MovedFundsSweepRequestState`). That only weakens detection of
+// enum *value reordering*; slot/offset positions, struct member order, and
+// every other field's type are still fully checked.
+describe("Bridge - Storage Layout", () => {
+  describe("compatibility with the currently deployed mainnet implementation", () => {
+    it("should not report a storage-layout incompatibility", async () => {
+      const originalLayout =
+        mainnetBridgeImplementation.storageLayout as unknown as StorageLayout
+
+      assert.isAbove(
+        originalLayout.storage.length,
+        0,
+        "baseline mainnet deployment artifact " +
+          "(deployments/mainnet/BridgeTIP109HotfixImplementation.json) is " +
+          "missing its storage layout"
+      )
+
+      const buildInfo = await artifacts.getBuildInfo(
+        "contracts/bridge/Bridge.sol:Bridge"
+      )
+
+      if (buildInfo === undefined) {
+        throw new Error(
+          "no build info found for contracts/bridge/Bridge.sol:Bridge; " +
+            "run `hardhat compile` before this test"
+        )
+      }
+
+      // `storageLayout` isn't in Hardhat's `CompilerOutputContract` type;
+      // see `CompiledContractWithStorageLayout` above.
+      const compiledBridge = buildInfo.output.contracts[
+        "contracts/bridge/Bridge.sol"
+      ].Bridge as unknown as CompiledContractWithStorageLayout
+      const updatedLayout = compiledBridge.storageLayout
+
+      assert.isAbove(
+        updatedLayout?.storage?.length ?? 0,
+        0,
+        "compiled contracts/bridge/Bridge.sol:Bridge is missing its storage " +
+          "layout; ensure solc `outputSelection` includes `storageLayout`"
+      )
+
+      const report = getStorageUpgradeReport(
+        originalLayout,
+        updatedLayout,
+        withValidationDefaults({ unsafeAllowCustomTypes: true })
+      )
+
+      assert.isTrue(
+        report.pass,
+        `${
+          "Bridge storage layout is incompatible with the currently deployed " +
+          `mainnet implementation at ${mainnetBridgeImplementation.address} ` +
+          "(deployments/mainnet/BridgeTIP109HotfixImplementation.json):\n\n"
+        }${report.explain(false)}`
+      )
+    })
+  })
+})

--- a/solidity/test/bridge/RebateStaking.test.ts
+++ b/solidity/test/bridge/RebateStaking.test.ts
@@ -489,32 +489,43 @@ describe("RebateStaking", () => {
     })
   })
 
-  describe("setSponsorAuthorization", () => {
+  describe("setSponsorConsent", () => {
+    const stakeAmount = defaultStakeAmount
+    let tx: ContractTransaction
+
     before(async () => {
       await createSnapshot()
+
+      await t.connect(deployer).mint(thirdParty.address, stakeAmount)
+      await t.connect(thirdParty).approve(rebateStaking.address, stakeAmount)
+      await rebateStaking.connect(thirdParty).stake(stakeAmount)
     })
 
     after(async () => {
       await restoreSnapshot()
     })
 
-    it("should not revert when called by an address that is not a staker", async () => {
+    it("should revert when called by a non-staker", async () => {
       await expect(
         rebateStaking
-          .connect(thirdParty)
-          .setSponsorAuthorization(deployer.address, true)
-      ).to.not.be.reverted
+          .connect(governance)
+          .setSponsorConsent(deployer.address, true)
+      ).to.be.revertedWith("NotAStaker")
+    })
+
+    it("should revert when depositor is zero", async () => {
+      await expect(
+        rebateStaking.connect(thirdParty).setSponsorConsent(ZERO_ADDRESS, true)
+      ).to.be.revertedWith("ZeroAddress")
     })
 
     context("when a staker authorizes a sponsored depositor", () => {
-      let tx: ContractTransaction
-
       before(async () => {
         await createSnapshot()
 
         tx = await rebateStaking
           .connect(thirdParty)
-          .setSponsorAuthorization(deployer.address, true)
+          .setSponsorConsent(deployer.address, true)
       })
 
       after(async () => {
@@ -523,7 +534,7 @@ describe("RebateStaking", () => {
 
       it("should authorize the depositor for that staker", async () => {
         expect(
-          await rebateStaking.isAuthorizedSponsor(
+          await rebateStaking.isSponsorConsentGranted(
             thirdParty.address,
             deployer.address
           )
@@ -532,16 +543,16 @@ describe("RebateStaking", () => {
 
       it("should not authorize a different depositor for that staker", async () => {
         expect(
-          await rebateStaking.isAuthorizedSponsor(
+          await rebateStaking.isSponsorConsentGranted(
             thirdParty.address,
             governance.address
           )
         ).to.equal(false)
       })
 
-      it("should emit SponsorAuthorizationSet event", async () => {
+      it("should emit SponsorConsentSet event", async () => {
         await expect(tx)
-          .to.emit(rebateStaking, "SponsorAuthorizationSet")
+          .to.emit(rebateStaking, "SponsorConsentSet")
           .withArgs(thirdParty.address, deployer.address, true)
       })
 
@@ -553,7 +564,7 @@ describe("RebateStaking", () => {
 
           revokeTx = await rebateStaking
             .connect(thirdParty)
-            .setSponsorAuthorization(deployer.address, false)
+            .setSponsorConsent(deployer.address, false)
         })
 
         after(async () => {
@@ -562,16 +573,16 @@ describe("RebateStaking", () => {
 
         it("should revoke the depositor's authorization for that staker", async () => {
           expect(
-            await rebateStaking.isAuthorizedSponsor(
+            await rebateStaking.isSponsorConsentGranted(
               thirdParty.address,
               deployer.address
             )
           ).to.equal(false)
         })
 
-        it("should emit SponsorAuthorizationSet event", async () => {
+        it("should emit SponsorConsentSet event", async () => {
           await expect(revokeTx)
-            .to.emit(rebateStaking, "SponsorAuthorizationSet")
+            .to.emit(rebateStaking, "SponsorConsentSet")
             .withArgs(thirdParty.address, deployer.address, false)
         })
       })

--- a/solidity/test/bridge/RebateStaking.test.ts
+++ b/solidity/test/bridge/RebateStaking.test.ts
@@ -489,6 +489,95 @@ describe("RebateStaking", () => {
     })
   })
 
+  describe("setSponsorAuthorization", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should not revert when called by an address that is not a staker", async () => {
+      await expect(
+        rebateStaking
+          .connect(thirdParty)
+          .setSponsorAuthorization(deployer.address, true)
+      ).to.not.be.reverted
+    })
+
+    context("when a staker authorizes a sponsored depositor", () => {
+      let tx: ContractTransaction
+
+      before(async () => {
+        await createSnapshot()
+
+        tx = await rebateStaking
+          .connect(thirdParty)
+          .setSponsorAuthorization(deployer.address, true)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should authorize the depositor for that staker", async () => {
+        expect(
+          await rebateStaking.isAuthorizedSponsor(
+            thirdParty.address,
+            deployer.address
+          )
+        ).to.equal(true)
+      })
+
+      it("should not authorize a different depositor for that staker", async () => {
+        expect(
+          await rebateStaking.isAuthorizedSponsor(
+            thirdParty.address,
+            governance.address
+          )
+        ).to.equal(false)
+      })
+
+      it("should emit SponsorAuthorizationSet event", async () => {
+        await expect(tx)
+          .to.emit(rebateStaking, "SponsorAuthorizationSet")
+          .withArgs(thirdParty.address, deployer.address, true)
+      })
+
+      context("when the staker revokes the authorization", () => {
+        let revokeTx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          revokeTx = await rebateStaking
+            .connect(thirdParty)
+            .setSponsorAuthorization(deployer.address, false)
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should revoke the depositor's authorization for that staker", async () => {
+          expect(
+            await rebateStaking.isAuthorizedSponsor(
+              thirdParty.address,
+              deployer.address
+            )
+          ).to.equal(false)
+        })
+
+        it("should emit SponsorAuthorizationSet event", async () => {
+          await expect(revokeTx)
+            .to.emit(rebateStaking, "SponsorAuthorizationSet")
+            .withArgs(thirdParty.address, deployer.address, false)
+        })
+      })
+    })
+  })
+
   describe("applyForRebate", () => {
     const treasuryFee = ethers.BigNumber.from(950)
 


### PR DESCRIPTION
## Summary

Closes the gap where a T staker who mints through a relayer-style depositor (e.g. `NativeBTCDepositor`) loses their fee waiver because the Bridge sees the depositor contract as `msg.sender` and routes the `RebateStaking` lookup against that contract's (empty) stake instead of the L1 receiver's.

- Adds a governance-managed `sponsoredDepositors` allowlist to `BridgeState`.
- In `Deposit._revealDeposit`, when the caller is allowlisted, `extraData != bytes32(0)`, the decoded address is non-zero and canonically left-padded (high 12 bytes zero), **and** that address has separately consented via `RebateStaking.setSponsorConsent`, the rebate is keyed off the address decoded from `extraData` rather than `msg.sender`. Any missing precondition falls back to charging the depositor's own (possibly empty) stake, never reverts.
- `deposit.depositor` is unchanged — refund and finalize accounting are untouched; delegation via `RebateStaking.getStaker` keeps working.
- New `Bridge.setSponsoredDepositor(address, bool)` (onlyGovernance) + `isSponsoredDepositor(address)` view; matching `BridgeGovernance.setSponsoredDepositor(...)` forwarder.
- New event `SponsoredDepositorSet(address indexed depositor, bool sponsored)`.
- New `RebateStaking.setSponsorConsent(address depositor, bool authorized)` (caller must be a staker) + `RebateStaking.isSponsorConsentGranted(address staker, address depositor)` view (delegation-aware — resolves through `getStaker` so it mirrors what `applyForRebate` actually charges); new event `SponsorConsentSet(address indexed staker, address indexed depositor, bool authorized)`.
- Storage: `BridgeState.__gap` reduced 48 → 47 (new `sponsoredDepositors` mapping). `RebateStaking.__gap` reduced 49 → 47 (two new mappings: `rebateAuthorizations` from a prior PR plus this PR's `stakerSponsorConsent`). Both layouts verified against the deployed mainnet baselines by a new parameterized `Bridge.StorageLayout.test.ts` covering both contracts.

## Why

`depositTreasuryFeeDivisor = 500` on mainnet today (20 bps), so this is the fee a user with T staked would expect their rebate to reduce on every deposit. Without this routing, gasless minting through `NativeBTCDepositor` (live on mainnet at [`0xad7c6d46f4a4bc2d3a227067d03218d6d7c9aaa5`](https://etherscan.io/address/0xad7c6d46f4a4bc2d3a227067d03218d6d7c9aaa5)) always pays the full 20 bps because the depositor contract has no stake. After this change, the user's existing `RebateStaking` budget is honored exactly as it would be on a direct L1 reveal.

## Trust model

Activation requires **two independent steps**, both load-bearing:

1. **Governance allowlist** (`Bridge.setSponsoredDepositor` / `BridgeGovernance.setSponsoredDepositor`): governance opts a depositor contract into having its reveals' `extraData` interpreted as an L1 rebate staker address at all.
2. **Per-staker consent** (`RebateStaking.setSponsorConsent`): the L1 staker whose stake would be charged must separately authorize that specific depositor. This is not optional hardening — without it, anyone could grief a staker's rolling-window rebate cap by embedding that staker's address in a relayed deposit's `extraData` with no action or consent from the victim.

Both gates must be satisfied (plus a canonical `extraData` encoding, see below) or the rebate falls back to charging the depositor's own (possibly empty) stake — the reveal never reverts on a missing precondition. Rollout note: after the governance allowlist call below, **no existing `NativeBTCDepositor` user's rebate routes to their own stake until that user separately submits their own `setSponsorConsent` transaction** — this is a step the depositor flow, the SDK, and this PR do not automate on a staker's behalf; communicate it to affected users as part of rollout.

## Allowlist scope

The allowlist is intentionally narrow. Membership means *"`extraData` on reveals from this contract is the L1 address whose stake should be charged, once that address also grants sponsor consent."* Only `NativeBTCDepositor` satisfies that today. The allowlist ships **empty**; after merge, a single governance call adds the mainnet proxy:

```
bridgeGovernance.setSponsoredDepositor(
    0xad7c6d46f4a4bc2d3a227067d03218d6d7c9aaa5, // NativeBTCDepositor
    true
)
```

Explicitly out of scope: cross-chain depositors (Sui, StarkNet, Arbitrum/Base via Wormhole). Their `extraData` is an L2/non-EVM identifier, not an L1 staker. Cross-chain rebates are handled by #952 with its proper EIP-712/EIP-1271 authorization model.

`extraData` must be canonically left-padded (high 12 bytes zero) to route — this matches `NativeBTCDepositor`'s own `CrosschainUtils.addressToBytes32` convention and is enforced defensively for any future depositor with a different encoding; a non-canonical payload falls back to the depositor's own stake rather than reverting. A TypeScript SDK wrapper for `RebateStaking.setSponsorConsent` is out of scope for this PR — the SDK does not currently wrap any `RebateStaking` function, and adding one is a separate, standalone piece of work.

## Test plan

- [x] `npx hardhat test test/bridge/Bridge.Deposit.test.ts test/bridge/Bridge.StorageLayout.test.ts test/bridge/Bridge.Governance.test.ts test/bridge/RebateStaking.test.ts` — **570 passing**, 0 failing
- [x] Tests verify:
  - `setSponsoredDepositor` access control + event + toggle on/off
  - `setSponsorConsent` reverts for non-stakers and the zero address; sets/revokes the per-pair consent; emits `SponsorConsentSet`
  - Rebate consumes from receiver (not depositor) when the depositor is allowlisted **and** the receiver has granted consent, using a dedicated fixture with canonically-padded `extraData`
  - Rebate falls back to charging the depositor's own stake (unchanged behavior) when the depositor is not allowlisted, consent is missing, or `extraData` is non-canonically padded
  - `deposit.depositor` and `deposit.extraData` are recorded unchanged
  - Storage layout of both `Bridge` and `RebateStaking` matches their deployed mainnet baselines (parameterized regression test; independently confirmed to fail on a reverted `__gap`/mapping-order mutation)
- [x] `npx hardhat compile` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx prettier --check` clean on all changed files
- [x] `solhint` — no new warnings (4 pre-existing warnings on `Bridge.sol`/`Deposit.sol`, confirmed identical on `origin/dev`)
- [x] Deploy script (`87_upgrade_bridge_sponsored_depositor.ts`) redeploys the `Deposit` library fresh (previously read the stale existing deployment record, which would have shipped this PR's entire behavioral change inert on mainnet) with a fail-loud guard against an unchanged address

🤖 Generated with [Claude Code](https://claude.com/claude-code)
