### PR TITLE
build: pin @keep-network dist-tags instead of floating on `development`

### DIFF
--- a/cross-chain/optimism/package.json
+++ b/cross-chain/optimism/package.json
@@ -37,7 +37,7 @@
     "test": "hardhat test"
   },
   "dependencies": {
-    "@keep-network/tbtc-v2": "development",
+    "@keep-network/tbtc-v2": "1.4.0-dev.0",
     "@openzeppelin/contracts": "^4.8.1",
     "@openzeppelin/contracts-upgradeable": "^4.8.1"
   },

--- a/cross-chain/optimism/yarn.lock
+++ b/cross-chain/optimism/yarn.lock
@@ -773,7 +773,7 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/tbtc-v2@development":
+"@keep-network/tbtc-v2@1.4.0-dev.0":
   version "1.4.0-dev.0"
   resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.4.0-dev.0.tgz#3c3b40d36917ad3e35a4f64d4b45f64e6ce46b8a"
   integrity sha512-aOoo+WxgV8eR03z0vjstG7lX0q9B5K4VAi7GYT8lVO0uLErXpHawveNZKNnt+DBh4Sp1c3IZuF21EYJKKCLEyw==

--- a/cross-chain/polygon/package.json
+++ b/cross-chain/polygon/package.json
@@ -36,7 +36,7 @@
     "test": "hardhat test"
   },
   "dependencies": {
-    "@keep-network/tbtc-v2": "development",
+    "@keep-network/tbtc-v2": "1.4.0-dev.0",
     "@openzeppelin/contracts": "^4.8.1",
     "@openzeppelin/contracts-upgradeable": "^4.8.1"
   },

--- a/cross-chain/polygon/yarn.lock
+++ b/cross-chain/polygon/yarn.lock
@@ -773,7 +773,7 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/tbtc-v2@development":
+"@keep-network/tbtc-v2@1.4.0-dev.0":
   version "1.4.0-dev.0"
   resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.4.0-dev.0.tgz#3c3b40d36917ad3e35a4f64d4b45f64e6ce46b8a"
   integrity sha512-aOoo+WxgV8eR03z0vjstG7lX0q9B5K4VAi7GYT8lVO0uLErXpHawveNZKNnt+DBh4Sp1c3IZuF21EYJKKCLEyw==

