### PR TITLE
fix(cross-chain): follow checks-effects-interactions in L1 depositor finalizeDeposit

### DIFF
--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -430,25 +430,37 @@ abstract contract AbstractL1BTCDepositor is
             tbtcAmount
         );
 
+        // Following the checks-effects-interactions pattern, the deferred
+        // gas reimbursement is read and deleted from storage before the
+        // external `_transferTbtc` call. The actual reimbursement payout
+        // happens after that call, as the last step of the deposit
+        // finalization.
+        GasReimbursement memory reimbursement;
+        if (address(reimbursementPool) != address(0)) {
+            reimbursement = gasReimbursements[depositKey];
+
+            if (reimbursement.receiver != address(0)) {
+                // slither-disable-next-line reentrancy-benign
+                delete gasReimbursements[depositKey];
+            }
+        }
+
         _transferTbtc(tbtcAmount, destinationChainDepositOwner);
 
         // `ReimbursementPool` calls the untrusted receiver address using a
         // low-level call. Reentrancy risk is mitigated by making sure that
-        // `ReimbursementPool.refund` is a non-reentrant function and executing
-        // reimbursements as the last step of the deposit finalization.
+        // `ReimbursementPool.refund` is a non-reentrant function, by deleting
+        // the deferred reimbursement from storage before the external
+        // `_transferTbtc` call (checks-effects-interactions), and by
+        // executing reimbursements as the last step of the deposit
+        // finalization.
         if (address(reimbursementPool) != address(0)) {
             // If there is a deferred reimbursement for this deposit
             // initialization, pay it out now. No need to check reimbursement
             // authorization for the initialization caller. If the deferred
             // reimbursement is here, that implies the caller was authorized
             // to receive it.
-            GasReimbursement memory reimbursement = gasReimbursements[
-                depositKey
-            ];
             if (reimbursement.receiver != address(0)) {
-                // slither-disable-next-line reentrancy-benign
-                delete gasReimbursements[depositKey];
-
                 reimbursementPool.refund(
                     reimbursement.gasSpent,
                     reimbursement.receiver

--- a/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
+++ b/solidity/contracts/cross-chain/AbstractL1BTCDepositor.sol
@@ -435,6 +435,7 @@ abstract contract AbstractL1BTCDepositor is
         // external `_transferTbtc` call. The actual reimbursement payout
         // happens after that call, as the last step of the deposit
         // finalization.
+        // slither-disable-next-line uninitialized-local
         GasReimbursement memory reimbursement;
         if (address(reimbursementPool) != address(0)) {
             reimbursement = gasReimbursements[depositKey];

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
@@ -464,20 +464,32 @@ contract L1BTCDepositorWormholeV2Arbitrum is
             tbtcAmount
         );
 
+        // Following the checks-effects-interactions pattern, the deferred
+        // gas reimbursement is read and deleted from storage before the
+        // external `_transferTbtc` call. The actual reimbursement payout
+        // happens after that call, as the last step of the deposit
+        // finalization.
+        GasReimbursement memory reimbursement;
+        if (address(reimbursementPool) != address(0)) {
+            reimbursement = gasReimbursements[depositKey];
+
+            if (reimbursement.receiver != address(0)) {
+                // slither-disable-next-line reentrancy-benign
+                delete gasReimbursements[depositKey];
+            }
+        }
+
         _transferTbtc(tbtcAmount, destinationChainDepositOwner);
 
         // `ReimbursementPool` calls the untrusted receiver address using a
         // low-level call. Reentrancy risk is mitigated by making sure that
-        // `ReimbursementPool.refund` is a non-reentrant function and executing
-        // reimbursements as the last step of the deposit finalization.
+        // `ReimbursementPool.refund` is a non-reentrant function, by deleting
+        // the deferred reimbursement from storage before the external
+        // `_transferTbtc` call (checks-effects-interactions), and by
+        // executing reimbursements as the last step of the deposit
+        // finalization.
         if (address(reimbursementPool) != address(0)) {
-            GasReimbursement memory reimbursement = gasReimbursements[
-                depositKey
-            ];
             if (reimbursement.receiver != address(0)) {
-                // slither-disable-next-line reentrancy-benign
-                delete gasReimbursements[depositKey];
-
                 reimbursementPool.refund(
                     reimbursement.gasSpent,
                     reimbursement.receiver

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Arbitrum.sol
@@ -469,6 +469,7 @@ contract L1BTCDepositorWormholeV2Arbitrum is
         // external `_transferTbtc` call. The actual reimbursement payout
         // happens after that call, as the last step of the deposit
         // finalization.
+        // slither-disable-next-line uninitialized-local
         GasReimbursement memory reimbursement;
         if (address(reimbursementPool) != address(0)) {
             reimbursement = gasReimbursements[depositKey];

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
@@ -460,20 +460,32 @@ contract L1BTCDepositorWormholeV2Base is
             tbtcAmount
         );
 
+        // Following the checks-effects-interactions pattern, the deferred
+        // gas reimbursement is read and deleted from storage before the
+        // external `_transferTbtc` call. The actual reimbursement payout
+        // happens after that call, as the last step of the deposit
+        // finalization.
+        GasReimbursement memory reimbursement;
+        if (address(reimbursementPool) != address(0)) {
+            reimbursement = gasReimbursements[depositKey];
+
+            if (reimbursement.receiver != address(0)) {
+                // slither-disable-next-line reentrancy-benign
+                delete gasReimbursements[depositKey];
+            }
+        }
+
         _transferTbtc(tbtcAmount, destinationChainDepositOwner);
 
         // `ReimbursementPool` calls the untrusted receiver address using a
         // low-level call. Reentrancy risk is mitigated by making sure that
-        // `ReimbursementPool.refund` is a non-reentrant function and executing
-        // reimbursements as the last step of the deposit finalization.
+        // `ReimbursementPool.refund` is a non-reentrant function, by deleting
+        // the deferred reimbursement from storage before the external
+        // `_transferTbtc` call (checks-effects-interactions), and by
+        // executing reimbursements as the last step of the deposit
+        // finalization.
         if (address(reimbursementPool) != address(0)) {
-            GasReimbursement memory reimbursement = gasReimbursements[
-                depositKey
-            ];
             if (reimbursement.receiver != address(0)) {
-                // slither-disable-next-line reentrancy-benign
-                delete gasReimbursements[depositKey];
-
                 reimbursementPool.refund(
                     reimbursement.gasSpent,
                     reimbursement.receiver

--- a/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
+++ b/solidity/contracts/cross-chain/wormhole/L1BTCDepositorWormholeV2Base.sol
@@ -465,6 +465,7 @@ contract L1BTCDepositorWormholeV2Base is
         // external `_transferTbtc` call. The actual reimbursement payout
         // happens after that call, as the last step of the deposit
         // finalization.
+        // slither-disable-next-line uninitialized-local
         GasReimbursement memory reimbursement;
         if (address(reimbursementPool) != address(0)) {
             reimbursement = gasReimbursements[depositKey];

--- a/solidity/contracts/test/TestL1BTCDepositor.sol
+++ b/solidity/contracts/test/TestL1BTCDepositor.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+import "../cross-chain/AbstractL1BTCDepositor.sol";
+
+/// @notice Test implementation of the `AbstractL1BTCDepositor` contract.
+///         Used to test the base contract logic in isolation from any
+///         specific bridging integration.
+contract TestL1BTCDepositor is AbstractL1BTCDepositor {
+    /// @notice Deposit key whose deferred gas reimbursement entry is
+    ///         inspected during the `_transferTbtc` call.
+    uint256 public trackedDepositKey;
+    /// @notice True if `gasReimbursements[trackedDepositKey]` was already
+    ///         cleared from storage at the time `_transferTbtc` executed.
+    bool public reimbursementClearedBeforeTransfer;
+
+    event TbtcTransferred(uint256 amount, bytes32 destinationChainReceiver);
+
+    function initialize(address _tbtcBridge, address _tbtcVault)
+        external
+        initializer
+    {
+        __AbstractL1BTCDepositor_initialize(_tbtcBridge, _tbtcVault);
+        __Ownable_init();
+    }
+
+    function setTrackedDepositKey(uint256 depositKey) external {
+        trackedDepositKey = depositKey;
+    }
+
+    function _transferTbtc(uint256 amount, bytes32 destinationChainReceiver)
+        internal
+        override
+    {
+        reimbursementClearedBeforeTransfer =
+            gasReimbursements[trackedDepositKey].receiver == address(0);
+
+        emit TbtcTransferred(amount, destinationChainReceiver);
+    }
+}

--- a/solidity/test/cross-chain/AbstractL1BTCDepositor.test.ts
+++ b/solidity/test/cross-chain/AbstractL1BTCDepositor.test.ts
@@ -1,0 +1,341 @@
+import { ethers, getUnnamedAccounts, helpers, waffle } from "hardhat"
+import chai, { expect } from "chai"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber, ContractTransaction } from "ethers"
+import {
+  IBridge,
+  ITBTCVault,
+  ReimbursementPool,
+  TestERC20,
+  TestL1BTCDepositor,
+} from "../../typechain"
+import type {
+  BitcoinTxInfoStruct,
+  DepositRevealInfoStruct,
+} from "../../typechain/L2BTCDepositorWormhole"
+import { to1ePrecision } from "../helpers/contract-test-helpers"
+
+chai.use(smock.matchers)
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime } = helpers.time
+
+// Just an arbitrary TBTCVault address.
+const tbtcVaultAddress = "0xB5679dE944A79732A75CE556191DF11F489448d5"
+
+type InitializeDepositFixture = {
+  // Deposit key built as keccak256(fundingTxHash, reveal.fundingOutputIndex)
+  depositKey: string
+  fundingTx: BitcoinTxInfoStruct
+  reveal: DepositRevealInfoStruct
+  destinationChainDepositOwner: string
+}
+
+// Fixture used for the initializeDeposit test scenario.
+const initializeDepositFixture: InitializeDepositFixture = {
+  depositKey:
+    "0x97a4104f4114ba56dde79d02c4e8296596c3259da60d0e53fa97170f7cf7258d",
+  fundingTx: {
+    version: "0x01000000",
+    inputVector:
+      "0x01dfe39760a5edabdab013114053d789ada21e356b59fea41d980396" +
+      "c1a4474fad0100000023220020e57edf10136b0434e46bc08c5ac5a1e4" +
+      "5f64f778a96f984d0051873c7a8240f2ffffffff",
+    outputVector:
+      "0x02804f1200000000002200202f601522e7bb1f7de5c56bdbd45590b3" +
+      "499bad09190581dcaa17e152d8f0c2a9b7e837000000000017a9148688" +
+      "4e6be1525dab5ae0b451bd2c72cee67dcf4187",
+    locktime: "0x00000000",
+  },
+  reveal: {
+    fundingOutputIndex: 0,
+    blindingFactor: "0xba863847d2d0fee3",
+    walletPubKeyHash: "0xf997563fee8610ca28f99ac05bd8a29506800d4d",
+    refundPubKeyHash: "0x7ac2d9378a1c47e589dfb8095ca95ed2140d2726",
+    refundLocktime: "0xde2b4c67",
+    vault: tbtcVaultAddress,
+  },
+  destinationChainDepositOwner:
+    "0x00000000000000000000000023b82a7108f9ceb34c3cdc44268be21d151d4124",
+}
+
+describe("AbstractL1BTCDepositor", () => {
+  const satoshiMultiplier = to1ePrecision(1, 10)
+  const depositAmount = BigNumber.from(100000)
+  const treasuryFee = BigNumber.from(500)
+  const optimisticMintingFeeDivisor = 20 // 5%
+  const depositTxMaxFee = BigNumber.from(1000)
+
+  // amountSubTreasury = (depositAmount - treasuryFee) * satoshiMultiplier = 99500 * 1e10
+  // omFee = amountSubTreasury / optimisticMintingFeeDivisor = 4975 * 1e10
+  // txMaxFee = depositTxMaxFee * satoshiMultiplier = 1000 * 1e10
+  // tbtcAmount = amountSubTreasury - omFee - txMaxFee = 93525 * 1e10
+  const expectedTbtcAmount = to1ePrecision(93525, 10)
+
+  const contractsFixture = async () => {
+    const { deployer, governance } = await helpers.signers.getNamedSigners()
+
+    const accounts = await getUnnamedAccounts()
+    const relayer = await ethers.getSigner(accounts[1])
+
+    const bridge = await smock.fake<IBridge>("IBridge")
+    const tbtcToken = await (
+      await ethers.getContractFactory("TestERC20")
+    ).deploy()
+    const tbtcVault = await smock.fake<ITBTCVault>("ITBTCVault", {
+      // The TBTCVault contract address must be known in advance and match
+      // the one used in initializeDeposit fixture. This is necessary to
+      // pass the vault address check in the initializeDeposit function.
+      address: tbtcVaultAddress,
+    })
+    // Attach the tbtcToken mock to the tbtcVault mock.
+    tbtcVault.tbtcToken.returns(tbtcToken.address)
+
+    const reimbursementPool = await smock.fake<ReimbursementPool>(
+      "ReimbursementPool"
+    )
+
+    const depositor = (await (
+      await ethers.getContractFactory("TestL1BTCDepositor", deployer)
+    ).deploy()) as TestL1BTCDepositor
+    await depositor
+      .connect(deployer)
+      .initialize(bridge.address, tbtcVault.address)
+    await depositor.connect(deployer).transferOwnership(governance.address)
+
+    return {
+      governance,
+      relayer,
+      bridge,
+      tbtcVault,
+      reimbursementPool,
+      depositor,
+    }
+  }
+
+  let governance: SignerWithAddress
+  let relayer: SignerWithAddress
+
+  let bridge: FakeContract<IBridge>
+  let tbtcVault: FakeContract<ITBTCVault>
+  let reimbursementPool: FakeContract<ReimbursementPool>
+  let depositor: TestL1BTCDepositor
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ governance, relayer, bridge, tbtcVault, reimbursementPool, depositor } =
+      await waffle.loadFixture(contractsFixture))
+  })
+
+  // Sets the Bridge and TBTCVault mocks to a state that allows finalizing
+  // the deposit from the fixture.
+  const allowFinalization = async () => {
+    // Set Bridge fees. Set only relevant fields.
+    bridge.depositParameters.returns({
+      depositDustThreshold: 0,
+      depositTreasuryFeeDivisor: 0,
+      depositTxMaxFee,
+      depositRevealAheadPeriod: 0,
+    })
+    tbtcVault.optimisticMintingFeeDivisor.returns(optimisticMintingFeeDivisor)
+
+    const revealedAt = (await lastBlockTime()) - 7200
+    const finalizedAt = await lastBlockTime()
+    bridge.deposits
+      .whenCalledWith(initializeDepositFixture.depositKey)
+      .returns({
+        depositor: depositor.address,
+        amount: depositAmount,
+        revealedAt,
+        vault: initializeDepositFixture.reveal.vault,
+        treasuryFee,
+        sweptAt: finalizedAt,
+        extraData: initializeDepositFixture.destinationChainDepositOwner,
+      })
+    tbtcVault.optimisticMintingRequests
+      .whenCalledWith(initializeDepositFixture.depositKey)
+      .returns([revealedAt, finalizedAt])
+  }
+
+  const resetFakes = () => {
+    reimbursementPool.maxGasPrice.reset()
+    reimbursementPool.staticGas.reset()
+    reimbursementPool.refund.reset()
+    bridge.depositParameters.reset()
+    tbtcVault.optimisticMintingFeeDivisor.reset()
+    bridge.revealDepositWithExtraData.reset()
+    bridge.deposits.reset()
+    tbtcVault.optimisticMintingRequests.reset()
+  }
+
+  describe("finalizeDeposit", () => {
+    context(
+      "when the reimbursement pool is set and a deferred gas reimbursement exists",
+      () => {
+        let initializeDepositGasSpent: BigNumber
+        let tx: ContractTransaction
+
+        before(async () => {
+          await createSnapshot()
+
+          // Use 1Gwei to make sure it's smaller than default gas price
+          // used by Hardhat (200 Gwei) and this value will be used
+          // for msgValueOffset calculation.
+          reimbursementPool.maxGasPrice.returns(BigNumber.from(1000000000))
+          reimbursementPool.staticGas.returns(10000) // Just an arbitrary value.
+
+          await depositor
+            .connect(governance)
+            .updateReimbursementPool(reimbursementPool.address)
+          await depositor
+            .connect(governance)
+            .updateReimbursementAuthorization(relayer.address, true)
+
+          await depositor
+            .connect(relayer)
+            .initializeDeposit(
+              initializeDepositFixture.fundingTx,
+              initializeDepositFixture.reveal,
+              initializeDepositFixture.destinationChainDepositOwner
+            )
+
+          // Capture the gas spent for the initializeDeposit call
+          // for post-finalization comparison.
+          initializeDepositGasSpent = (
+            await depositor.gasReimbursements(
+              initializeDepositFixture.depositKey
+            )
+          ).gasSpent
+
+          // Make the `_transferTbtc` override observe the deferred gas
+          // reimbursement entry of the finalized deposit.
+          await depositor.setTrackedDepositKey(
+            initializeDepositFixture.depositKey
+          )
+
+          await allowFinalization()
+
+          tx = await depositor
+            .connect(relayer)
+            .finalizeDeposit(initializeDepositFixture.depositKey)
+        })
+
+        after(async () => {
+          resetFakes()
+
+          await restoreSnapshot()
+        })
+
+        it("should transfer tBTC to the destination chain deposit owner", async () => {
+          await expect(tx)
+            .to.emit(depositor, "TbtcTransferred")
+            .withArgs(
+              expectedTbtcAmount,
+              initializeDepositFixture.destinationChainDepositOwner
+            )
+        })
+
+        it("should emit DepositFinalized event", async () => {
+          await expect(tx)
+            .to.emit(depositor, "DepositFinalized")
+            .withArgs(
+              initializeDepositFixture.depositKey,
+              initializeDepositFixture.destinationChainDepositOwner,
+              relayer.address,
+              depositAmount.mul(satoshiMultiplier),
+              expectedTbtcAmount
+            )
+        })
+
+        it("should clear the deferred gas reimbursement before the tBTC transfer", async () => {
+          // Checks-effects-interactions: the deferred gas reimbursement
+          // must be deleted from storage before the external
+          // `_transferTbtc` call is made.
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(await depositor.reimbursementClearedBeforeTransfer()).to.be
+            .true
+        })
+
+        it("should delete the deferred gas reimbursement from storage", async () => {
+          const gasReimbursement = await depositor.gasReimbursements(
+            initializeDepositFixture.depositKey
+          )
+
+          expect(gasReimbursement.receiver).to.equal(
+            ethers.constants.AddressZero
+          )
+          expect(gasReimbursement.gasSpent).to.equal(0)
+        })
+
+        it("should pay out proper reimbursements after the transfer", async () => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(reimbursementPool.refund).to.have.been.calledTwice
+
+          // First call is the deferred gas reimbursement for deposit
+          // initialization.
+          const firstCall = reimbursementPool.refund.getCall(0)
+          expect(firstCall.args[0]).to.equal(initializeDepositGasSpent)
+          expect(firstCall.args[1]).to.equal(relayer.address)
+
+          // Second call is the reimbursement for the deposit finalization.
+          const secondCall = reimbursementPool.refund.getCall(1)
+          expect(secondCall.args[1]).to.equal(relayer.address)
+        })
+      }
+    )
+
+    context("when the reimbursement pool is not set", () => {
+      before(async () => {
+        await createSnapshot()
+
+        // Record a deferred gas reimbursement upon initialization...
+        await depositor
+          .connect(governance)
+          .updateReimbursementPool(reimbursementPool.address)
+        await depositor
+          .connect(governance)
+          .updateReimbursementAuthorization(relayer.address, true)
+
+        await depositor
+          .connect(relayer)
+          .initializeDeposit(
+            initializeDepositFixture.fundingTx,
+            initializeDepositFixture.reveal,
+            initializeDepositFixture.destinationChainDepositOwner
+          )
+
+        // ...but detach the reimbursement pool before finalization.
+        await depositor
+          .connect(governance)
+          .updateReimbursementPool(ethers.constants.AddressZero)
+
+        await allowFinalization()
+
+        await depositor
+          .connect(relayer)
+          .finalizeDeposit(initializeDepositFixture.depositKey)
+      })
+
+      after(async () => {
+        resetFakes()
+
+        await restoreSnapshot()
+      })
+
+      it("should leave the deferred gas reimbursement in storage", async () => {
+        const gasReimbursement = await depositor.gasReimbursements(
+          initializeDepositFixture.depositKey
+        )
+
+        expect(gasReimbursement.receiver).to.equal(relayer.address)
+        expect(gasReimbursement.gasSpent.toNumber()).to.be.greaterThan(0)
+      })
+
+      it("should not call the reimbursement pool", async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        expect(reimbursementPool.refund).to.not.have.been.called
+      })
+    })
+  })
+})

--- a/solidity/test/cross-chain/AbstractL1BTCDepositor.test.ts
+++ b/solidity/test/cross-chain/AbstractL1BTCDepositor.test.ts
@@ -208,6 +208,10 @@ describe("AbstractL1BTCDepositor", () => {
             )
           ).gasSpent
 
+          // The deferred reimbursement entry must exist before finalization,
+          // otherwise the ordering assertions would pass vacuously.
+          expect(initializeDepositGasSpent).to.be.gt(0)
+
           // Make the `_transferTbtc` override observe the deferred gas
           // reimbursement entry of the finalized deposit.
           await depositor.setTrackedDepositKey(


### PR DESCRIPTION
Closes #885.

## What

`finalizeDeposit` deleted the deferred gas reimbursement entry (`delete gasReimbursements[depositKey]`) only **after** the external `_transferTbtc` call. This PR hoists the read + delete of the deferred reimbursement above `_transferTbtc`, so all state mutations happen before external interactions. The `reimbursementPool.refund` payouts still execute after the transfer, preserving the documented "reimbursements are the last step of finalization" invariant.

The same reordering is applied in the three places that carry the pattern:

- `AbstractL1BTCDepositor.finalizeDeposit` (the contract named in the issue)
- `L1BTCDepositorWormholeV2Arbitrum.finalizeDeposit` and `L1BTCDepositorWormholeV2Base.finalizeDeposit` — standalone contracts with a verbatim copy of the same ordering

## Deliberate scoping

- **No reentrancy guard added** (the issue's secondary suggestion): the L1 depositor contracts are live upgradeable proxies, and adding `ReentrancyGuardUpgradeable` would change the storage layout. The early `deposits[depositKey] = DepositState.Finalized` write already blocks same-key reentry into `finalizeDeposit`, so the CEI reorder closes the remaining gap without touching storage.
- **Behavior parity when the pool is unset**: the read/delete stays gated on `address(reimbursementPool) != address(0)`, exactly as before; a dedicated parity test covers the pool-detached case.
- This is defense-in-depth hardening, not a live exploit fix — the deposit-state guard is set before any external call.

## Testing

- New `solidity/test/cross-chain/AbstractL1BTCDepositor.test.ts` with a `TestL1BTCDepositor` stub whose `_transferTbtc` override observes the reimbursement storage slot. The ordering test **fails against the previous code** (verified by reverting only the contract change) and passes with the fix; the parity tests pass on both.
- Depositor test suite (Abstract + Wormhole + Ntt + V2 Arbitrum/Base + StarkNet + NativeBTC test files): 247 passing / 0 failing / 4 pending (pre-existing skips).
- `prettier` and `solhint` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxCWMXfUdFygLaGaS2SPhg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deposit finalization reliability by clearing deferred gas reimbursement records before transfers.
  * Strengthened reentrancy protection during cross-chain TBTC transfers.
  * Preserved reimbursement refunds while preventing stale records when the reimbursement service is unavailable.

* **Tests**
  * Added coverage for reimbursement clearing, refund payouts, transfer sequencing, and detached reimbursement services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->