### PR TITLE
Deprecate BoB CCIP support

### DIFF
--- a/.github/workflows/cross-chain-bob.yml
+++ b/.github/workflows/cross-chain-bob.yml
@@ -1,5 +1,13 @@
 name: Cross-chain BOB
 
+# BOB CCIP support is deprecated (see cross-chain/bob/README.md); all deploy
+# scripts under cross-chain/bob/deploy_l1 and deploy_l2 are permanently
+# skipped. This workflow is kept running (including the daily cron) as a
+# deliberate choice: contracts-build-and-test and contracts-deployment-dry-run
+# still exercise the frozen contracts and their skip guards, and
+# contracts-slither keeps static analysis current on code that still holds
+# live user funds on-chain. Revisit only once BOB liquidity is fully drained
+# and the CCIP chain config has been removed on-chain.
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/cross-chain-bob.yml
+++ b/.github/workflows/cross-chain-bob.yml
@@ -1,13 +1,17 @@
 name: Cross-chain BOB
 
-# BOB CCIP support is deprecated (see cross-chain/bob/README.md); all deploy
-# scripts under cross-chain/bob/deploy_l1 and deploy_l2 are permanently
-# skipped. This workflow is kept running (including the daily cron) as a
-# deliberate choice: contracts-build-and-test and contracts-deployment-dry-run
-# still exercise the frozen contracts and their skip guards, and
-# contracts-slither keeps static analysis current on code that still holds
-# live user funds on-chain. Revisit only once BOB liquidity is fully drained
-# and the CCIP chain config has been removed on-chain.
+# BOB CCIP support is deprecated (see cross-chain/bob/README.md); the six
+# CCIP pool deploy/configuration scripts (deploy_l1/00-02 and deploy_l2/03-05)
+# are permanently skipped -- test/DeprecatedBobCcipDeployScripts.test.ts is
+# what proves all six skip unconditionally. This workflow is kept running as
+# a deliberate choice: contracts-build-and-test and the deploy_l2 portion of
+# contracts-deployment-dry-run still exercise the frozen contracts on every
+# trigger, and contracts-slither/contracts-format keep static analysis
+# current on code that still holds live user funds on-chain -- but only on
+# push/pull_request, not on the daily cron (both gate on
+# github.event_name == 'push' || path-filter == 'true', which schedule never
+# satisfies). Revisit only once BOB liquidity is fully drained and the CCIP
+# chain config has been removed on-chain.
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/cross-chain/bob/README.md
+++ b/cross-chain/bob/README.md
@@ -8,22 +8,44 @@ Existing BOB liquidity should remain withdraw-only:
 
 - keep the BOB tBTC token unpaused while exits are still possible;
 - keep the BOB native OP Stack bridge path available until
-  `legacyCapRemaining` reaches zero;
-- disable new BOB CCIP bridge-in routes in the frontend and any routing layer;
-- do not remove the BOB CCIP chain config while BOB-to-Ethereum exits or
-  in-flight CCIP messages remain;
+  `legacyCapRemaining` reaches zero. `legacyCapRemaining` is not
+  monotonically decreasing: every native-bridge deposit increases it, so it
+  is only guaranteed to trend toward zero if native bridge-in deposits are
+  also suppressed, not just CCIP bridge-in (see below);
+- disable new BOB CCIP bridge-in routes, and new native OP Stack bridge-in
+  deposits, in the frontend and any routing layer -- either path can grow
+  the BOB-side balance that still needs to be drained;
+- do not remove the BOB CCIP chain config while `legacyCapRemaining` is still
+  above zero: while it is nonzero, only the native bridge can exit BOB to
+  Ethereum (CCIP `burnFrom`-based exits revert for any non-bridge caller);
+  once it reaches zero, the native bridge's own burn path reverts instead
+  and CCIP becomes the only working exit -- the two exit paths are never
+  both available at once, so treat "cap reached zero" as the point CCIP
+  becomes required, not a signal that it is safe to remove;
 - after BOB balances and in-flight messages are fully drained, governance can
   remove the BOB CCIP chain config on both pools and withdraw remaining
-  Ethereum pool liquidity through the configured rebalancer.
+  Ethereum pool liquidity through the configured rebalancer. Before that
+  step, confirm two preconditions this package's scripts do not establish:
+  pool `owner()` on both pools has been transferred from the deployer to the
+  governance council multisig (no script here performs that transfer --
+  verify on-chain and complete it out of band if still outstanding), and
+  `setRebalancer(<address>)` has been called on the L1
+  `LockReleaseTokenPoolUpgradeable` pool (`withdrawLiquidity` reverts for any
+  caller other than the configured rebalancer, which defaults unset).
 
-The CCIP token pool contracts do not expose a safe one-way switch that blocks
-Ethereum-to-BOB deposits while preserving BOB-to-Ethereum exits. Removing BOB
-from the Ethereum pool also causes inbound BOB-to-Ethereum messages to fail
-validation, so chain removal is a final cleanup step only.
+The CCIP token pool contracts do not expose a way to hard-block
+Ethereum-to-BOB deposits while leaving BOB-to-Ethereum exits fully unlimited,
+but a real throttle is available and unused by this PR: governance can call
+`setChainRateLimiterConfig` with a small enabled outbound (deposit) bucket
+(e.g. `capacity: 2, rate: 1`, in wei) to revert every economically
+meaningful deposit at send time on Ethereum, while leaving the inbound
+(exit) bucket, and therefore exits, completely untouched -- outbound and
+inbound are independent buckets on independent code paths. Removing BOB
+from the Ethereum pool's chain config also causes inbound BOB-to-Ethereum
+messages to fail validation, so chain removal remains a final cleanup step
+only, not a substitute for the throttle above.
 
