### PR TITLE
fix(starknet): enforce strict fee equality in StarkNetBitcoinDepositor

### DIFF
--- a/cross-chain/starknet/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
+++ b/cross-chain/starknet/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
@@ -107,10 +107,12 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         uint256 amount,
         bytes32 destinationChainReceiver
     ) internal override {
-        // This function is called by finalizeDeposit which is payable
-        // The caller must send ETH to cover the StarkGate bridge fee
+        // This function is called by finalizeDeposit which is payable.
+        // The caller must send ETH to cover the StarkGate bridge fee exactly:
+        // the whole msg.value is forwarded to StarkGate, which never refunds
+        // the surplus, so any overpayment would be lost.
         uint256 fee = estimateFee();
-        require(msg.value >= fee, "Insufficient L1->L2 message fee");
+        require(msg.value == fee, "Incorrect L1->L2 message fee");
         require(address(tbtcToken) != address(0), "tBTC token not initialized");
 
         // Convert bytes32 to uint256 for StarkNet address format
@@ -121,7 +123,6 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         tbtcToken.safeIncreaseAllowance(address(starkGateBridge), amount);
 
         // Bridge tBTC to StarkNet
-        // All msg.value is sent to the bridge (no refund)
         // slither-disable-next-line unused-return
         starkGateBridge.deposit{value: msg.value}(
             address(tbtcToken),

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -368,10 +368,11 @@ abstract contract AbstractL1BTCDepositor is
     ///      - `initializeDeposit` was called for the given deposit before,
     ///      - ERC20 L1 tBTC was minted by tBTC Bridge to this contract,
     ///      - The function was not called for the given deposit before,
-    ///      - The call must carry a payment for the briding system that
+    ///      - The call must carry a payment for the bridging system that
     ///        is responsible for executing the deposit finalization on the
-    ///        corresponding destination chain. The payment must be greater than or
-    ///        equal to the value returned by the `quoteFinalizeDeposit` function.
+    ///        corresponding destination chain. The exact payment requirement
+    ///        (a minimum vs. an exact amount, and whether `quoteFinalizeDeposit`
+    ///        is even exposed) is defined by each concrete depositor.
     /// @dev When `reimburseTxMaxFee` is true, the deposit transaction max fee
     ///      reimbursement is applied only if this contract's tBTC balance can
     ///      cover the base deposit amount plus the reimbursement. Otherwise,

--- a/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
+++ b/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
@@ -93,8 +93,20 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
 
     /// @notice Get the estimated fee for a deposit from the StarkGate bridge
     /// @return The estimated fee in wei
+    /// @dev `finalizeDeposit` requires `msg.value` to equal this value exactly.
+    ///      This assumes StarkGate's `estimateDepositFeeWei` stays constant; it
+    ///      is typed `view`, not `pure`, so a future StarkGate upgrade that
+    ///      makes the fee dynamic would cause in-flight finalizations to
+    ///      revert and require relayer re-quoting. Do not revert to `>=`.
     function estimateFee() public view returns (uint256) {
         return starkGateBridge.estimateDepositFeeWei();
+    }
+
+    /// @notice Get the estimated fee for a deposit from the StarkGate bridge.
+    /// @return cost The cost of the `finalizeDeposit` function call in WEI.
+    /// @dev Provided for interface consistency with sibling depositors.
+    function quoteFinalizeDeposit() external view returns (uint256 cost) {
+        cost = estimateFee();
     }
 
     // ========== Internal Functions ==========

--- a/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
+++ b/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
@@ -102,13 +102,6 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         return starkGateBridge.estimateDepositFeeWei();
     }
 
-    /// @notice Get the estimated fee for a deposit from the StarkGate bridge.
-    /// @return cost The cost of the `finalizeDeposit` function call in WEI.
-    /// @dev Provided for interface consistency with sibling depositors.
-    function quoteFinalizeDeposit() external view returns (uint256 cost) {
-        cost = estimateFee();
-    }
-
     // ========== Internal Functions ==========
 
     /// @notice Transfers tBTC to StarkNet L2 using StarkGate bridge

--- a/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
+++ b/solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol
@@ -107,10 +107,12 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         internal
         override
     {
-        // This function is called by finalizeDeposit which is payable
-        // The caller must send ETH to cover the StarkGate bridge fee
+        // This function is called by finalizeDeposit which is payable.
+        // The caller must send ETH to cover the StarkGate bridge fee exactly:
+        // the whole msg.value is forwarded to StarkGate, which never refunds
+        // the surplus, so any overpayment would be lost.
         uint256 fee = estimateFee();
-        require(msg.value >= fee, "Insufficient L1->L2 message fee");
+        require(msg.value == fee, "Incorrect L1->L2 message fee");
         require(address(tbtcToken) != address(0), "tBTC token not initialized");
 
         // Convert bytes32 to uint256 for StarkNet address format
@@ -121,7 +123,6 @@ contract StarkNetBitcoinDepositor is AbstractL1BTCDepositor {
         tbtcToken.safeIncreaseAllowance(address(starkGateBridge), amount);
 
         // Bridge tBTC to StarkNet
-        // All msg.value is sent to the bridge (no refund)
         // slither-disable-next-line unused-return
         starkGateBridge.deposit{value: msg.value}(
             address(tbtcToken),

--- a/solidity/test/cross-chain/StarkNetBitcoinDepositor.test.ts
+++ b/solidity/test/cross-chain/StarkNetBitcoinDepositor.test.ts
@@ -286,6 +286,17 @@ describe("StarkNetBitcoinDepositor", () => {
       ).to.be.revertedWith("Incorrect L1->L2 message fee")
     })
 
+    it("should revert when the fee drifts after the caller's quote", async () => {
+      const quotedFee = INITIAL_MESSAGE_FEE
+      await starkGateBridge.setEstimateDepositFeeWeiReturn(
+        INITIAL_MESSAGE_FEE.add(1)
+      )
+
+      await expect(
+        depositor.finalizeDeposit(depositKey, { value: quotedFee })
+      ).to.be.revertedWith("Incorrect L1->L2 message fee")
+    })
+
     it("should call StarkGate bridge with correct parameters", async () => {
       await depositor.finalizeDeposit(depositKey, {
         value: INITIAL_MESSAGE_FEE,

--- a/solidity/test/cross-chain/StarkNetBitcoinDepositor.test.ts
+++ b/solidity/test/cross-chain/StarkNetBitcoinDepositor.test.ts
@@ -275,7 +275,15 @@ describe("StarkNetBitcoinDepositor", () => {
 
       await expect(
         depositor.finalizeDeposit(depositKey, { value: insufficientFee })
-      ).to.be.revertedWith("Insufficient L1->L2 message fee")
+      ).to.be.revertedWith("Incorrect L1->L2 message fee")
+    })
+
+    it("should revert with excessive fee", async () => {
+      const excessiveFee = INITIAL_MESSAGE_FEE.add(1)
+
+      await expect(
+        depositor.finalizeDeposit(depositKey, { value: excessiveFee })
+      ).to.be.revertedWith("Incorrect L1->L2 message fee")
     })
 
     it("should call StarkGate bridge with correct parameters", async () => {

--- a/solidity/test/cross-chain/starknet/CoreLogicTests.sol
+++ b/solidity/test/cross-chain/starknet/CoreLogicTests.sol
@@ -232,8 +232,18 @@ contract CoreLogicTests is Test, TestSetup, GasReporter {
         uint256 insufficientFee = INITIAL_MESSAGE_FEE - 1;
         vm.deal(address(this), insufficientFee);
 
-        vm.expectRevert("Insufficient L1->L2 message fee");
+        vm.expectRevert("Incorrect L1->L2 message fee");
         depositor.finalizeDeposit{value: insufficientFee}(DEPOSIT_KEY_BYTES32);
+    }
+
+    function test_FinalizeDeposit_RevertExcessiveFee() public {
+        _setupValidDepositForFinalization();
+
+        uint256 excessiveFee = INITIAL_MESSAGE_FEE + 1;
+        vm.deal(address(this), excessiveFee);
+
+        vm.expectRevert("Incorrect L1->L2 message fee");
+        depositor.finalizeDeposit{value: excessiveFee}(DEPOSIT_KEY_BYTES32);
     }
 
     function test_FinalizeDeposit_EmitsTBTCBridgedEvent() public {

--- a/solidity/test/cross-chain/starknet/CoreLogicTests.sol
+++ b/solidity/test/cross-chain/starknet/CoreLogicTests.sol
@@ -232,18 +232,8 @@ contract CoreLogicTests is Test, TestSetup, GasReporter {
         uint256 insufficientFee = INITIAL_MESSAGE_FEE - 1;
         vm.deal(address(this), insufficientFee);
 
-        vm.expectRevert("Incorrect L1->L2 message fee");
+        vm.expectRevert("Insufficient L1->L2 message fee");
         depositor.finalizeDeposit{value: insufficientFee}(DEPOSIT_KEY_BYTES32);
-    }
-
-    function test_FinalizeDeposit_RevertExcessiveFee() public {
-        _setupValidDepositForFinalization();
-
-        uint256 excessiveFee = INITIAL_MESSAGE_FEE + 1;
-        vm.deal(address(this), excessiveFee);
-
-        vm.expectRevert("Incorrect L1->L2 message fee");
-        depositor.finalizeDeposit{value: excessiveFee}(DEPOSIT_KEY_BYTES32);
     }
 
     function test_FinalizeDeposit_EmitsTBTCBridgedEvent() public {


### PR DESCRIPTION
Supersedes #937, rebased onto current `main` with the test updates that PR was missing. The diagnosis and the fix are **@Mavline's** — credited via `Co-authored-by`.

## Problem

`StarkNetBitcoinDepositor._transferTbtc()` checked `require(msg.value >= fee)` and then forwarded the **entire** `msg.value` to StarkGate:

```solidity
uint256 fee = estimateFee();
require(msg.value >= fee, "Insufficient L1->L2 message fee");
...
starkGateBridge.deposit{value: msg.value}(...);
```

StarkGate never refunds the surplus, so any overpayment was permanently lost. The old code even acknowledged it: `// All msg.value is sent to the bridge (no refund)`.

Both Wormhole depositors and both V2 variants already require exact payment — `L1BTCDepositorWormhole.sol:193`, `BTCDepositorWormhole.sol:115`, `L1BTCDepositorWormholeV2Arbitrum.sol`, `L1BTCDepositorWormholeV2Base.sol`. The two NTT depositors (`L1BTCDepositorNtt.sol:336`, `L1BTCDepositorNttWithExecutor.sol:898`) still use `>=`, but neither has a mainnet or Sepolia deployment yet. StarkNet was the only **live** outlier.

## Fix

`require(msg.value == fee, "Incorrect L1->L2 message fee")`.

**Why `==` and not `>=`-plus-refund:** StarkGate's `estimateDepositFeeWei()` is `external pure`, returning `DEPOSIT_FEE_GAS * DEFAULT_WEI_PER_GAS` = `20000 * 5 gwei` = **0.0001 ETH**, a compile-time constant ([Fees.sol](https://github.com/starknet-io/starkgate-contracts/blob/main/src/solidity/Fees.sol), which notes *"block.basefee cannot be used"*). The fee does not drift per block, so exact payment carries no liveness risk, and adding refund logic would be unnecessary surface to return an overpayment a constant-reading caller never makes. This repo's own `IStarkGateBridge` interface types the function `view` rather than `pure`, so `StarkNetBitcoinDepositor.estimateFee()` now carries a `@dev` note recording that assumption explicitly.

## Impact — low severity, worth fixing anyway

Real exposure is small and this is **not** urgent:

- StarkGate's `checkFee` caps `msg.value` at `MAX_FEE = 0.01 ETH` and reverts past it, so worst-case loss is bounded at ~0.0099 ETH per call, and only if a caller overpays ~100×.
- `finalizeDeposit` is relayer-called; the relayer reads `estimateFee()` and sends the exact constant. Nothing overpays today.
- The old `>=` also let an overpayment loss land on the DAO instead of the caller, if this depositor ever gets a `ReimbursementPool` wired: `AbstractL1BTCDepositor.finalizeDeposit()` refunds the caller's full `msg.value` from the pool when authorized. Confirmed dormant today — the live proxy's `reimbursementPool()` currently returns the zero address — but `==` pre-empts that drain vector too if a pool is ever attached.

The value is the **failure mode**, not the money. The fee buffer was removed from this contract once already (the `DynamicFees` tests still carry the tombstones). If a future relayer author adds one back, today's `>=` silently burns ETH; `==` reverts in their first test.

## Testing

- `npx hardhat compile` — clean
- Full cross-chain suite: **141 passing, 0 failing**
- `solhint` + `prettier --check` — clean
- **Verified the new test is not vacuous:** reverting the contract to `>=` makes `should revert with excessive fee` fail with *"Expected transaction to be reverted"* — i.e. on old code overpaying succeeds and burns the surplus. That's the bug, reproduced.
- Added a test proving the fee is read live at execution time (`setEstimateDepositFeeWeiReturn` after the caller's conceptual quote), not cached from an earlier call.

## Notes for reviewers

- #937 changed the revert string but left two assertions on the old text, which would have gone red. Both updated here: `StarkNetBitcoinDepositor.test.ts:278` and `starknet/CoreLogicTests.sol:235`.
- `test/cross-chain/starknet/*.sol` import `forge-std/Test.sol` and use Foundry cheatcodes, but there is **no `foundry.toml` in the repo** and Hardhat does not compile `.sol` under `test/`. Those files are dead code that CI never runs. On review, the specific `CoreLogicTests.sol` edit from the paragraph above turned out to target a constructor and API surface (`quoteFinalizeDeposit()`, `l1ToL2MessageFee()`, `updateL1ToL2MessageFee()`) the real contract doesn't have, so it's been dropped from this PR rather than fixed forward — only the TS test gates CI either way.
- Review also flagged that `StarkNetBitcoinDepositor` has no `quoteFinalizeDeposit()`, unlike its six sibling depositors (which only expose `estimateFee()`). Deliberately left out of this PR: it would be an additive API on a live, proxy-fronted mainnet contract, not a fix for the fee-equality defect this PR addresses. Worth its own small follow-up PR if wanted.
- **Sequencing, corrected:** the depositor is live behind a proxy (`0xC9031f76006da0BD4bFa9E02aDf0d448dB3BC155`) at `solidity/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol`. `cross-chain/starknet/` is a **separate, independently-deployed package** with its own copy of this contract, its own deploy scripts, and its own mainnet deployment artifact — and #979's `03_upgrade_starknet_btc_depositor_to_968.ts` (`ALREADY_EXECUTED = false`, not yet broadcast) compiles `StarkNetBitcoinDepositor` from *that* tree, not from `solidity/`. Fixing only `solidity/` would have left the upgrade shipping the exact same `>=` bug. This PR now mirrors the identical `==` fix into `cross-chain/starknet/contracts/cross-chain/starknet/StarkNetBitcoinDepositor.sol` as well, so merging before the #968 upgrade broadcasts carries the real fix to mainnet as originally intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * StarkNet Bitcoin deposits now require the exact L1-to-L2 message fee.
  * Overpayments and underpayments are rejected with a consistent error message.
  * Prevents unrecoverable loss caused by sending excess bridging fees.

* **Tests**
  * Added coverage for deposits with excessive message fees.
  * Updated insufficient-fee validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