--- a/cross-chain/starknet/package.json
+++ b/cross-chain/starknet/package.json
@@ -43,9 +43,9 @@
   },
   "dependencies": {
     "@keep-network/bitcoin-spv-sol": "3.4.0-solc-0.8",
-    "@keep-network/ecdsa": "development",
-    "@keep-network/random-beacon": "development",
-    "@keep-network/tbtc-v2": "development",
+    "@keep-network/ecdsa": "2.1.0-dev.19",
+    "@keep-network/random-beacon": "2.1.0-dev.18",
+    "@keep-network/tbtc-v2": "1.8.0-dev.1",
     "@openzeppelin/contracts": "^4.8.1",
     "@openzeppelin/contracts-upgradeable": "^4.8.1",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"

--- a/cross-chain/starknet/yarn.lock
+++ b/cross-chain/starknet/yarn.lock
@@ -741,7 +741,7 @@
   resolved "https://registry.yarnpkg.com/@keep-network/bitcoin-spv-sol/-/bitcoin-spv-sol-3.4.0-solc-0.8.tgz#8b44c246ffab8ea993efe196f6bf385b1a3b84dc"
   integrity sha512-KlpY9BbasyLvYXSS7dsJktgRChu/yjdFLOX8ldGA/pltLicCm/l0F4oqxL8wSws9XD12vq9x0B5qzPygVLB2TQ==
 
-"@keep-network/ecdsa@2.1.0-dev.19", "@keep-network/ecdsa@development":
+"@keep-network/ecdsa@2.1.0-dev.19":
   version "2.1.0-dev.19"
   resolved "https://registry.yarnpkg.com/@keep-network/ecdsa/-/ecdsa-2.1.0-dev.19.tgz#749af8bd65f70135d1734f7c5f9bff82ae308fdb"
   integrity sha512-cyqRqK/sOqyaXZWY/O9ij6EINQuJ+bHLMiuufOFyP5YCj4GCuNqOcCytGAZPT+mED/0J/xn0vm+fgiCBq/uJkQ==
@@ -791,7 +791,7 @@
     "@openzeppelin/upgrades" "^2.7.2"
     openzeppelin-solidity "2.3.0"
 
-"@keep-network/random-beacon@2.1.0-dev.18", "@keep-network/random-beacon@development":
+"@keep-network/random-beacon@2.1.0-dev.18":
   version "2.1.0-dev.18"
   resolved "https://registry.yarnpkg.com/@keep-network/random-beacon/-/random-beacon-2.1.0-dev.18.tgz#2647731eea35f931afb565988cc8d8cf6a34f6b7"
   integrity sha512-UrVq///+jqOLQ5k8/aFvD1ZUMvVe49iS81U8mDoi9A005FiQzKUK9QFKv3Z0h6joG4prF/hlABRTEQ1UA7tgRA==
@@ -816,7 +816,7 @@
     "@openzeppelin/contracts" "^4.3.2"
     "@thesis/solidity-contracts" "github:thesis/solidity-contracts#4985bcf"
 
-"@keep-network/tbtc-v2@development":
+"@keep-network/tbtc-v2@1.8.0-dev.1":
   version "1.8.0-dev.1"
   resolved "https://registry.yarnpkg.com/@keep-network/tbtc-v2/-/tbtc-v2-1.8.0-dev.1.tgz#e1c4903cb7f08532f4fec29891db30f1ff1cfb8d"
   integrity sha512-44bc3mkDBYuW2y/GfSIeiymxU/k5rheYMQ08HjjD0i9haqgHOOcjdutmKkKS2xU0Qge3OI4jAZ2VdCVG2a8wtA==

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@keep-network/bitcoin-spv-sol": "3.4.0-solc-0.8",
-    "@keep-network/ecdsa": "development",
-    "@keep-network/random-beacon": "development",
-    "@keep-network/tbtc": "development",
+    "@keep-network/ecdsa": "2.1.0-dev.19",
+    "@keep-network/random-beacon": "2.1.0-dev.18",
+    "@keep-network/tbtc": "1.1.2-dev.1",
     "@openzeppelin/contracts": "^4.8.1",
     "@openzeppelin/contracts-upgradeable": "^4.8.1",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"

--- a/solidity/yarn.lock
+++ b/solidity/yarn.lock
@@ -1906,7 +1906,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@keep-network/ecdsa@npm:development":
+"@keep-network/ecdsa@npm:2.1.0-dev.19":
   version: 2.1.0-dev.19
   resolution: "@keep-network/ecdsa@npm:2.1.0-dev.19"
   dependencies:
@@ -1977,7 +1977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@keep-network/random-beacon@npm:2.1.0-dev.18, @keep-network/random-beacon@npm:development":
+"@keep-network/random-beacon@npm:2.1.0-dev.18":
   version: 2.1.0-dev.18
   resolution: "@keep-network/random-beacon@npm:2.1.0-dev.18"
   dependencies:
@@ -2014,11 +2014,11 @@ __metadata:
   dependencies:
     "@defi-wonderland/smock": "npm:^2.3.4"
     "@keep-network/bitcoin-spv-sol": "npm:3.4.0-solc-0.8"
-    "@keep-network/ecdsa": "npm:development"
+    "@keep-network/ecdsa": "npm:2.1.0-dev.19"
     "@keep-network/hardhat-helpers": "npm:0.6.0-pre.18"
     "@keep-network/hardhat-local-networks-config": "npm:^0.1.0-pre.4"
-    "@keep-network/random-beacon": "npm:development"
-    "@keep-network/tbtc": "npm:development"
+    "@keep-network/random-beacon": "npm:2.1.0-dev.18"
+    "@keep-network/tbtc": "npm:1.1.2-dev.1"
     "@nomiclabs/hardhat-ethers": "npm:^2.0.6"
     "@nomiclabs/hardhat-etherscan": "npm:^3.1.0"
     "@nomiclabs/hardhat-waffle": "npm:^2.0.2"
@@ -2058,7 +2058,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@keep-network/tbtc@npm:development":
+"@keep-network/tbtc@npm:1.1.2-dev.1":
   version: 1.1.2-dev.1
   resolution: "@keep-network/tbtc@npm:1.1.2-dev.1"
   dependencies:

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -59,8 +59,8 @@
   "dependencies": {
     "@bitcoinerlab/secp256k1": "^1.0.5",
     "@coral-xyz/anchor": "0.28.0",
-    "@keep-network/ecdsa": "development",
-    "@keep-network/tbtc-v2": "development",
+    "@keep-network/ecdsa": "2.1.0-dev.19",
+    "@keep-network/tbtc-v2": "1.8.0-dev.1",
     "@mysten/sui": "1.34.0",
     "@solana/spl-token": "0.3.9",
     "@solana/web3.js": "~1.97.0",

--- a/typescript/yarn.lock
+++ b/typescript/yarn.lock
@@ -1517,7 +1517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@keep-network/ecdsa@npm:2.1.0-dev.19, @keep-network/ecdsa@npm:development":
+"@keep-network/ecdsa@npm:2.1.0-dev.19":
   version: 2.1.0-dev.19
   resolution: "@keep-network/ecdsa@npm:2.1.0-dev.19"
   dependencies:
@@ -1609,9 +1609,9 @@ __metadata:
     "@bitcoinerlab/secp256k1": "npm:^1.0.5"
     "@coral-xyz/anchor": "npm:0.28.0"
     "@ethersproject/providers": "npm:^5.7.2"
-    "@keep-network/ecdsa": "npm:development"
+    "@keep-network/ecdsa": "npm:2.1.0-dev.19"
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep"
-    "@keep-network/tbtc-v2": "npm:development"
+    "@keep-network/tbtc-v2": "npm:1.8.0-dev.1"
     "@mysten/sui": "npm:1.34.0"
     "@solana/spl-token": "npm:0.3.9"
     "@solana/web3.js": "npm:~1.97.0"
@@ -1653,7 +1653,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@keep-network/tbtc-v2@npm:development":
+"@keep-network/tbtc-v2@npm:1.8.0-dev.1":
   version: 1.8.0-dev.1
   resolution: "@keep-network/tbtc-v2@npm:1.8.0-dev.1"
   dependencies:


### PR DESCRIPTION
Ten dependency entries across five manifests declare a bare npm dist-tag rather
than a version:

```json
"@keep-network/ecdsa": "development",
"@keep-network/tbtc-v2": "development",
```

All ten are in `dependencies` — **runtime** — of packages that are themselves
published to npm. Anyone resolving them fresh gets whatever `development` points
at that day. In `solidity/` these artifacts also supply the contract ABIs and
deployment records that the deploy scripts read out of `node_modules`.

## This has already drifted

`cross-chain/optimism` and `cross-chain/polygon` lockfiles hold
`@keep-network/tbtc-v2@1.4.0-dev.0`. The tag today resolves to **1.8.0-dev.1** —
four minors apart. A fresh install of those packages already produces a
different tree than CI builds from.

## No dependency actually changes

Every entry is pinned to exactly what its own lockfile already resolved:

| manifest | pinned |
| --- | --- |
| `solidity` | ecdsa `2.1.0-dev.19`, random-beacon `2.1.0-dev.18`, tbtc `1.1.2-dev.1` |
| `typescript` | ecdsa `2.1.0-dev.19`, tbtc-v2 `1.8.0-dev.1` |
| `cross-chain/optimism`, `cross-chain/polygon` | tbtc-v2 `1.4.0-dev.0` |
| `cross-chain/starknet` | ecdsa `2.1.0-dev.19`, random-beacon `2.1.0-dev.18`, tbtc-v2 `1.8.0-dev.1` |

The `solidity/yarn.lock` diff is **descriptor renames only — no `resolution:`
lines change**, confirming the installed tree is byte-identical:

```
-"@keep-network/ecdsa@npm:development":
+"@keep-network/ecdsa@npm:2.1.0-dev.19":
```

Full solidity suite: **2949 passing, 0 failing**.

## Note

These are first-party packages, so tracking the dev line is entirely reasonable
— it just wants to happen through a version bump that lands in a commit, rather
than through a tag that moves underneath the manifest. If the intent is
continuous tracking, a Renovate/Dependabot rule bumping to an exact version
would preserve it without giving up reproducibility.