### PR TITLE
chore: mark stale treasury fee values as historical/test-only

### DIFF
--- a/solidity/deploy/14_set_deposit_parameters.ts
+++ b/solidity/deploy/14_set_deposit_parameters.ts
@@ -8,6 +8,13 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 
   deployments.log("setting initial deposit parameters")
 
+  // HISTORICAL NOTE: This mainnet-only script already ran at deployment time
+  // and set the deposit treasury fee divisor to 0 (fee disabled back then).
+  // It has since been superseded by governance actions and will not re-run
+  // on mainnet. Do not read the value below as the current configuration:
+  // as of TIP-109, the mainnet deposit and redemption treasury fee divisors
+  // are both 500 (20 bps). Always query Bridge.depositParameters() and
+  // Bridge.redemptionParameters() on-chain for current values.
   const depositTreasuryFeeDivisor = ethers.BigNumber.from("0")
 
   // We set the deposit reveal ahead period to 8 months and two weeks, assuming

--- a/solidity/test/fixtures/index.ts
+++ b/solidity/test/fixtures/index.ts
@@ -1,5 +1,11 @@
 import { to1ePrecision } from "../helpers/contract-test-helpers"
 
+// NOTE: These are test-only defaults mirroring the Bridge initializer values.
+// They intentionally do NOT track mainnet: Bridge parameters are governance
+// managed and have diverged. In particular, as of TIP-109 the mainnet deposit
+// and redemption treasury fee divisors are both 500 (20 bps), not the 2000
+// (5 bps) used below. Query Bridge.depositParameters() and
+// Bridge.redemptionParameters() on-chain for current values.
 export const constants = {
   unmintFee: to1ePrecision(1, 15), // 0.001
   depositDustThreshold: 1000000, // 1000000 satoshi = 0.01 BTC


### PR DESCRIPTION
## Motivation

Two places in the repo carry treasury fee values that are easy to misread as the current mainnet configuration:

- `solidity/deploy/14_set_deposit_parameters.ts` sets `depositTreasuryFeeDivisor = 0` — a historical mainnet-only action from deployment time, since superseded by governance
- `solidity/test/fixtures/index.ts` uses `2000` (5 bps) for both treasury fee divisors — test defaults mirroring the Bridge initializer

(The `Bridge` initializer itself also uses `2000`, but that block already carries an explicit "initial parameters, governance-managed" disclaimer, so it is left untouched.)

Current mainnet values, verified on-chain against `Bridge` at `0x5e4861a80B55f035D899f66772117F00FA0E8e7B`:

| Parameter | Value | Meaning |
| --- | --- | --- |
| `depositTreasuryFeeDivisor` | 500 | 20 bps |
| `redemptionTreasuryFeeDivisor` | 500 | 20 bps |
| `TBTCVault.optimisticMintingFeeDivisor` | 0 | OM fee off |

## Changes

Comment-only annotations at both locations stating that the values are historical/test-only, what the current mainnet values are (TIP-109: 500 = 20 bps for both divisors), and that `Bridge.depositParameters()` / `Bridge.redemptionParameters()` on-chain are the source of truth.

No behavior impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added historical context to deposit treasury fee configuration.
  * Clarified that current mainnet values are governance-managed and should be verified on-chain.
  * Documented that test fixture defaults may differ from mainnet settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->