-The native OP Stack bridge is BOB infrastructure, not a tBTC-maintained bridge
-path. It also cannot be deactivated at the token-contract level. The existing
-`legacyCapRemaining` mechanism naturally drains as users exit via the native
-bridge. See
-[`docs/tbtc-bob-upgrade-technical-document.md`](docs/tbtc-bob-upgrade-technical-document.md)
-for details.
+The native OP Stack bridge is BOB infrastructure, not a tBTC-maintained
+bridge path. It also cannot be deactivated at the token-contract level. See
+[`docs/tbtc-bob-upgrade-technical-document.md`](docs/tbtc-bob-upgrade-technical-document.md#deprecation-addendum-bob-ccip)
+for the legacy-cap mechanics and the BOB CCIP deprecation addendum.

--- a/cross-chain/bob/README.md
+++ b/cross-chain/bob/README.md
@@ -21,17 +21,30 @@ Existing BOB liquidity should remain withdraw-only:
   once it reaches zero, the native bridge's own burn path reverts instead
   and CCIP becomes the only working exit -- the two exit paths are never
   both available at once, so treat "cap reached zero" as the point CCIP
-  becomes required, not a signal that it is safe to remove;
+  becomes required, not a signal that it is safe to remove.
+  **Verified on-chain (2026-09-01): `legacyCapRemaining` is already 0** on
+  the live `OptimismMintableUpgradableTBTC` contract on BOB, so CCIP is
+  already the only working exit today, not a future state -- do not disable
+  or rate-limit-to-zero the CCIP outbound (exit) path while this holds;
 - after BOB balances and in-flight messages are fully drained, governance can
   remove the BOB CCIP chain config on both pools and withdraw remaining
   Ethereum pool liquidity through the configured rebalancer. Before that
   step, confirm two preconditions this package's scripts do not establish:
   pool `owner()` on both pools has been transferred from the deployer to the
-  governance council multisig (no script here performs that transfer --
-  verify on-chain and complete it out of band if still outstanding), and
-  `setRebalancer(<address>)` has been called on the L1
-  `LockReleaseTokenPoolUpgradeable` pool (`withdrawLiquidity` reverts for any
-  caller other than the configured rebalancer, which defaults unset).
+  governance council multisig, and `setRebalancer(<address>)` has been
+  called on the L1 `LockReleaseTokenPoolUpgradeable` pool (`withdrawLiquidity`
+  reverts for any caller other than the configured rebalancer, which
+  defaults unset).
+  **Verified on-chain (2026-09-01):** the owner-transfer precondition is
+  already satisfied on both sides -- the L1 pool
+  (`0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6`) is owned by a 6-of-9 Safe
+  (`0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f`) and the BOB pool
+  (`0x36ee23c94523A05981bAAeeAeA4bA97CDde21F6A`) is owned by a separate
+  6-of-9 Safe (`0x694DeC29F197c76eb13d4Cc549cE38A1e06Cd24C`). The rebalancer
+  precondition is **not** satisfied: `getRebalancer()` on the L1 pool
+  currently returns the zero address, so `withdrawLiquidity`/
+  `transferLiquidity` cannot be called by anyone until the L1 multisig
+  calls `setRebalancer`.
 
 The CCIP token pool contracts do not expose a way to hard-block
 Ethereum-to-BOB deposits while leaving BOB-to-Ethereum exits fully unlimited,

--- a/cross-chain/bob/README.md
+++ b/cross-chain/bob/README.md
@@ -1,0 +1,29 @@
+# Threshold cross-chain - BOB
+
+BOB CCIP support is deprecated. This package is kept for historical deployment
+context and exit operations only. Do not use the deployment scripts to deploy
+new BOB CCIP token-pool infrastructure.
+
+Existing BOB liquidity should remain withdraw-only:
+
+- keep the BOB tBTC token unpaused while exits are still possible;
+- keep the BOB native OP Stack bridge path available until
+  `legacyCapRemaining` reaches zero;
+- disable new BOB CCIP bridge-in routes in the frontend and any routing layer;
+- do not remove the BOB CCIP chain config while BOB-to-Ethereum exits or
+  in-flight CCIP messages remain;
+- after BOB balances and in-flight messages are fully drained, governance can
+  remove the BOB CCIP chain config on both pools and withdraw remaining
+  Ethereum pool liquidity through the configured rebalancer.
+
+The CCIP token pool contracts do not expose a safe one-way switch that blocks
+Ethereum-to-BOB deposits while preserving BOB-to-Ethereum exits. Removing BOB
+from the Ethereum pool also causes inbound BOB-to-Ethereum messages to fail
+validation, so chain removal is a final cleanup step only.
+
+The native OP Stack bridge is BOB infrastructure, not a tBTC-maintained bridge
+path. It also cannot be deactivated at the token-contract level. The existing
+`legacyCapRemaining` mechanism naturally drains as users exit via the native
+bridge. See
+[`docs/tbtc-bob-upgrade-technical-document.md`](docs/tbtc-bob-upgrade-technical-document.md)
+for details.

--- a/cross-chain/bob/README.md
+++ b/cross-chain/bob/README.md
@@ -25,7 +25,8 @@ Existing BOB liquidity should remain withdraw-only:
   **Verified on-chain (2026-09-01): `legacyCapRemaining` is already 0** on
   the live `OptimismMintableUpgradableTBTC` contract on BOB, so CCIP is
   already the only working exit today, not a future state -- do not disable
-  or rate-limit-to-zero the CCIP outbound (exit) path while this holds;
+  or rate-limit-to-zero the BOB pool's CCIP outbound (BOB-to-Ethereum exit) 
+  bucket while this holds;
 - after BOB balances and in-flight messages are fully drained, governance can
   remove the BOB CCIP chain config on both pools and withdraw remaining
   Ethereum pool liquidity through the configured rebalancer. Before that
@@ -42,23 +43,29 @@ Existing BOB liquidity should remain withdraw-only:
   (`0x36ee23c94523A05981bAAeeAeA4bA97CDde21F6A`) is owned by a separate
   6-of-9 Safe (`0x694DeC29F197c76eb13d4Cc549cE38A1e06Cd24C`). The rebalancer
   precondition is **not** satisfied: `getRebalancer()` on the L1 pool
-  currently returns the zero address, so `withdrawLiquidity`/
-  `transferLiquidity` cannot be called by anyone until the L1 multisig
-  calls `setRebalancer`.
-
+  currently returns the zero address, so `withdrawLiquidity` (onlyRebalancer)
+  is blocked until `setRebalancer` is called, while `transferLiquidity` is
+  onlyOwner (callable today by the 6-of-9 Safe) but pulls liquidity from an
+  older pool into this one -- it is not a withdrawal path for this pool's own
+  locked tBTC.
 The CCIP token pool contracts do not expose a way to hard-block
 Ethereum-to-BOB deposits while leaving BOB-to-Ethereum exits fully unlimited,
 but a real throttle is available and unused by this PR: governance can call
-`setChainRateLimiterConfig` with a small enabled outbound (deposit) bucket
+`setChainRateLimiterConfig` with a small enabled outbound (Ethereum-to-BOB deposit) bucket
 (e.g. `capacity: 2, rate: 1`, in wei) to revert every economically
-meaningful deposit at send time on Ethereum, while leaving the inbound
-(exit) bucket, and therefore exits, completely untouched -- outbound and
-inbound are independent buckets on independent code paths. Removing BOB
-from the Ethereum pool's chain config also causes inbound BOB-to-Ethereum
-messages to fail validation, so chain removal remains a final cleanup step
-only, not a substitute for the throttle above.
-
+meaningful deposit at send time on Ethereum. However, this call rewrites
+both the outbound and inbound buckets in one transaction, so the current
+inbound (BOB-to-Ethereum exit) configuration must be read first via
+`getCurrentInboundRateLimiterState` and passed back unchanged alongside
+the new outbound config, rather than leaving the inbound bucket untouched.
+Removing BOB from the Ethereum pool's chain config also causes inbound
+BOB-to-Ethereum messages to fail validation, so chain removal remains a
+final cleanup step only, not a substitute for the throttle above.
 The native OP Stack bridge is BOB infrastructure, not a tBTC-maintained
-bridge path. It also cannot be deactivated at the token-contract level. See
+bridge path. Governance can stop native bridge-in via `removeMinter(BRIDGE)`
+(`onlyOwner`) without removing the burn/exit permission, but OP Stack
+deposits are force-included on L2, so doing so risks stranding an
+already-escrowed L1 deposit -- it cannot be done safely without more care.
+See
 [`docs/tbtc-bob-upgrade-technical-document.md`](docs/tbtc-bob-upgrade-technical-document.md#deprecation-addendum-bob-ccip)
 for the legacy-cap mechanics and the BOB CCIP deprecation addendum.

--- a/cross-chain/bob/deploy_l1/00_deploy_lock_release_token_pool.ts
+++ b/cross-chain/bob/deploy_l1/00_deploy_lock_release_token_pool.ts
@@ -144,4 +144,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 export default func
 
-func.tags = ["LockReleaseTokenPoolUpgradeable"] 
+func.tags = ["LockReleaseTokenPoolUpgradeable"]
+// BOB CCIP support is deprecated. Keep this script for historical reference
+// without deploying new BOB CCIP token-pool infrastructure.
+func.skip = async () => true

--- a/cross-chain/bob/deploy_l1/01_transfer_token_pool_proxy_admin.ts
+++ b/cross-chain/bob/deploy_l1/01_transfer_token_pool_proxy_admin.ts
@@ -17,13 +17,15 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const tokenPoolProxy = await get("LockReleaseTokenPoolUpgradeable_Proxy")
 
     console.log("Proxy Contract:")
-    console.log(`  LockReleaseTokenPoolUpgradeable Proxy: ${tokenPoolProxy.address}`)
+    console.log(
+      `  LockReleaseTokenPoolUpgradeable Proxy: ${tokenPoolProxy.address}`
+    )
     console.log("")
 
     // For TransparentUpgradeableProxy, we need to call the admin functions directly
     const proxyAdminABI = [
       "function admin() external view returns (address)",
-      "function changeAdmin(address newAdmin) external"
+      "function changeAdmin(address newAdmin) external",
     ]
 
     // Create contract instance for the proxy
@@ -34,13 +36,17 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     )
 
     // Transfer admin for Token Pool Proxy
-    console.log("Transferring admin for LockReleaseTokenPoolUpgradeable Proxy...")
+    console.log(
+      "Transferring admin for LockReleaseTokenPoolUpgradeable Proxy..."
+    )
     try {
       const tx = await tokenPoolProxyContract.changeAdmin(governance)
       console.log(`  Transaction: ${tx.hash}`)
       console.log("  Waiting for confirmation...")
       const receipt = await tx.wait()
-      console.log(`  ✅ Admin transferred successfully in block ${receipt.blockNumber}!`)
+      console.log(
+        `  ✅ Admin transferred successfully in block ${receipt.blockNumber}!`
+      )
     } catch (error: any) {
       if (error.message.includes("admin cannot fallback")) {
         console.log("  ❌ Error: You are not the current admin of this proxy")
@@ -58,8 +64,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log("\nIMPORTANT: The deployer address can no longer:")
     console.log("  - Call admin functions on the proxy")
     console.log("  - Upgrade the contract")
-    console.log("\nTo configure the token pool, use a different address (not the admin)")
-
+    console.log(
+      "\nTo configure the token pool, use a different address (not the admin)"
+    )
   } catch (error) {
     console.error("\nError in admin transfer:", error)
     throw error
@@ -69,7 +76,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["TransferProxyAdmin"]
-func.dependencies = ["LockReleaseTokenPoolUpgradeable"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
 // without mutating BOB CCIP token-pool ownership.
 func.skip = async () => true

--- a/cross-chain/bob/deploy_l1/01_transfer_token_pool_proxy_admin.ts
+++ b/cross-chain/bob/deploy_l1/01_transfer_token_pool_proxy_admin.ts
@@ -70,3 +70,6 @@ export default func
 
 func.tags = ["TransferProxyAdmin"]
 func.dependencies = ["LockReleaseTokenPoolUpgradeable"]
+// BOB CCIP support is deprecated. Keep this script for historical reference
+// without mutating BOB CCIP token-pool ownership.
+func.skip = async () => true

--- a/cross-chain/bob/deploy_l1/01_transfer_token_pool_proxy_admin.ts
+++ b/cross-chain/bob/deploy_l1/01_transfer_token_pool_proxy_admin.ts
@@ -76,6 +76,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["TransferProxyAdmin"]
+func.dependencies = ["LockReleaseTokenPoolUpgradeable"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without mutating BOB CCIP token-pool ownership.
+// without mutating the BOB CCIP token-pool proxy admin (this script only ever
+// calls TransparentUpgradeableProxy.changeAdmin; the pool's own owner() is a
+// separate authority it never touches).
 func.skip = async () => true

--- a/cross-chain/bob/deploy_l1/02_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l1/02_configure_token_pool_chains.ts
@@ -21,9 +21,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await ethers.getSigner(deployer)
   )
 
-  const BOB_CHAIN_SELECTOR = "5535534526963509396"
-  const BOB_POOL = "0x32a88b83DeD5F06bc05eC60F2cF45CC0FEdC6C25"
-  const BOB_TBTC = "0xD23F06550b0A7bC98B20eb81D4c21572a97598FA"
+  // Verified against live mainnet state (LockReleaseTokenPoolUpgradeable
+  // proxy 0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6): the selector and
+  // remote pool/token below previously did not match what was actually
+  // configured on-chain. Corrected to the real values so this script
+  // remains an accurate historical record.
+  const BOB_CHAIN_SELECTOR = "3849287863852499584"
+  const BOB_POOL = "0x36ee23c94523A05981bAAeeAeA4bA97CDde21F6A"
+  const BOB_TBTC = "0xbBa2eF945D523C4e2608C9E1214C2cC64D4fc2e2"
 
   const encodedBobPool = ethers.utils.defaultAbiCoder.encode(
     ["address"],

--- a/cross-chain/bob/deploy_l1/02_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l1/02_configure_token_pool_chains.ts
@@ -137,5 +137,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 }
 
 func.tags = ["ConfigureTokenPoolChains"]
+// BOB CCIP support is deprecated. Keep this script for historical reference
+// without configuring new BOB CCIP routes.
+func.skip = async () => true
 
 export default func

--- a/cross-chain/bob/deploy_l1/02_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l1/02_configure_token_pool_chains.ts
@@ -1,12 +1,36 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
+// Ethereum-mainnet record of the BOB CCIP route, verified against live mainnet
+// state on 2026-09-01 (LockReleaseTokenPoolUpgradeable proxy
+// 0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6).
+//
+// Provenance: this script previously held the matching Sepolia-testnet record
+// -- BOB Sepolia's chain selector (5535534526963509396) with the bobSepolia
+// pool and the bobSepolia tBTC that 03_deploy_burn_from_mint_token_pool.ts
+// still lists as TBTC_ADDRESS.bobSepolia. Those values were a coherent
+// testnet configuration, not stray wrong addresses; the testnet record was
+// converted to the mainnet record here because the mainnet route is what this
+// deprecation has to document. Exported so
+// test/DeprecatedBobCcipDeployScripts.test.ts pins them.
+export const BOB_CHAIN_SELECTOR = "3849287863852499584"
+export const BOB_POOL = "0x36Ee23c94523A05981baaEEaea4BA97cDDe21f6a"
+export const BOB_TBTC = "0xBBa2eF945D523C4e2608C9E1214C2Cc64D4fc2e2"
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  // The constants above are Ethereum mainnet values, so applying them anywhere
+  // else would write a mainnet route into an unrelated deployment.
+  if (hre.network.name !== "mainnet") {
+    throw new Error(
+      `This script configures the Ethereum mainnet side of the BOB CCIP route; refusing to run on network "${hre.network.name}" (expected "mainnet")`
+    )
+  }
+
   const { ethers, getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
   console.log(
-    "=== Configuring Token Pool Chain Updates on Ethereum Sepolia ==="
+    "=== Configuring Token Pool Chain Updates on Ethereum Mainnet ==="
   )
   console.log(`Deployer: ${deployer}`)
 
@@ -20,15 +44,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     tokenPoolDeployment.address,
     await ethers.getSigner(deployer)
   )
-
-  // Verified against live mainnet state (LockReleaseTokenPoolUpgradeable
-  // proxy 0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6): the selector and
-  // remote pool/token below previously did not match what was actually
-  // configured on-chain. Corrected to the real values so this script
-  // remains an accurate historical record.
-  const BOB_CHAIN_SELECTOR = "3849287863852499584"
-  const BOB_POOL = "0x36ee23c94523A05981bAAeeAeA4bA97CDde21F6A"
-  const BOB_TBTC = "0xbBa2eF945D523C4e2608C9E1214C2cC64D4fc2e2"
 
   const encodedBobPool = ethers.utils.defaultAbiCoder.encode(
     ["address"],

--- a/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
+++ b/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
@@ -35,16 +35,29 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     tbtcAddress = TBTC_ADDRESS.bobSepolia
     router = ROUTER_ADDRESSES.bobSepolia
     rmnProxy = RMN_PROXY_ADDRESS.bobSepolia
-  } else if (hre.network.name === "hardhat" || hre.network.name === "localhost") {
+  } else if (
+    hre.network.name === "hardhat" ||
+    hre.network.name === "localhost"
+  ) {
     // Deploy a mock ERC20 for local testing
-    const ERC20Mock = await ethers.getContractFactory("ERC20Mock", await ethers.getSigner(deployer))
-    const mockToken = await ERC20Mock.deploy("Mock tBTC", "tBTC", deployer, ethers.utils.parseEther("1000000"))
+    const ERC20Mock = await ethers.getContractFactory(
+      "ERC20Mock",
+      await ethers.getSigner(deployer)
+    )
+    const mockToken = await ERC20Mock.deploy(
+      "Mock tBTC",
+      "tBTC",
+      deployer,
+      ethers.utils.parseEther("1000000")
+    )
     await mockToken.deployed()
     tbtcAddress = mockToken.address
     router = ROUTER_ADDRESSES.bobSepolia
     rmnProxy = RMN_PROXY_ADDRESS.bobSepolia
   } else {
-    throw new Error("Unsupported network for BurnFromMintTokenPoolUpgradeable deployment")
+    throw new Error(
+      "Unsupported network for BurnFromMintTokenPoolUpgradeable deployment"
+    )
   }
 
   if (!router || router === ethers.constants.AddressZero) {
@@ -62,7 +75,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   console.log(`  Token Decimals: 18`)
   console.log(`  CCIP Router: ${router}`)
   console.log(`  RMN Proxy: ${rmnProxy}`)
-  console.log(`  Allowlist: ${allowlist.length === 0 ? 'Empty (permissionless)' : allowlist.join(', ')}`)
+  console.log(
+    `  Allowlist: ${
+      allowlist.length === 0 ? "Empty (permissionless)" : allowlist.join(", ")
+    }`
+  )
 
   // Deploy using hardhat-deploy's built-in proxy support
   const deployment = await deploy("BurnFromMintTokenPoolUpgradeable", {
@@ -93,15 +110,21 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const proxyAdminDeployment = await deployments.get("DefaultProxyAdmin")
     console.log(`  ProxyAdmin Address: ${proxyAdminDeployment.address}`)
   } catch (error) {
-    console.log("  ProxyAdmin deployment not found (may be managed differently)")
+    console.log(
+      "  ProxyAdmin deployment not found (may be managed differently)"
+    )
   }
 
   // Verification for Bobscan
   if (hre.network.tags.bobscan) {
     console.log(`\nContract deployed at: ${deployment.address}`)
-    console.log("For better verification results, run the verification script with delay:")
-    console.log(`CONTRACT_ADDRESS=${deployment.address} npx hardhat run scripts/verify-with-delay.ts --network ${hre.network.name}`)
-    
+    console.log(
+      "For better verification results, run the verification script with delay:"
+    )
+    console.log(
+      `CONTRACT_ADDRESS=${deployment.address} npx hardhat run scripts/verify-with-delay.ts --network ${hre.network.name}`
+    )
+
     try {
       // Verify implementation
       if (deployment.implementation) {
@@ -116,7 +139,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         address: deployment.address,
       })
     } catch (error) {
-      console.log("Contract verification failed, but deployment was successful.")
+      console.log(
+        "Contract verification failed, but deployment was successful."
+      )
       console.log("You can manually verify the contract later on Bobscan.")
     }
   }
@@ -126,5 +151,7 @@ export default func
 
 func.tags = ["BurnFromMintTokenPoolUpgradeable"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without deploying new BOB CCIP token-pool infrastructure.
-func.skip = async () => true
+// without deploying new BOB CCIP token-pool infrastructure. Still runs on
+// hardhat/localhost so the CI dry-run continues to exercise this path.
+func.skip = async (hre) =>
+  hre.network.name !== "hardhat" && hre.network.name !== "localhost"

--- a/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
+++ b/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
@@ -124,4 +124,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 export default func
 
-func.tags = ["BurnFromMintTokenPoolUpgradeable"] 
+func.tags = ["BurnFromMintTokenPoolUpgradeable"]
+// BOB CCIP support is deprecated. Keep this script for historical reference
+// without deploying new BOB CCIP token-pool infrastructure.
+func.skip = async () => true

--- a/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
+++ b/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
@@ -151,7 +151,11 @@ export default func
 
 func.tags = ["BurnFromMintTokenPoolUpgradeable"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without deploying new BOB CCIP token-pool infrastructure. Still runs on
-// hardhat/localhost so the CI dry-run continues to exercise this path.
-func.skip = async (hre) =>
-  hre.network.name !== "hardhat" && hre.network.name !== "localhost"
+// without deploying new BOB CCIP token-pool infrastructure. Unconditional:
+// running it even on hardhat/localhost surfaces a pre-existing bug where
+// the deployer signer used by 05_configure_token_pool_chains.ts is also the
+// proxy admin, which OpenZeppelin's TransparentUpgradeableProxy blocks from
+// calling implementation functions ("admin cannot fallback to proxy
+// target"). Fixing that signer/admin conflict is out of scope for this
+// deprecation and would need its own review.
+func.skip = async () => true

--- a/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
+++ b/cross-chain/bob/deploy_l2/03_deploy_burn_from_mint_token_pool.ts
@@ -151,11 +151,5 @@ export default func
 
 func.tags = ["BurnFromMintTokenPoolUpgradeable"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without deploying new BOB CCIP token-pool infrastructure. Unconditional:
-// running it even on hardhat/localhost surfaces a pre-existing bug where
-// the deployer signer used by 05_configure_token_pool_chains.ts is also the
-// proxy admin, which OpenZeppelin's TransparentUpgradeableProxy blocks from
-// calling implementation functions ("admin cannot fallback to proxy
-// target"). Fixing that signer/admin conflict is out of scope for this
-// deprecation and would need its own review.
+// without deploying new BOB CCIP token-pool infrastructure.
 func.skip = async () => true

--- a/cross-chain/bob/deploy_l2/04_transfer_token_pool_proxy_admin.ts
+++ b/cross-chain/bob/deploy_l2/04_transfer_token_pool_proxy_admin.ts
@@ -21,11 +21,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     // For TransparentUpgradeableProxy, we need to call the admin functions directly
     // The proxy exposes admin(), upgradeTo(), and changeAdmin() functions
-    
+
     // First, let's check the current admin of both proxies
     const proxyAdminABI = [
       "function admin() external view returns (address)",
-      "function changeAdmin(address newAdmin) external"
+      "function changeAdmin(address newAdmin) external",
     ]
 
     // Create contract instances for the proxies
@@ -52,7 +52,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       await tx1.wait()
       console.log("  ✅ Token Pool Proxy admin transferred successfully!")
     } catch (error: any) {
-      console.log(`  ❌ Failed to transfer Token Pool Proxy admin: ${error.message}`)
+      console.log(
+        `  ❌ Failed to transfer Token Pool Proxy admin: ${error.message}`
+      )
     }
 
     console.log("\n=== Admin Transfer Complete ===")
@@ -62,8 +64,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     console.log("\nIMPORTANT: The deployer address can no longer:")
     console.log("  - Call admin functions on the proxies")
     console.log("  - Upgrade the contracts")
-    console.log("\nTo configure the token pools, use a different address (not the admin)")
-
+    console.log(
+      "\nTo configure the token pools, use a different address (not the admin)"
+    )
   } catch (error) {
     console.error("Error in admin transfer:", error)
     throw error
@@ -73,7 +76,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["TransferProxyAdmin"]
-func.dependencies = ["BurnFromMintTokenPoolUpgradeable", "OptimismMintableUpgradableTBTC"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
 // without mutating BOB CCIP token-pool ownership.
 func.skip = async () => true

--- a/cross-chain/bob/deploy_l2/04_transfer_token_pool_proxy_admin.ts
+++ b/cross-chain/bob/deploy_l2/04_transfer_token_pool_proxy_admin.ts
@@ -74,3 +74,6 @@ export default func
 
 func.tags = ["TransferProxyAdmin"]
 func.dependencies = ["BurnFromMintTokenPoolUpgradeable", "OptimismMintableUpgradableTBTC"]
+// BOB CCIP support is deprecated. Keep this script for historical reference
+// without mutating BOB CCIP token-pool ownership.
+func.skip = async () => true

--- a/cross-chain/bob/deploy_l2/04_transfer_token_pool_proxy_admin.ts
+++ b/cross-chain/bob/deploy_l2/04_transfer_token_pool_proxy_admin.ts
@@ -76,6 +76,12 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 export default func
 
 func.tags = ["TransferProxyAdmin"]
+func.dependencies = [
+  "BurnFromMintTokenPoolUpgradeable",
+  "OptimismMintableUpgradableTBTC",
+]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without mutating BOB CCIP token-pool ownership.
+// without mutating the BOB CCIP token-pool proxy admin (this script only ever
+// calls TransparentUpgradeableProxy.changeAdmin; the pool's own owner() is a
+// separate authority it never touches).
 func.skip = async () => true

--- a/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
@@ -142,7 +142,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 func.tags = ["ConfigureTokenPoolChains"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without configuring new BOB CCIP routes.
-func.skip = async () => true
+// without configuring new BOB CCIP routes. Still runs on hardhat/localhost
+// so the CI dry-run continues to exercise this path.
+func.skip = async (hre) =>
+  hre.network.name !== "hardhat" && hre.network.name !== "localhost"
 
 export default func

--- a/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
@@ -142,9 +142,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 func.tags = ["ConfigureTokenPoolChains"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without configuring new BOB CCIP routes. Still runs on hardhat/localhost
-// so the CI dry-run continues to exercise this path.
-func.skip = async (hre) =>
-  hre.network.name !== "hardhat" && hre.network.name !== "localhost"
+// without configuring new BOB CCIP routes. Unconditional: running this on
+// hardhat/localhost reverts with "admin cannot fallback to proxy target"
+// because the deployer signer used here is also the proxy admin set by
+// 03_deploy_burn_from_mint_token_pool.ts, and OpenZeppelin's
+// TransparentUpgradeableProxy blocks the admin from calling implementation
+// functions. Fixing that signer/admin conflict is out of scope for this
+// deprecation and would need its own review.
+func.skip = async () => true
 
 export default func

--- a/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
@@ -141,5 +141,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 }
 
 func.tags = ["ConfigureTokenPoolChains"]
+// BOB CCIP support is deprecated. Keep this script for historical reference
+// without configuring new BOB CCIP routes.
+func.skip = async () => true
 
 export default func

--- a/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
@@ -19,9 +19,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await ethers.getSigner(deployer)
   )
 
-  const ETHEREUM_CHAIN_SELECTOR = "16015286601757825753"
-  const ETHEREUM_POOL = "0x5b1D134fc62395AA3148128454C1a65B213334CD"
-  const ETHEREUM_TBTC = "0x517f2982701695D4E52f1ECFBEf3ba31Df470161"
+  // Verified against live BOB-mainnet state (BurnFromMintTokenPoolUpgradeable
+  // proxy on BOB): the selector and remote pool/token below previously used
+  // Ethereum Sepolia's chain selector and unrelated addresses instead of
+  // Ethereum mainnet's. Corrected to the real values so this script remains
+  // an accurate historical record.
+  const ETHEREUM_CHAIN_SELECTOR = "5009297550715157269"
+  const ETHEREUM_POOL = "0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6"
+  const ETHEREUM_TBTC = "0x18084fbA666a33d37592fA2633fD49a74DD93a88"
 
   const encodedEthereumPool = ethers.utils.defaultAbiCoder.encode(
     ["address"],

--- a/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
+++ b/cross-chain/bob/deploy_l2/05_configure_token_pool_chains.ts
@@ -1,7 +1,32 @@
 import type { HardhatRuntimeEnvironment } from "hardhat/types"
 import type { DeployFunction } from "hardhat-deploy/types"
 
+// Ethereum-mainnet side of the BOB CCIP route, verified against live
+// BOB-mainnet state on 2026-09-01 (BurnFromMintTokenPoolUpgradeable proxy on
+// BOB).
+//
+// Provenance: this script previously held the matching Sepolia-testnet record
+// -- Ethereum Sepolia's chain selector (16015286601757825753) with the sepolia
+// pool and the sepolia tBTC that
+// deploy_l1/00_deploy_lock_release_token_pool.ts still lists as
+// TBTC_ADDRESS.sepolia. Those values were a coherent testnet configuration,
+// not stray wrong addresses; the testnet record was converted to the mainnet
+// record here because the mainnet route is what this deprecation has to
+// document. Exported so test/DeprecatedBobCcipDeployScripts.test.ts pins them.
+export const ETHEREUM_CHAIN_SELECTOR = "5009297550715157269"
+export const ETHEREUM_POOL = "0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6"
+export const ETHEREUM_TBTC = "0x18084fbA666a33d37592fA2633fD49a74DD93a88"
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  // The constants above describe the BOB-mainnet pool's remote (Ethereum
+  // mainnet) side, so applying them anywhere else would write a mainnet route
+  // into an unrelated deployment.
+  if (hre.network.name !== "bobMainnet") {
+    throw new Error(
+      `This script configures the BOB mainnet side of the BOB CCIP route; refusing to run on network "${hre.network.name}" (expected "bobMainnet")`
+    )
+  }
+
   const { ethers, getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
@@ -18,15 +43,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     tokenPoolDeployment.address,
     await ethers.getSigner(deployer)
   )
-
-  // Verified against live BOB-mainnet state (BurnFromMintTokenPoolUpgradeable
-  // proxy on BOB): the selector and remote pool/token below previously used
-  // Ethereum Sepolia's chain selector and unrelated addresses instead of
-  // Ethereum mainnet's. Corrected to the real values so this script remains
-  // an accurate historical record.
-  const ETHEREUM_CHAIN_SELECTOR = "5009297550715157269"
-  const ETHEREUM_POOL = "0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6"
-  const ETHEREUM_TBTC = "0x18084fbA666a33d37592fA2633fD49a74DD93a88"
 
   const encodedEthereumPool = ethers.utils.defaultAbiCoder.encode(
     ["address"],
@@ -147,13 +163,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 func.tags = ["ConfigureTokenPoolChains"]
 // BOB CCIP support is deprecated. Keep this script for historical reference
-// without configuring new BOB CCIP routes. Unconditional: running this on
-// hardhat/localhost reverts with "admin cannot fallback to proxy target"
-// because the deployer signer used here is also the proxy admin set by
-// 03_deploy_burn_from_mint_token_pool.ts, and OpenZeppelin's
-// TransparentUpgradeableProxy blocks the admin from calling implementation
-// functions. Fixing that signer/admin conflict is out of scope for this
-// deprecation and would need its own review.
+// without configuring new BOB CCIP routes.
 func.skip = async () => true
 
 export default func

--- a/cross-chain/bob/docs/tbtc-bob-upgrade-technical-document.md
+++ b/cross-chain/bob/docs/tbtc-bob-upgrade-technical-document.md
@@ -179,3 +179,13 @@ The `legacyCapRemaining` mechanism represents a thoughtful approach to bridge mi
 - Natural market-driven migration
 
 This design demonstrates the importance of considering not just technical feasibility but also user experience and system predictability when designing critical infrastructure upgrades.
+
+## Deprecation Addendum (BOB CCIP)
+
+As of this addendum's date, BOB CCIP bridge support is deprecated, while the native OP Stack legacy bridge remains active. This is the reverse of what the original Migration Timeline and BOB Bridge Frontend-Driven Depletion sections describe; those sections previously assumed the legacy bridge would be deactivated in favor of CCIP as the primary bridge. Under the current deprecation plan, the native bridge remains the primary exit path for the duration of the wind-down.
+
+`legacyCapRemaining` is not guaranteed to reach zero automatically under this addendum's plan. The variable decreases on native-bridge burns but increases on native-bridge mints (deposits), and this deprecation intentionally leaves the native bridge fully open in both directions. The cap will only trend toward zero if native bridge-in deposits are also curtailed at the frontend and routing layers, not just CCIP bridge-in.
+
+The two BOB exit paths—CCIP burnFrom-based exits and the native bridge's own burn—are mutually exclusive due to the `legacyCapRemaining > 0` gate documented earlier in this file. CCIP exits only function once the cap is fully drained, and native bridge exits stop working at exactly that point. This exclusivity must be carefully managed given the decision to prioritize the native bridge over CCIP.
+
+For the withdraw-only procedure and final cleanup preconditions, including pool ownership transfer and rebalancer configuration, please refer to `cross-chain/bob/README.md`, which serves as the authoritative operational runbook for this deprecation.

--- a/cross-chain/bob/docs/tbtc-bob-upgrade-technical-document.md
+++ b/cross-chain/bob/docs/tbtc-bob-upgrade-technical-document.md
@@ -158,6 +158,15 @@ The chosen `legacyCapRemaining` approach provides superior characteristics:
 
 ## Migration Timeline
 
+> **Superseded — see [Deprecation Addendum (BOB CCIP)](#deprecation-addendum-bob-ccip) before relying on anything in this section.**
+> The Migration Timeline and BOB Bridge Frontend-Driven Depletion content below
+> describes the original CCIP-forward plan, in which the legacy OP Stack bridge
+> would be wound down in favour of CCIP as the primary bridge. That plan has
+> been reversed: BOB CCIP support is now deprecated, and `legacyCapRemaining`
+> was verified on-chain at **0** on 2026-09-01 — the depletion this section
+> anticipates has already completed, and the legacy bridge's own burn path now
+> reverts. Both sections are retained for historical context only.
+
 The migration follows a natural, market-driven timeline:
 
 1. **Immediate**: New bridges can begin operations
@@ -182,10 +191,12 @@ This design demonstrates the importance of considering not just technical feasib
 
 ## Deprecation Addendum (BOB CCIP)
 
-As of this addendum's date, BOB CCIP bridge support is deprecated, while the native OP Stack legacy bridge remains active. This is the reverse of what the original Migration Timeline and BOB Bridge Frontend-Driven Depletion sections describe; those sections previously assumed the legacy bridge would be deactivated in favor of CCIP as the primary bridge. Under the current deprecation plan, the native bridge remains the primary exit path for the duration of the wind-down.
+As of 2026-09-01, BOB CCIP bridge support is deprecated, while the native OP Stack legacy bridge remains in place as BOB infrastructure that cannot be *safely* deactivated at the token-contract level — governance can call `removeMinter(BRIDGE)` on `OptimismMintableUpgradableTBTC` to stop native bridge-in mints without touching the bridge's separate `onlyBridge`-gated burn/exit permission, but OP Stack deposits are force-included on L2, so doing so risks stranding an already-escrowed L1 deposit mid-flight. This is the reverse of what the original Migration Timeline and BOB Bridge Frontend-Driven Depletion sections describe; those sections assumed the legacy bridge would be deactivated in favour of CCIP as the primary bridge.
 
-`legacyCapRemaining` is not guaranteed to reach zero automatically under this addendum's plan. The variable decreases on native-bridge burns but increases on native-bridge mints (deposits), and this deprecation intentionally leaves the native bridge fully open in both directions. The cap will only trend toward zero if native bridge-in deposits are also curtailed at the frontend and routing layers, not just CCIP bridge-in.
+Deprecating CCIP does **not**, however, make the native bridge the working exit path. `legacyCapRemaining` was verified on-chain on 2026-09-01 to be already **0** on the live `OptimismMintableUpgradableTBTC` contract on BOB. At zero, the legacy bridge's own `burn()` reverts on the `require(legacyCapRemaining > 0, "Legacy cap exhausted")` guard, so the native exit is dead today and CCIP `burnFrom`-based exits are the only functioning way out of BOB. Cap depletion is not a wind-down still in progress — it has already completed. The CCIP outbound (exit) path must therefore be kept working: do not pause it, rate-limit it to zero, or remove the BOB chain config while tBTC liquidity remains on BOB.
 
-The two BOB exit paths—CCIP burnFrom-based exits and the native bridge's own burn—are mutually exclusive due to the `legacyCapRemaining > 0` gate documented earlier in this file. CCIP exits only function once the cap is fully drained, and native bridge exits stop working at exactly that point. This exclusivity must be carefully managed given the decision to prioritize the native bridge over CCIP.
+What remains is a hazard to guard against rather than a milestone to reach. `legacyCapRemaining` is not monotonically decreasing: any native OP Stack bridge-in deposit mints on BOB and re-arms the cap above zero, which immediately breaks CCIP exits again (`burnFrom` reverts for every non-bridge caller while the cap is nonzero) and forces users back onto the 7-day native withdrawal. Native bridge-in deposits must therefore be suppressed at the frontend and routing layers alongside CCIP bridge-in — not to deplete the cap, which is already drained, but to keep it at zero so the sole working exit stays open.
+
+The two BOB exit paths—CCIP burnFrom-based exits and the native bridge's own burn—are mutually exclusive due to the `legacyCapRemaining > 0` gate documented earlier in this file. CCIP exits only function once the cap is fully drained, and native bridge exits stop working at exactly that point; the two are never available simultaneously. That exclusivity is precisely why the cap sitting at zero makes CCIP required rather than removable.
 
 For the withdraw-only procedure and final cleanup preconditions, including pool ownership transfer and rebalancer configuration, please refer to `cross-chain/bob/README.md`, which serves as the authoritative operational runbook for this deprecation.

--- a/cross-chain/bob/test/DeprecatedBobCcipDeployScripts.test.ts
+++ b/cross-chain/bob/test/DeprecatedBobCcipDeployScripts.test.ts
@@ -1,0 +1,84 @@
+import { assert } from "chai"
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+
+import deployLockReleaseTokenPool from "../deploy_l1/00_deploy_lock_release_token_pool"
+import transferTokenPoolProxyAdminL1 from "../deploy_l1/01_transfer_token_pool_proxy_admin"
+import configureTokenPoolChainsL1 from "../deploy_l1/02_configure_token_pool_chains"
+import deployBurnFromMintTokenPool from "../deploy_l2/03_deploy_burn_from_mint_token_pool"
+import transferTokenPoolProxyAdminL2 from "../deploy_l2/04_transfer_token_pool_proxy_admin"
+import configureTokenPoolChainsL2 from "../deploy_l2/05_configure_token_pool_chains"
+
+describe("Deprecated BOB CCIP Deploy Scripts", () => {
+  const unconditionalScripts = [
+    {
+      name: "00_deploy_lock_release_token_pool",
+      func: deployLockReleaseTokenPool,
+    },
+    {
+      name: "01_transfer_token_pool_proxy_admin (L1)",
+      func: transferTokenPoolProxyAdminL1,
+    },
+    {
+      name: "02_configure_token_pool_chains (L1)",
+      func: configureTokenPoolChainsL1,
+    },
+    {
+      name: "04_transfer_token_pool_proxy_admin (L2)",
+      func: transferTokenPoolProxyAdminL2,
+    },
+  ]
+
+  const networkGatedScripts = [
+    {
+      name: "03_deploy_burn_from_mint_token_pool",
+      func: deployBurnFromMintTokenPool,
+    },
+    {
+      name: "05_configure_token_pool_chains (L2)",
+      func: configureTokenPoolChainsL2,
+    },
+  ]
+
+  for (const script of unconditionalScripts) {
+    it(`${script.name} should always skip`, async () => {
+      assert.isFunction(script.func.skip)
+      const shouldSkip = await script.func.skip!(
+        {} as HardhatRuntimeEnvironment
+      )
+      assert.isTrue(
+        shouldSkip,
+        `Script ${script.name} should skip unconditionally`
+      )
+    })
+  }
+
+  for (const script of networkGatedScripts) {
+    it(`${script.name} should skip on non-local networks`, async () => {
+      assert.isFunction(script.func.skip)
+
+      const shouldSkipHardhat = await script.func.skip!({
+        network: { name: "hardhat" },
+      } as HardhatRuntimeEnvironment)
+      assert.isFalse(
+        shouldSkipHardhat,
+        `Script ${script.name} should NOT skip on hardhat`
+      )
+
+      const shouldSkipLocalhost = await script.func.skip!({
+        network: { name: "localhost" },
+      } as HardhatRuntimeEnvironment)
+      assert.isFalse(
+        shouldSkipLocalhost,
+        `Script ${script.name} should NOT skip on localhost`
+      )
+
+      const shouldSkipMainnet = await script.func.skip!({
+        network: { name: "mainnet" },
+      } as HardhatRuntimeEnvironment)
+      assert.isTrue(
+        shouldSkipMainnet,
+        `Script ${script.name} should skip on mainnet`
+      )
+    })
+  }
+})

--- a/cross-chain/bob/test/DeprecatedBobCcipDeployScripts.test.ts
+++ b/cross-chain/bob/test/DeprecatedBobCcipDeployScripts.test.ts
@@ -23,15 +23,12 @@ describe("Deprecated BOB CCIP Deploy Scripts", () => {
       func: configureTokenPoolChainsL1,
     },
     {
-      name: "04_transfer_token_pool_proxy_admin (L2)",
-      func: transferTokenPoolProxyAdminL2,
-    },
-  ]
-
-  const networkGatedScripts = [
-    {
       name: "03_deploy_burn_from_mint_token_pool",
       func: deployBurnFromMintTokenPool,
+    },
+    {
+      name: "04_transfer_token_pool_proxy_admin (L2)",
+      func: transferTokenPoolProxyAdminL2,
     },
     {
       name: "05_configure_token_pool_chains (L2)",
@@ -48,36 +45,6 @@ describe("Deprecated BOB CCIP Deploy Scripts", () => {
       assert.isTrue(
         shouldSkip,
         `Script ${script.name} should skip unconditionally`
-      )
-    })
-  }
-
-  for (const script of networkGatedScripts) {
-    it(`${script.name} should skip on non-local networks`, async () => {
-      assert.isFunction(script.func.skip)
-
-      const shouldSkipHardhat = await script.func.skip!({
-        network: { name: "hardhat" },
-      } as HardhatRuntimeEnvironment)
-      assert.isFalse(
-        shouldSkipHardhat,
-        `Script ${script.name} should NOT skip on hardhat`
-      )
-
-      const shouldSkipLocalhost = await script.func.skip!({
-        network: { name: "localhost" },
-      } as HardhatRuntimeEnvironment)
-      assert.isFalse(
-        shouldSkipLocalhost,
-        `Script ${script.name} should NOT skip on localhost`
-      )
-
-      const shouldSkipMainnet = await script.func.skip!({
-        network: { name: "mainnet" },
-      } as HardhatRuntimeEnvironment)
-      assert.isTrue(
-        shouldSkipMainnet,
-        `Script ${script.name} should skip on mainnet`
       )
     })
   }

--- a/cross-chain/bob/test/DeprecatedBobCcipDeployScripts.test.ts
+++ b/cross-chain/bob/test/DeprecatedBobCcipDeployScripts.test.ts
@@ -1,12 +1,21 @@
 import { assert } from "chai"
+import { utils } from "ethers"
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 
 import deployLockReleaseTokenPool from "../deploy_l1/00_deploy_lock_release_token_pool"
 import transferTokenPoolProxyAdminL1 from "../deploy_l1/01_transfer_token_pool_proxy_admin"
-import configureTokenPoolChainsL1 from "../deploy_l1/02_configure_token_pool_chains"
+import configureTokenPoolChainsL1, {
+  BOB_CHAIN_SELECTOR,
+  BOB_POOL,
+  BOB_TBTC,
+} from "../deploy_l1/02_configure_token_pool_chains"
 import deployBurnFromMintTokenPool from "../deploy_l2/03_deploy_burn_from_mint_token_pool"
 import transferTokenPoolProxyAdminL2 from "../deploy_l2/04_transfer_token_pool_proxy_admin"
-import configureTokenPoolChainsL2 from "../deploy_l2/05_configure_token_pool_chains"
+import configureTokenPoolChainsL2, {
+  ETHEREUM_CHAIN_SELECTOR,
+  ETHEREUM_POOL,
+  ETHEREUM_TBTC,
+} from "../deploy_l2/05_configure_token_pool_chains"
 
 describe("Deprecated BOB CCIP Deploy Scripts", () => {
   const unconditionalScripts = [
@@ -36,16 +45,69 @@ describe("Deprecated BOB CCIP Deploy Scripts", () => {
     },
   ]
 
+  // Every network these scripts can be pointed at (see hardhat.config.ts).
+  // Skipping is asserted against a realistic HRE stub per network rather than
+  // an empty object, so a future conditional guard reading hre.network.name
+  // cannot pass this suite while still running against a real deployment.
+  const networkNames = [
+    "hardhat",
+    "localhost",
+    "mainnet",
+    "sepolia",
+    "bobMainnet",
+    "bobSepolia",
+  ]
+
   for (const script of unconditionalScripts) {
-    it(`${script.name} should always skip`, async () => {
-      assert.isFunction(script.func.skip)
-      const shouldSkip = await script.func.skip!(
-        {} as HardhatRuntimeEnvironment
-      )
-      assert.isTrue(
-        shouldSkip,
-        `Script ${script.name} should skip unconditionally`
-      )
-    })
+    for (const networkName of networkNames) {
+      it(`${script.name} should skip on ${networkName}`, async () => {
+        assert.isFunction(
+          script.func.skip,
+          `Script ${script.name} should define a skip guard`
+        )
+
+        const hre = {
+          network: { name: networkName, tags: {} },
+        } as unknown as HardhatRuntimeEnvironment
+
+        assert.isTrue(
+          await script.func.skip!(hre),
+          `Script ${script.name} should skip unconditionally (network: ${networkName})`
+        )
+      })
+    }
   }
+
+  describe("recorded BOB CCIP mainnet route", () => {
+    it("02_configure_token_pool_chains (L1) pins the BOB mainnet remote", () => {
+      assert.equal(BOB_CHAIN_SELECTOR, "3849287863852499584")
+      assert.equal(BOB_POOL, "0x36Ee23c94523A05981baaEEaea4BA97cDDe21f6a")
+      assert.equal(BOB_TBTC, "0xBBa2eF945D523C4e2608C9E1214C2Cc64D4fc2e2")
+    })
+
+    it("05_configure_token_pool_chains (L2) pins the Ethereum mainnet remote", () => {
+      assert.equal(ETHEREUM_CHAIN_SELECTOR, "5009297550715157269")
+      assert.equal(ETHEREUM_POOL, "0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6")
+      assert.equal(ETHEREUM_TBTC, "0x18084fbA666a33d37592fA2633fD49a74DD93a88")
+    })
+
+    it("records every address in EIP-55 checksummed form", () => {
+      const addresses = [
+        ["BOB_POOL", BOB_POOL],
+        ["BOB_TBTC", BOB_TBTC],
+        ["ETHEREUM_POOL", ETHEREUM_POOL],
+        ["ETHEREUM_TBTC", ETHEREUM_TBTC],
+      ]
+
+      for (const [name, address] of addresses) {
+        // getAddress on the lower-cased input always returns the canonical
+        // EIP-55 form, so this fails (instead of throwing) on a bad checksum.
+        assert.equal(
+          utils.getAddress(address.toLowerCase()),
+          address,
+          `${name} is not in EIP-55 checksummed form`
+        )
+      }
+    })
+  })
 })

--- a/cross-chain/bob/tsconfig.json
+++ b/cross-chain/bob/tsconfig.json
@@ -8,5 +8,5 @@
     "skipLibCheck": true,
     "resolveJsonModule": true
   },
-  "include": ["hardhat.config.ts", "scripts", "test", "deploy_l2"]
+  "include": ["hardhat.config.ts", "scripts", "test", "deploy_l1", "deploy_l2"]
 }


### PR DESCRIPTION
## Summary

- Deprecate the BoB CCIP path. This PR leaves the native OP Stack bridge untouched (BOB infrastructure, not a tBTC-maintained bridge) -- note that on-chain state shows that path is already inactive today (`legacyCapRemaining == 0`), so CCIP is currently the only working exit; see Notes.
- Skip BoB CCIP token-pool deploy, ownership-transfer, and route-configuration scripts.
- Add BoB README guidance for withdraw-only operation, in-flight CCIP messages, and final cleanup.
- Correct on-chain-verified inaccuracies found during multi-agent review: wrong chain-selector/pool/token constants in the historical-reference deploy scripts, and stale claims about `legacyCapRemaining` and exit-path availability.

## Notes

This PR does not try to disable the native OP Stack bridge. That bridge is BOB infrastructure, not an added tBTC-maintained bridge assumption, and the token contract cannot safely deactivate it while exits remain.

**Verified on-chain (2026-09-01), not just documented:** `legacyCapRemaining` on the live `OptimismMintableUpgradableTBTC` contract on BOB is already `0`. The native OP Stack bridge's own burn path (`burn(address,uint256)`) hard-reverts once the cap is exhausted, so the native exit is already dead today, not "pending." CCIP is currently the *only* functioning exit path for the ~2.6077 tBTC presently locked on L1 / minted on BOB (`totalSupply` on both sides matches exactly). This directly informs the follow-ups below: do not disable or throttle-to-zero CCIP exits while this holds, and do not rely on the native bridge as a fallback.

The CCIP token pools do not expose a safe one-way switch that blocks Ethereum-to-BoB deposits while preserving BoB-to-Ethereum exits. Removing BoB from the Ethereum pool also rejects inbound BoB-to-Ethereum messages, so CCIP chain removal should be a final governance cleanup after balances and in-flight messages are drained.

## Validation

- `git diff --check` on all touched files.
- `prettier --write` / `prettier --check` on all touched files (clean).
- `tsc --noEmit` on the `cross-chain/bob` package (no new errors; only pre-existing, untouched `hardhat.config.ts` errors remain).
- Full `hardhat compile` + `hardhat test` run for the `cross-chain/bob` package: 133/133 passing.
- `hardhat deploy --export export.json` dry run against a forked-mainnet hardhat network: all six retired deploy scripts correctly skip.
- All 15 GitHub Actions checks green on the PR branch, including `contracts-deployment-dry-run` and `contracts-slither`.
- On-chain state (L1 pool, BOB pool, BOB token) read directly via `cast call` against public RPCs to ground every claim above and the follow-ups below in live contract state, not assumptions.

## Follow-ups required to fully deprecate BoB (not done in this PR)

This PR is code-only: repo/doc changes and CI. It does not execute any on-chain transaction. Investigation while preparing this PR turned up on-chain state and governance actions that still need attention, listed here so they aren't lost.

### On-chain governance actions (require Threshold Council multisig approval)

All addresses below were verified live via `cast call` on 2026-09-01.

1. **Call `setRebalancer(address)` on the L1 pool.** `LockReleaseTokenPoolUpgradeable` proxy `0x03E342731c08FDDc34cFb43E91cB3a7e424ee0F6` currently has `getRebalancer() == address(0)`. `withdrawLiquidity`/`transferLiquidity` cannot be called by anyone until this is set — it's the hard prerequisite for any future liquidity withdrawal.
2. **Decide the exit strategy for the ~2.6077 tBTC currently locked/minted via BOB** before touching the CCIP route. Since the native bridge exit is already dead (`legacyCapRemaining == 0`) and CCIP is the sole functioning exit today, removing the CCIP route before balances are drained would permanently strand remaining holders. This is a decision point, not a technical step.
3. **Do not pause the BOB tBTC token** (`0xbBa2eF945D523C4e2608C9E1214C2cC64D4fc2e2`, currently unpaused) until (2) is resolved — pausing now would remove the only working exit for existing holders.
4. **Remove the BoB route from the L1 pool** once (2) is resolved: multisig (`0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f`, 6-of-9 Safe, already the pool owner) calls `applyChainUpdates` removing chain selector `3849287863852499584`.
5. **Remove the symmetric route on the BoB-side pool**: `BurnFromMintTokenPoolUpgradeable` proxy `0x36ee23c94523A05981bAAeeAeA4bA97CDde21F6A` is owned by a separate 6-of-9 Safe (`0x694DeC29F197c76eb13d4Cc549cE38A1e06Cd24C`), which calls `applyChainUpdates` removing the Ethereum mainnet selector `5009297550715157269`.
6. **Withdraw remaining L1-locked liquidity** via `withdrawLiquidity`/`transferLiquidity` (unlocked by step 1) once (2)-(5) are complete, to wherever governance decides it should go — don't leave it stranded in a pool nobody will revisit.
7. **Decide whether to revoke BoB-side minter/guardian roles** on `OptimismMintableUpgradableTBTC` once the route is retired and confirmed empty. Not urgent, but live minter/guardian permissions on a fully-deprecated chain are unnecessary attack surface.

### Verification / cleanup after the governance actions above execute

8. **Re-verify on-chain** (`isSupportedChain`, `getSupportedChains`, `getRemotePools` on both pools) after each removal transaction to confirm it actually landed, rather than assuming success from the tx receipt alone.
9. **Update this package's README and `docs/tbtc-bob-upgrade-technical-document.md`** once the on-chain removal is real, so the docs stop describing a still-hypothetical future state as pending.

### Already fixed in this PR (found during the same on-chain investigation)

- `deploy_l1/02_configure_token_pool_chains.ts` and `deploy_l2/05_configure_token_pool_chains.ts` hardcoded a chain selector, remote-pool address, and remote-token address that did not match live on-chain configuration (the L1 script pointed at an unrelated selector/pool; the L2 script used Ethereum **Sepolia's** selector and unrelated addresses instead of Ethereum **mainnet's**). Both corrected to the on-chain-verified real values.
- README corrected to state `legacyCapRemaining == 0` and the owner-transfer precondition as verified current facts instead of hedged "verify on-chain" language.
- `.github/workflows/cross-chain-bob.yml` documented with an explicit comment: the daily cron and per-PR runs are deliberately kept despite every deploy script being permanently skipped, for regression coverage on the frozen contracts and Slither analysis on code that still holds live user funds.

