### PR TITLE
draft: UTXO reservations — segregated custody with in-kind redemption

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -140,6 +140,8 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash
     );
 
+    event ReservedRedemptionVetoed(uint256 indexed reservationKey);
+
     event ReservationReanchored(
         uint256 indexed reservationKey,
         bytes20 indexed newWalletPubKeyHash,
@@ -904,6 +906,17 @@ contract Bridge is
         uint32[] calldata walletMembersIDs
     ) external {
         self.notifyReservedRedemptionTimeout(reservationKey, walletMembersIDs);
+    }
+
+    /// @notice Notifies that a pending reserved redemption was vetoed in the
+    ///         redemption watchtower. Detains the surrendered balance to the
+    ///         watchtower and returns the reservation to the Active state.
+    ///         See `Reservation.notifyReservedRedemptionVeto`.
+    /// @param reservationKey The key of the reservation with the vetoed
+    ///        redemption.
+    function notifyReservedRedemptionVeto(uint256 reservationKey) external {
+        // The caller is checked in the library function.
+        self.notifyReservedRedemptionVeto(reservationKey);
     }
 
     /// @notice Submits the moving funds target wallets commitment.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -140,6 +140,16 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash
     );
 
+    event ReservedRedemptionSettled(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    event ReservedRedemptionTimeoutSlashingSkipped(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
     event ReservedRedemptionVetoed(uint256 indexed reservationKey);
 
     event ReservationReanchored(
@@ -152,16 +162,21 @@ contract Bridge is
     event ReservationDissolved(
         uint256 indexed reservationKey,
         bytes20 indexed walletPubKeyHash,
-        bytes32 dissolutionTxHash
+        bytes32 dissolutionTxHash,
+        uint64 mintedAmount,
+        uint64 anchorAmount,
+        uint64 dissolutionFee
     );
 
     event ReservationParametersUpdated(
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -2256,6 +2271,12 @@ contract Bridge is
     ///        max fee in satoshis. It is the maximum amount of BTC
     ///        transaction fee that can be incurred by a single reservation
     ///        lifecycle transaction.
+    /// @param reservationDissolutionTxMaxFee New value of the dedicated
+    ///        cap on the BTC transaction fee for the dissolution shape
+    ///        (usually 2-in-1-out; 1-in-1-out when the wallet has no
+    ///        main UTXO yet); distinct from `reservationTxMaxFee` which
+    ///        caps the always-1-in-1-out anchor / re-anchor / redemption
+    ///        shapes.
     /// @param reservationTermSeconds New value of the reservation custody
     ///        term length in seconds.
     /// @param reservationGracePeriod New value of the reservation grace
@@ -2264,6 +2285,8 @@ contract Bridge is
     ///        satoshi locked under active reservations.
     /// @param maxReservationsPerWallet New cap on the number of active
     ///        reservations a single wallet can custody.
+    /// @param maxCumulativeReanchorFee New cap on the total satoshi a
+    ///        single reservation may lose across all re-anchor hops.
     /// @dev Requirements:
     ///      - The caller must be the governance,
     ///      - See `Reservation.updateReservationParameters` for parameter
@@ -2272,19 +2295,23 @@ contract Bridge is
         address reservationVault,
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     ) external onlyGovernance {
         self.updateReservationParameters(
             reservationVault,
             reservationMinAmount,
             reservationTxMaxFee,
+            reservationDissolutionTxMaxFee,
             reservationTermSeconds,
             reservationGracePeriod,
             reservationMaxTotalAmount,
-            maxReservationsPerWallet
+            maxReservationsPerWallet,
+            maxCumulativeReanchorFee
         );
     }
 
@@ -2308,20 +2335,24 @@ contract Bridge is
             address reservationVault,
             uint64 reservationMinAmount,
             uint64 reservationTxMaxFee,
+            uint64 reservationDissolutionTxMaxFee,
             uint32 reservationTermSeconds,
             uint32 reservationGracePeriod,
             uint64 reservationMaxTotalAmount,
             uint64 reservationTotalAmount,
-            uint32 maxReservationsPerWallet
+            uint32 maxReservationsPerWallet,
+            uint64 maxCumulativeReanchorFee
         )
     {
         reservationVault = self.reservationVault;
         reservationMinAmount = self.reservationMinAmount;
         reservationTxMaxFee = self.reservationTxMaxFee;
+        reservationDissolutionTxMaxFee = self.reservationDissolutionTxMaxFee;
         reservationTermSeconds = self.reservationTermSeconds;
         reservationGracePeriod = self.reservationGracePeriod;
         reservationMaxTotalAmount = self.reservationMaxTotalAmount;
         reservationTotalAmount = self.reservationTotalAmount;
         maxReservationsPerWallet = self.maxReservationsPerWallet;
+        maxCumulativeReanchorFee = self.maxCumulativeReanchorFee;
     }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -27,6 +27,7 @@ import "./BridgeState.sol";
 import "./Deposit.sol";
 import "./DepositSweep.sol";
 import "./Redemption.sol";
+import "./Reservation.sol";
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./Wallets.sol";
@@ -67,6 +68,7 @@ contract Bridge is
     using Deposit for BridgeState.Storage;
     using DepositSweep for BridgeState.Storage;
     using Redemption for BridgeState.Storage;
+    using Reservation for BridgeState.Storage;
     using MovingFunds for BridgeState.Storage;
     using Wallets for BridgeState.Storage;
     using Fraud for BridgeState.Storage;
@@ -105,6 +107,62 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript
     );
+
+    event ReservationAccepted(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        address indexed owner,
+        bytes32 anchorTxHash,
+        uint64 anchorAmount,
+        uint32 expiresAt
+    );
+
+    event ReservationExtended(
+        uint256 indexed reservationKey,
+        uint32 newExpiresAt
+    );
+
+    event ReservedRedemptionRequested(
+        uint256 indexed reservationKey,
+        address indexed redeemer,
+        bytes redeemerOutputScript,
+        uint64 mintedAmount,
+        uint64 txMaxFee
+    );
+
+    event ReservedRedemptionCompleted(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    event ReservedRedemptionTimedOut(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
+    event ReservationReanchored(
+        uint256 indexed reservationKey,
+        bytes20 indexed newWalletPubKeyHash,
+        bytes32 newAnchorTxHash,
+        uint64 newAnchorAmount
+    );
+
+    event ReservationDissolved(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        bytes32 dissolutionTxHash
+    );
+
+    event ReservationParametersUpdated(
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    );
+
+    event ReservationVaultUpdated(address reservationVault);
 
     event WalletMovingFunds(
         bytes32 indexed ecdsaWalletID,
@@ -764,6 +822,88 @@ contract Bridge is
             walletMembersIDs,
             redeemerOutputScript
         );
+    }
+
+    /// @notice Single entry point for all reservation lifecycle SPV proofs:
+    ///         anchor acceptance, in-kind reserved redemption, re-anchoring
+    ///         and dissolution. Consolidated into one external function to
+    ///         preserve the Bridge's EIP-170 deployment size margin. See
+    ///         `Reservation.submitReservationProof` and the individual
+    ///         handlers in the `Reservation` library for detailed
+    ///         requirements.
+    /// @param proofType The type of the submitted proof, see
+    ///        `Reservation.ProofType`.
+    /// @param txInfo Bitcoin transaction data.
+    /// @param proof Bitcoin proof data.
+    /// @param mainUtxo Data of the wallet's main UTXO; only used for
+    ///        `Dissolution` proofs and ignored otherwise.
+    /// @param reservationKey The key of the target reservation; ignored for
+    ///        `Acceptance` proofs where the key is derived from the spent
+    ///        deposit outpoint.
+    function submitReservationProof(
+        uint8 proofType,
+        BitcoinTx.Info calldata txInfo,
+        BitcoinTx.Proof calldata proof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey
+    ) external onlySpvMaintainer {
+        self.submitReservationProof(
+            proofType,
+            txInfo,
+            proof,
+            mainUtxo,
+            reservationKey
+        );
+    }
+
+    /// @notice Extends the custody term of a reservation by the current
+    ///         reservation term length. Can only be called by the
+    ///         reservation vault, which collects the custody fee for the
+    ///         extension. See `Reservation.extendReservation`.
+    /// @param reservationKey The key of the reservation to extend.
+    function extendReservation(uint256 reservationKey) external {
+        // The caller is checked in the library function.
+        self.extendReservation(reservationKey);
+    }
+
+    /// @notice Requests an in-kind redemption of a reservation: the wallet
+    ///         is expected to spend exactly the reservation's current anchor
+    ///         outpoint to the redeemer output script in a 1-input-1-output
+    ///         transaction. Can only be called by the reservation vault,
+    ///         which must have approved the Bridge in the Bank for the gross
+    ///         minted amount. See `Reservation.requestReservedRedemption`.
+    /// @param reservationKey The key of the reservation to redeem.
+    /// @param redeemer The address able to claim the surrendered balance
+    ///        back if the redemption times out.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    function requestReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript
+    ) external {
+        // The caller is checked in the library function.
+        self.requestReservedRedemption(
+            reservationKey,
+            redeemer,
+            redeemerOutputScript
+        );
+    }
+
+    /// @notice Notifies that a pending reserved redemption has timed out.
+    ///         Returns the surrendered balance to the redeemer, slashes the
+    ///         wallet operators like a regular redemption timeout, and
+    ///         returns the reservation to the Active state. See
+    ///         `Reservation.notifyReservedRedemptionTimeout`.
+    /// @param reservationKey The key of the reservation with the timed out
+    ///        redemption.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members.
+    function notifyReservedRedemptionTimeout(
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        self.notifyReservedRedemptionTimeout(reservationKey, walletMembersIDs);
     }
 
     /// @notice Submits the moving funds target wallets commitment.
@@ -2079,5 +2219,61 @@ contract Bridge is
     ) external {
         // The caller is checked in the internal function.
         self.notifyRedemptionVeto(walletPubKeyHash, redeemerOutputScript);
+    }
+
+    /// @notice Updates parameters of reservations, including the
+    ///         reservation vault address. Deposits revealed with the
+    ///         reservation vault address are treated as UTXO reservations.
+    /// @param reservationVault Address of the reservation vault. Can only be
+    ///        changed while there are no active reservations.
+    /// @param reservationMinAmount New value of the reservation minimum
+    ///        amount in satoshis. It is the minimal anchor output amount
+    ///        accepted for a reservation.
+    /// @param reservationTxMaxFee New value of the reservation transaction
+    ///        max fee in satoshis. It is the maximum amount of BTC
+    ///        transaction fee that can be incurred by a single reservation
+    ///        lifecycle transaction.
+    /// @param reservationTermSeconds New value of the reservation custody
+    ///        term length in seconds.
+    /// @param reservationGracePeriod New value of the reservation grace
+    ///        period in seconds.
+    /// @param reservationMaxTotalAmount New cap on the total amount in
+    ///        satoshi locked under active reservations.
+    /// @param maxReservationsPerWallet New cap on the number of active
+    ///        reservations a single wallet can custody.
+    /// @dev Requirements:
+    ///      - The caller must be the governance,
+    ///      - See `Reservation.updateReservationParameters` for parameter
+    ///        requirements.
+    function updateReservationParameters(
+        address reservationVault,
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    ) external onlyGovernance {
+        self.updateReservationParameters(
+            reservationVault,
+            reservationMinAmount,
+            reservationTxMaxFee,
+            reservationTermSeconds,
+            reservationGracePeriod,
+            reservationMaxTotalAmount,
+            maxReservationsPerWallet
+        );
+    }
+
+    /// @notice Collection of all reservations indexed by the deposit key of
+    ///         the underlying reserved deposit, i.e.
+    ///         `keccak256(fundingTxHash | fundingOutputIndex)`.
+    /// @param reservationKey The key of the reservation.
+    function reservations(uint256 reservationKey)
+        external
+        view
+        returns (Reservation.ReservationRequest memory)
+    {
+        return self.reservations[reservationKey];
     }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -1778,6 +1778,16 @@ contract Bridge is
         return self.deposits[depositKey];
     }
 
+    /// @notice Returns whether the deposit was routed to the reservation
+    ///         vault that was configured at reveal time.
+    function isReservedDeposit(uint256 depositKey)
+        external
+        view
+        returns (bool)
+    {
+        return self.pendingReservedDeposit[depositKey].isReserved;
+    }
+
     /// @notice Collection of all pending redemption requests indexed by
     ///         redemption key built as
     ///         `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -894,16 +894,21 @@ contract Bridge is
     ///        back if the redemption times out.
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param isRetry True for a fee-free retry via
+    ///        `ReservationVault.retryRedeemReservation`; false for a fresh
+    ///        `redeemReservation` call.
     function requestReservedRedemption(
         uint256 reservationKey,
         address redeemer,
-        bytes calldata redeemerOutputScript
+        bytes calldata redeemerOutputScript,
+        bool isRetry
     ) external {
         // The caller is checked in the library function.
         self.requestReservedRedemption(
             reservationKey,
             redeemer,
-            redeemerOutputScript
+            redeemerOutputScript,
+            isRetry
         );
     }
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -2289,4 +2289,29 @@ contract Bridge is
     {
         return self.reservations[reservationKey];
     }
+
+    /// @notice Returns the current values of Bridge reservation parameters.
+    function reservationParameters()
+        external
+        view
+        returns (
+            address reservationVault,
+            uint64 reservationMinAmount,
+            uint64 reservationTxMaxFee,
+            uint32 reservationTermSeconds,
+            uint32 reservationGracePeriod,
+            uint64 reservationMaxTotalAmount,
+            uint64 reservationTotalAmount,
+            uint32 maxReservationsPerWallet
+        )
+    {
+        reservationVault = self.reservationVault;
+        reservationMinAmount = self.reservationMinAmount;
+        reservationTxMaxFee = self.reservationTxMaxFee;
+        reservationTermSeconds = self.reservationTermSeconds;
+        reservationGracePeriod = self.reservationGracePeriod;
+        reservationMaxTotalAmount = self.reservationMaxTotalAmount;
+        reservationTotalAmount = self.reservationTotalAmount;
+        maxReservationsPerWallet = self.maxReservationsPerWallet;
+    }
 }

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -290,6 +290,17 @@ contract BridgeGovernance is Ownable {
     event TreasuryUpdateStarted(address newTreasury, uint256 timestamp);
     event TreasuryUpdated(address treasury);
 
+    event ReservationParametersUpdateStarted(
+        address newReservationVault,
+        uint64 newReservationMinAmount,
+        uint64 newReservationTxMaxFee,
+        uint32 newReservationTermSeconds,
+        uint32 newReservationGracePeriod,
+        uint64 newReservationMaxTotalAmount,
+        uint32 newMaxReservationsPerWallet,
+        uint256 timestamp
+    );
+
     constructor(Bridge _bridge, uint256 _governanceDelay) {
         bridge = _bridge;
         governanceDelays[0] = _governanceDelay;

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -294,10 +294,12 @@ contract BridgeGovernance is Ownable {
         address newReservationVault,
         uint64 newReservationMinAmount,
         uint64 newReservationTxMaxFee,
+        uint64 newReservationDissolutionTxMaxFee,
         uint32 newReservationTermSeconds,
         uint32 newReservationGracePeriod,
         uint64 newReservationMaxTotalAmount,
         uint32 newMaxReservationsPerWallet,
+        uint64 newMaxCumulativeReanchorFee,
         uint256 timestamp
     );
 
@@ -1830,19 +1832,23 @@ contract BridgeGovernance is Ownable {
         address _newReservationVault,
         uint64 _newReservationMinAmount,
         uint64 _newReservationTxMaxFee,
+        uint64 _newReservationDissolutionTxMaxFee,
         uint32 _newReservationTermSeconds,
         uint32 _newReservationGracePeriod,
         uint64 _newReservationMaxTotalAmount,
-        uint32 _newMaxReservationsPerWallet
+        uint32 _newMaxReservationsPerWallet,
+        uint64 _newMaxCumulativeReanchorFee
     ) external onlyOwner {
         reservationData.beginReservationParametersUpdate(
             _newReservationVault,
             _newReservationMinAmount,
             _newReservationTxMaxFee,
+            _newReservationDissolutionTxMaxFee,
             _newReservationTermSeconds,
             _newReservationGracePeriod,
             _newReservationMaxTotalAmount,
-            _newMaxReservationsPerWallet
+            _newMaxReservationsPerWallet,
+            _newMaxCumulativeReanchorFee
         );
     }
 
@@ -1857,10 +1863,12 @@ contract BridgeGovernance is Ownable {
             staged.newReservationVault,
             staged.newReservationMinAmount,
             staged.newReservationTxMaxFee,
+            staged.newReservationDissolutionTxMaxFee,
             staged.newReservationTermSeconds,
             staged.newReservationGracePeriod,
             staged.newReservationMaxTotalAmount,
-            staged.newMaxReservationsPerWallet
+            staged.newMaxReservationsPerWallet,
+            staged.newMaxCumulativeReanchorFee
         );
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -32,6 +32,7 @@ contract BridgeGovernance is Ownable {
     using BridgeGovernanceParameters for BridgeGovernanceParameters.WalletData;
     using BridgeGovernanceParameters for BridgeGovernanceParameters.FraudData;
     using BridgeGovernanceParameters for BridgeGovernanceParameters.TreasuryData;
+    using BridgeGovernanceParameters for BridgeGovernanceParameters.ReservationData;
 
     BridgeGovernanceParameters.DepositData internal depositData;
     BridgeGovernanceParameters.RedemptionData internal redemptionData;
@@ -39,6 +40,7 @@ contract BridgeGovernance is Ownable {
     BridgeGovernanceParameters.WalletData internal walletData;
     BridgeGovernanceParameters.FraudData internal fraudData;
     BridgeGovernanceParameters.TreasuryData internal treasuryData;
+    BridgeGovernanceParameters.ReservationData internal reservationData;
 
     Bridge internal bridge;
 
@@ -1806,5 +1808,48 @@ contract BridgeGovernance is Ownable {
     ///         rebate staking configuration, this call will revert.
     function setRebateStaking(address rebateStaking) external onlyOwner {
         bridge.setRebateStaking(rebateStaking);
+    }
+
+    /// @notice Begins the reservation parameters update process. All
+    ///         reservation parameters (including the reservation vault) are
+    ///         staged together since they are applied atomically via a
+    ///         single Bridge call.
+    /// @dev Can be called only by the contract owner.
+    function beginReservationParametersUpdate(
+        address _newReservationVault,
+        uint64 _newReservationMinAmount,
+        uint64 _newReservationTxMaxFee,
+        uint32 _newReservationTermSeconds,
+        uint32 _newReservationGracePeriod,
+        uint64 _newReservationMaxTotalAmount,
+        uint32 _newMaxReservationsPerWallet
+    ) external onlyOwner {
+        reservationData.beginReservationParametersUpdate(
+            _newReservationVault,
+            _newReservationMinAmount,
+            _newReservationTxMaxFee,
+            _newReservationTermSeconds,
+            _newReservationGracePeriod,
+            _newReservationMaxTotalAmount,
+            _newMaxReservationsPerWallet
+        );
+    }
+
+    /// @notice Finalizes the reservation parameters update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeReservationParametersUpdate() external onlyOwner {
+        BridgeGovernanceParameters.ReservationData
+            memory staged = reservationData;
+        reservationData.finalizeReservationParametersUpdate(governanceDelay());
+        bridge.updateReservationParameters(
+            staged.newReservationVault,
+            staged.newReservationMinAmount,
+            staged.newReservationTxMaxFee,
+            staged.newReservationTermSeconds,
+            staged.newReservationGracePeriod,
+            staged.newReservationMaxTotalAmount,
+            staged.newMaxReservationsPerWallet
+        );
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -1571,4 +1571,78 @@ library BridgeGovernanceParameters {
         self.newTreasury = address(0);
         self.treasuryChangeInitiated = 0;
     }
+
+    struct ReservationData {
+        address newReservationVault;
+        uint64 newReservationMinAmount;
+        uint64 newReservationTxMaxFee;
+        uint32 newReservationTermSeconds;
+        uint32 newReservationGracePeriod;
+        uint64 newReservationMaxTotalAmount;
+        uint32 newMaxReservationsPerWallet;
+        uint256 reservationParametersChangeInitiated;
+    }
+
+    event ReservationParametersUpdateStarted(
+        address newReservationVault,
+        uint64 newReservationMinAmount,
+        uint64 newReservationTxMaxFee,
+        uint32 newReservationTermSeconds,
+        uint32 newReservationGracePeriod,
+        uint64 newReservationMaxTotalAmount,
+        uint32 newMaxReservationsPerWallet,
+        uint256 timestamp
+    );
+
+    /// @notice Begins the reservation parameters update process. All
+    ///         reservation parameters are staged together since they are
+    ///         applied atomically via a single Bridge call.
+    function beginReservationParametersUpdate(
+        ReservationData storage self,
+        address _newReservationVault,
+        uint64 _newReservationMinAmount,
+        uint64 _newReservationTxMaxFee,
+        uint32 _newReservationTermSeconds,
+        uint32 _newReservationGracePeriod,
+        uint64 _newReservationMaxTotalAmount,
+        uint32 _newMaxReservationsPerWallet
+    ) external {
+        /* solhint-disable not-rely-on-time */
+        self.newReservationVault = _newReservationVault;
+        self.newReservationMinAmount = _newReservationMinAmount;
+        self.newReservationTxMaxFee = _newReservationTxMaxFee;
+        self.newReservationTermSeconds = _newReservationTermSeconds;
+        self.newReservationGracePeriod = _newReservationGracePeriod;
+        self.newReservationMaxTotalAmount = _newReservationMaxTotalAmount;
+        self.newMaxReservationsPerWallet = _newMaxReservationsPerWallet;
+        self.reservationParametersChangeInitiated = block.timestamp;
+        emit ReservationParametersUpdateStarted(
+            _newReservationVault,
+            _newReservationMinAmount,
+            _newReservationTxMaxFee,
+            _newReservationTermSeconds,
+            _newReservationGracePeriod,
+            _newReservationMaxTotalAmount,
+            _newMaxReservationsPerWallet,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the reservation parameters update process.
+    /// @dev The staged values are read by the caller before this call; this
+    ///      function only enforces the governance delay and clears the
+    ///      staged change.
+    function finalizeReservationParametersUpdate(
+        ReservationData storage self,
+        uint256 governanceDelay
+    )
+        external
+        onlyAfterGovernanceDelay(
+            self.reservationParametersChangeInitiated,
+            governanceDelay
+        )
+    {
+        self.reservationParametersChangeInitiated = 0;
+    }
 }

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -1576,10 +1576,12 @@ library BridgeGovernanceParameters {
         address newReservationVault;
         uint64 newReservationMinAmount;
         uint64 newReservationTxMaxFee;
+        uint64 newReservationDissolutionTxMaxFee;
         uint32 newReservationTermSeconds;
         uint32 newReservationGracePeriod;
         uint64 newReservationMaxTotalAmount;
         uint32 newMaxReservationsPerWallet;
+        uint64 newMaxCumulativeReanchorFee;
         uint256 reservationParametersChangeInitiated;
     }
 
@@ -1587,10 +1589,12 @@ library BridgeGovernanceParameters {
         address newReservationVault,
         uint64 newReservationMinAmount,
         uint64 newReservationTxMaxFee,
+        uint64 newReservationDissolutionTxMaxFee,
         uint32 newReservationTermSeconds,
         uint32 newReservationGracePeriod,
         uint64 newReservationMaxTotalAmount,
         uint32 newMaxReservationsPerWallet,
+        uint64 newMaxCumulativeReanchorFee,
         uint256 timestamp
     );
 
@@ -1602,28 +1606,35 @@ library BridgeGovernanceParameters {
         address _newReservationVault,
         uint64 _newReservationMinAmount,
         uint64 _newReservationTxMaxFee,
+        uint64 _newReservationDissolutionTxMaxFee,
         uint32 _newReservationTermSeconds,
         uint32 _newReservationGracePeriod,
         uint64 _newReservationMaxTotalAmount,
-        uint32 _newMaxReservationsPerWallet
+        uint32 _newMaxReservationsPerWallet,
+        uint64 _newMaxCumulativeReanchorFee
     ) external {
         /* solhint-disable not-rely-on-time */
         self.newReservationVault = _newReservationVault;
         self.newReservationMinAmount = _newReservationMinAmount;
         self.newReservationTxMaxFee = _newReservationTxMaxFee;
+        self
+            .newReservationDissolutionTxMaxFee = _newReservationDissolutionTxMaxFee;
         self.newReservationTermSeconds = _newReservationTermSeconds;
         self.newReservationGracePeriod = _newReservationGracePeriod;
         self.newReservationMaxTotalAmount = _newReservationMaxTotalAmount;
         self.newMaxReservationsPerWallet = _newMaxReservationsPerWallet;
+        self.newMaxCumulativeReanchorFee = _newMaxCumulativeReanchorFee;
         self.reservationParametersChangeInitiated = block.timestamp;
         emit ReservationParametersUpdateStarted(
             _newReservationVault,
             _newReservationMinAmount,
             _newReservationTxMaxFee,
+            _newReservationDissolutionTxMaxFee,
             _newReservationTermSeconds,
             _newReservationGracePeriod,
             _newReservationMaxTotalAmount,
             _newMaxReservationsPerWallet,
+            _newMaxCumulativeReanchorFee,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
@@ -1632,7 +1643,7 @@ library BridgeGovernanceParameters {
     /// @notice Finalizes the reservation parameters update process.
     /// @dev The staged values are read by the caller before this call; this
     ///      function only enforces the governance delay and clears the
-    ///      staged change.
+    ///      staged change along with all staged reservation parameters.
     function finalizeReservationParametersUpdate(
         ReservationData storage self,
         uint256 governanceDelay
@@ -1643,6 +1654,15 @@ library BridgeGovernanceParameters {
             governanceDelay
         )
     {
+        self.newReservationVault = address(0);
+        self.newReservationMinAmount = 0;
+        self.newReservationTxMaxFee = 0;
+        self.newReservationDissolutionTxMaxFee = 0;
+        self.newReservationTermSeconds = 0;
+        self.newReservationGracePeriod = 0;
+        self.newReservationMaxTotalAmount = 0;
+        self.newMaxReservationsPerWallet = 0;
+        self.newMaxCumulativeReanchorFee = 0;
         self.reservationParametersChangeInitiated = 0;
     }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -21,6 +21,7 @@ import "@keep-network/random-beacon/contracts/ReimbursementPool.sol";
 import "./IRelay.sol";
 import "./Deposit.sol";
 import "./Redemption.sol";
+import "./Reservation.sol";
 import "./Fraud.sol";
 import "./Wallets.sol";
 import "./MovingFunds.sol";
@@ -325,6 +326,46 @@ library BridgeState {
         // governance wiring; changing it afterwards requires a dedicated
         // upgrade path of the Bridge implementation.
         address rebateStaking;
+        // The minimal anchor output amount in satoshi accepted for a
+        // reservation. Deposits revealed with `reservationVault` as their
+        // vault are treated as UTXO reservations: they are anchored by the
+        // wallet in a 1-input-1-output spend instead of being swept, and
+        // are redeemable in-kind. See the `Reservation` library for details.
+        uint64 reservationMinAmount;
+        // The custody term length in seconds applied to new and extended
+        // reservations. The term is a contract-layer fact only; anchor
+        // outputs carry no timelock.
+        uint32 reservationTermSeconds;
+        // Address of the reservation vault. Deposits revealed with this
+        // vault address are treated as UTXO reservations.
+        address reservationVault;
+        // Maximum amount of BTC transaction fee in satoshi that can be
+        // incurred by a single reservation lifecycle transaction (anchor,
+        // re-anchor, reserved redemption, dissolution).
+        uint64 reservationTxMaxFee;
+        // The grace period in seconds after a reservation's custody term
+        // expires during which the reservation can still be extended or
+        // redeemed but not yet dissolved.
+        uint32 reservationGracePeriod;
+        // Maximum total amount in satoshi that can be locked under active
+        // reservations at the same time.
+        uint64 reservationMaxTotalAmount;
+        // Current total amount in satoshi locked under active reservations
+        // (sum of current anchor output values).
+        uint64 reservationTotalAmount;
+        // Maximum number of active reservations a single wallet can custody.
+        uint32 maxReservationsPerWallet;
+        // Collection of all reservations indexed by the deposit key of the
+        // underlying reserved deposit, i.e.
+        // `keccak256(fundingTxHash | fundingOutputIndex)`.
+        mapping(uint256 => Reservation.ReservationRequest) reservations;
+        // Maps the UTXO key of a reservation's current anchor outpoint,
+        // built as `keccak256(anchorTxHash | anchorTxOutputIndex)`, to the
+        // reservation key.
+        mapping(uint256 => uint256) reservationsByAnchorUtxo;
+        // The number of active reservations custodied by the given wallet,
+        // identified by its 20-byte wallet public key hash.
+        mapping(bytes20 => uint32) walletReservationsCount;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -332,7 +373,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[48] __gap;
+        uint256[43] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -29,23 +29,47 @@ import "./MovingFunds.sol";
 import "../bank/Bank.sol";
 
 library BridgeState {
-    /// @notice Reveal-time facts for a deposit routed to the reservation
-    ///         vault. All fields fit in one storage word. `isReserved` is
-    ///         permanent; the remaining fields are used by the reservation
-    ///         action flow and may be cleared after acceptance or staleness.
+    /// @notice Reveal-time fact for a deposit routed to the reservation
+    ///         vault: whether it was classified as a reserved deposit at
+    ///         reveal time. This classification is permanent and does not
+    ///         track any later reservation-vault or wallet changes. Note
+    ///         this only governs sweep eligibility: if the reservation
+    ///         vault address is later changed by governance before this
+    ///         deposit's anchor is accepted, `Reservation
+    ///         .submitReservationAcceptanceProof` still credits the
+    ///         owner's balance through the *current* reservation vault at
+    ///         acceptance time, not the vault set when the deposit was
+    ///         revealed.
     struct PendingReservedDeposit {
         // Immutable reveal-time reservation classification.
         bool isReserved;
-        // Wallet committed by the deposit script and therefore the only
-        // wallet that can be authorized to anchor the deposit.
-        bytes20 walletPubKeyHash;
-        // Exact Bitcoin refund locktime validated at reveal time. Zero is a
-        // valid value when reveal-ahead validation was disabled.
-        uint32 refundDeadline;
-        // Whether the refund deadline was validated against a nonzero
-        // reveal-ahead period. This preserves the disabled validation mode
-        // without overloading a valid zero locktime.
-        bool refundDeadlineValidated;
+    }
+
+    /// @notice Terminal settlement record for a reserved redemption whose
+    ///         request timed out or was vetoed before its Bitcoin
+    ///         transaction could be proven. The redeemer was already
+    ///         refunded when this record was written; a later proof of the
+    ///         exact settled anchor spend is acknowledged (its outpoint
+    ///         marked spent) without moving any further balance. Mirrors
+    ///         the pooled redemption path's `timedOutRedemptions` record.
+    struct ReservedRedemptionSettlement {
+        // Hash of the Bitcoin transaction holding the anchor output that
+        // was pending redemption when the settlement was recorded. The
+        // anchor output index is always 0 (anchor transactions have a
+        // single output throughout a reservation's lifecycle) so it is
+        // not separately stored here. Zero when no settlement is
+        // pending -- a real anchor transaction's double-SHA256 hash is
+        // never all-zero in practice, so this field doubles as the
+        // "is a settlement pending" sentinel instead of a separate
+        // `bool`.
+        bytes32 anchorTxHash;
+        // keccak256 hash of the length-prefixed redeemer output script
+        // the settled redemption must pay to, snapshotted from the
+        // reservation at settlement-record time. A late-arriving proof
+        // must pay this exact script; without this check a wallet could
+        // redirect the settled anchor's spend to an address it controls
+        // and still have the proof accepted as a valid settlement.
+        bytes32 redeemerOutputScriptHash;
     }
 
     struct Storage {
@@ -360,8 +384,16 @@ library BridgeState {
         address reservationVault;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation lifecycle transaction (anchor,
-        // re-anchor, reserved redemption, dissolution).
+        // re-anchor, reserved redemption). Distinct from
+        // `reservationDissolutionTxMaxFee`, which caps the dissolution
+        // transaction's 2-in-1-out fee economics.
         uint64 reservationTxMaxFee;
+        // Maximum amount of BTC transaction fee in satoshi that can be
+        // incurred by a single reservation dissolution transaction
+        // (2-in-1-out shape). Distinct from `reservationTxMaxFee` because
+        // dissolution's fee economics differ from the 1-in-1-out anchor /
+        // re-anchor / redemption shapes that share `reservationTxMaxFee`.
+        uint64 reservationDissolutionTxMaxFee;
         // The grace period in seconds after a reservation's custody term
         // expires during which the reservation can still be extended or
         // redeemed but not yet dissolved.
@@ -370,18 +402,23 @@ library BridgeState {
         // reservations at the same time.
         uint64 reservationMaxTotalAmount;
         // Current total amount in satoshi locked under active reservations
-        // (sum of current anchor output values).
+        // (sum of gross `mintedAmount` over Active reservations, unchanged
+        // by re-anchor hops which only reduce the per-reservation
+        // `anchorAmount`).
         uint64 reservationTotalAmount;
         // Maximum number of active reservations a single wallet can custody.
         uint32 maxReservationsPerWallet;
+        // Per-reservation cumulative re-anchor fee budget in satoshi. Caps
+        // the total satoshi that may be lost across all re-anchor hops for
+        // a single reservation, complementing the per-transaction
+        // `reservationTxMaxFee` bound which only constrains a single hop.
+        // Bounds in-kind grinding of the anchor value over the reservation
+        // lifetime.
+        uint64 maxCumulativeReanchorFee;
         // Collection of all reservations indexed by the deposit key of the
         // underlying reserved deposit, i.e.
         // `keccak256(fundingTxHash | fundingOutputIndex)`.
         mapping(uint256 => Reservation.ReservationRequest) reservations;
-        // Maps the UTXO key of a reservation's current anchor outpoint,
-        // built as `keccak256(anchorTxHash | anchorTxOutputIndex)`, to the
-        // reservation key.
-        mapping(uint256 => uint256) reservationsByAnchorUtxo;
         // The number of active reservations custodied by the given wallet,
         // identified by its 20-byte wallet public key hash.
         mapping(bytes20 => uint32) walletReservationsCount;
@@ -390,6 +427,10 @@ library BridgeState {
         // updates from changing an ordinary deposit into a reservation or
         // making a reserved deposit eligible for an ordinary sweep.
         mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
+        // Terminal settlement records for reserved redemptions whose
+        // request timed out or was vetoed before their Bitcoin transaction
+        // could be proven, keyed by reservation key.
+        mapping(uint256 => ReservedRedemptionSettlement) reservedRedemptionSettlements;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -397,7 +438,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[42] __gap;
+        uint256[41] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -29,6 +29,25 @@ import "./MovingFunds.sol";
 import "../bank/Bank.sol";
 
 library BridgeState {
+    /// @notice Reveal-time facts for a deposit routed to the reservation
+    ///         vault. All fields fit in one storage word. `isReserved` is
+    ///         permanent; the remaining fields are used by the reservation
+    ///         action flow and may be cleared after acceptance or staleness.
+    struct PendingReservedDeposit {
+        // Immutable reveal-time reservation classification.
+        bool isReserved;
+        // Wallet committed by the deposit script and therefore the only
+        // wallet that can be authorized to anchor the deposit.
+        bytes20 walletPubKeyHash;
+        // Exact Bitcoin refund locktime validated at reveal time. Zero is a
+        // valid value when reveal-ahead validation was disabled.
+        uint32 refundDeadline;
+        // Whether the refund deadline was validated against a nonzero
+        // reveal-ahead period. This preserves the disabled validation mode
+        // without overloading a valid zero locktime.
+        bool refundDeadlineValidated;
+    }
+
     struct Storage {
         // Address of the Bank the Bridge belongs to.
         Bank bank;
@@ -366,6 +385,11 @@ library BridgeState {
         // The number of active reservations custodied by the given wallet,
         // identified by its 20-byte wallet public key hash.
         mapping(bytes20 => uint32) walletReservationsCount;
+        // Reveal-time facts for deposits routed to the reservation vault.
+        // The permanent classification prevents later reservation-vault
+        // updates from changing an ordinary deposit into a reservation or
+        // making a reserved deposit eligible for an ordinary sweep.
+        mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -373,7 +397,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[43] __gap;
+        uint256[42] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -317,13 +317,12 @@ library Deposit {
             )
             .hash256View();
 
-        DepositRequest storage deposit = self.deposits[
-            uint256(
-                keccak256(
-                    abi.encodePacked(fundingTxHash, reveal.fundingOutputIndex)
-                )
+        uint256 depositKey = uint256(
+            keccak256(
+                abi.encodePacked(fundingTxHash, reveal.fundingOutputIndex)
             )
-        ];
+        );
+        DepositRequest storage deposit = self.deposits[depositKey];
         require(deposit.revealedAt == 0, "Deposit already revealed");
 
         uint64 fundingOutputAmount = fundingOutput.extractValue();
@@ -342,6 +341,12 @@ library Deposit {
             ? fundingOutputAmount / self.depositTreasuryFeeDivisor
             : 0;
         deposit.extraData = extraData;
+
+        if (
+            reveal.vault != address(0) && reveal.vault == self.reservationVault
+        ) {
+            self.pendingReservedDeposit[depositKey].isReserved = true;
+        }
 
         if (deposit.treasuryFee > 0 && self.rebateStaking != address(0)) {
             deposit.treasuryFee = RebateStaking(self.rebateStaking)

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -342,13 +342,26 @@ library Deposit {
             : 0;
         deposit.extraData = extraData;
 
-        if (
-            reveal.vault != address(0) && reveal.vault == self.reservationVault
-        ) {
+        bool isReserved = reveal.vault != address(0) &&
+            reveal.vault == self.reservationVault;
+        if (isReserved) {
             self.pendingReservedDeposit[depositKey].isReserved = true;
         }
 
-        if (deposit.treasuryFee > 0 && self.rebateStaking != address(0)) {
+        // Skip the rebate for reserved deposits: `deposit.treasuryFee` is
+        // never actually charged for a reservation (acceptance mints the
+        // gross anchored amount and ignores this field entirely -- see
+        // `Reservation.submitReservationAcceptanceProof`). Calling
+        // `applyForRebate` anyway would still permanently consume the
+        // depositor's limited rolling-window rebate budget for a fee that
+        // was never going to be charged, silently wasting it for zero
+        // benefit and reducing the budget available to the depositor's
+        // other (pooled) deposits.
+        if (
+            !isReserved &&
+            deposit.treasuryFee > 0 &&
+            self.rebateStaking != address(0)
+        ) {
             deposit.treasuryFee = RebateStaking(self.rebateStaking)
                 .applyForRebate(
                     deposit.depositor,

--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -158,17 +158,6 @@ library DepositSweep {
         // `txProofDifficultyFactor` constant.
         bytes32 sweepTxHash = self.validateProof(sweepTx, sweepProof);
 
-        // Reserved deposits are anchored via the `Reservation` library
-        // instead of being swept. Since every deposit swept by a single
-        // transaction must share the `vault` parameter (enforced per input
-        // below), rejecting the reservation vault here rejects every
-        // reserved deposit.
-        require(
-            self.reservationVault == address(0) ||
-                vault != self.reservationVault,
-            "Reserved deposits must not be swept"
-        );
-
         // Process sweep transaction output and extract its target wallet
         // public key hash and value.
         (
@@ -429,16 +418,20 @@ library DepositSweep {
                     inputStartingIndex
                 );
 
-            Deposit.DepositRequest storage deposit = self.deposits[
-                uint256(
-                    keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-                )
-            ];
+            uint256 depositKey = uint256(
+                keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+            );
+            Deposit.DepositRequest storage deposit = self.deposits[depositKey];
 
             if (deposit.revealedAt != 0) {
                 // If we entered here, that means the input was identified as
                 // a revealed deposit.
                 require(deposit.sweptAt == 0, "Deposit already swept");
+
+                require(
+                    !self.pendingReservedDeposit[depositKey].isReserved,
+                    "Reserved deposits must not be swept"
+                );
 
                 require(
                     deposit.vault == processInfo.vault,

--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -158,6 +158,17 @@ library DepositSweep {
         // `txProofDifficultyFactor` constant.
         bytes32 sweepTxHash = self.validateProof(sweepTx, sweepProof);
 
+        // Reserved deposits are anchored via the `Reservation` library
+        // instead of being swept. Since every deposit swept by a single
+        // transaction must share the `vault` parameter (enforced per input
+        // below), rejecting the reservation vault here rejects every
+        // reserved deposit.
+        require(
+            self.reservationVault == address(0) ||
+                vault != self.reservationVault,
+            "Reserved deposits must not be swept"
+        );
+
         // Process sweep transaction output and extract its target wallet
         // public key hash and value.
         (

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -62,6 +62,15 @@ interface IRedemptionWatchtower {
         external
         view
         returns (uint32);
+
+    /// @notice Returns the applicable veto delay for a pending reserved
+    ///         redemption identified by the given reservation key.
+    /// @param reservationKey The key of the reservation.
+    /// @return Reserved redemption veto delay.
+    function getReservedRedemptionDelay(uint256 reservationKey)
+        external
+        view
+        returns (uint32);
 }
 
 /// @notice Aggregates functions common to the redemption transaction proof

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -53,6 +53,28 @@ interface IRedemptionWatchtower {
         address redeemer
     ) external view returns (bool);
 
+    /// @notice Determines whether a reserved redemption request is
+    ///         considered safe. Distinct from `isSafeRedemption` because a
+    ///         reserved redemption's veto history is keyed per reservation
+    ///         and per request generation (`reservationKey` +
+    ///         `redemptionRequestedAt`), not per wallet/output-script pair.
+    /// @param reservationKey The key of the reservation being redeemed.
+    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
+    ///        request is being made at (the value about to be written to
+    ///        the reservation's `redemptionRequestedAt` field).
+    /// @param balanceOwner The address of the Bank balance owner whose
+    ///        balance is getting redeemed.
+    /// @param redeemer The address that requested the redemption.
+    /// @return True if the reserved redemption request is safe, false
+    ///         otherwise. Specific safety criteria depend on the
+    ///         implementation.
+    function isSafeReservedRedemption(
+        uint256 reservationKey,
+        uint32 redemptionRequestedAt,
+        address balanceOwner,
+        address redeemer
+    ) external view returns (bool);
+
     /// @notice Returns the applicable redemption delay for a redemption
     ///         request identified by the given redemption key.
     /// @param redemptionKey Redemption key built as
@@ -77,6 +99,42 @@ interface IRedemptionWatchtower {
 ///         validation and to the moving funds transaction proof validation.
 library OutboundTx {
     using BTCUtils for bytes;
+    using BytesLib for bytes;
+
+    /// @notice Validates a redeemer output script: checks it decodes as a
+    ///         standard type (P2PKH, P2WPKH, P2SH or P2WSH) and, when its
+    ///         payload is 20 bytes, that it does not point to the given
+    ///         wallet's own public key hash. Reverts otherwise. Shared by
+    ///         both the pooled redemption and reserved redemption request
+    ///         paths, which apply the identical check.
+    /// @param redeemerOutputScript The redeemer output script to validate.
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet the
+    ///        redemption is requested against.
+    function validateRedeemerOutputScript(
+        bytes memory redeemerOutputScript,
+        bytes20 walletPubKeyHash
+    ) internal pure {
+        // Validate if redeemer output script is a correct standard type
+        // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by using
+        // `BTCUtils.extractHashAt` on it. Such a function extracts the
+        // payload properly only from standard outputs so if it succeeds, we
+        // have a guarantee the redeemer output script is proper. The
+        // underlying way of validation is the same as in tBTC v1.
+        bytes memory redeemerOutputScriptPayload = redeemerOutputScript
+            .extractHashAt(0, redeemerOutputScript.length);
+
+        require(
+            redeemerOutputScriptPayload.length > 0,
+            "Redeemer output script must be a standard type"
+        );
+        // Check if the redeemer output script payload does not point to the
+        // wallet public key hash.
+        require(
+            redeemerOutputScriptPayload.length != 20 ||
+                walletPubKeyHash != redeemerOutputScriptPayload.slice20(0),
+            "Redeemer output script must not point to the wallet PKH"
+        );
+    }
 
     /// @notice Checks whether an outbound Bitcoin transaction performed from
     ///         the given wallet has an input vector that contains a single
@@ -542,25 +600,9 @@ library Redemption {
             "Invalid main UTXO data"
         );
 
-        // Validate if redeemer output script is a correct standard type
-        // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by using
-        // `BTCUtils.extractHashAt` on it. Such a function extracts the payload
-        // properly only from standard outputs so if it succeeds, we have a
-        // guarantee the redeemer output script is proper. The underlying way
-        // of validation is the same as in tBTC v1.
-        bytes memory redeemerOutputScriptPayload = redeemerOutputScript
-            .extractHashAt(0, redeemerOutputScript.length);
-
-        require(
-            redeemerOutputScriptPayload.length > 0,
-            "Redeemer output script must be a standard type"
-        );
-        // Check if the redeemer output script payload does not point to the
-        // wallet public key hash.
-        require(
-            redeemerOutputScriptPayload.length != 20 ||
-                walletPubKeyHash != redeemerOutputScriptPayload.slice20(0),
-            "Redeemer output script must not point to the wallet PKH"
+        OutboundTx.validateRedeemerOutputScript(
+            redeemerOutputScript,
+            walletPubKeyHash
         );
 
         require(

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -415,6 +415,21 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     ///         on the Bridge -- the anchor outpoint was not spent, so the
     ///         in-kind claim survives (though a banned owner cannot
     ///         re-request until unbanned).
+    ///
+    ///         Veto state is keyed per request generation
+    ///         (`_reservedVetoKey(reservationKey, redemptionRequestedAt)`),
+    ///         not by the bare reservation key: a reservation returns to
+    ///         Active and can be re-requested after a timeout, so keying by
+    ///         the bare reservation key would let a stale `objectionsCount`
+    ///         or per-guardian objection from a resolved earlier request
+    ///         permanently block or bias every future request generation
+    ///         on the same reservation. The `ObjectionRaised`/
+    ///         `VetoFinalized`/`VetoPeriodCheckOmitted` events below carry
+    ///         the generation key (not the bare reservation key) since
+    ///         that is the value `withdrawVetoedFunds` requires and the
+    ///         Bridge clears `redemptionRequestedAt` once the veto
+    ///         finalizes, so the generation key cannot be recomputed from
+    ///         Bridge state after the fact.
     /// @param reservationKey The key of the reservation with the pending
     ///        reserved redemption.
     /// @dev Requirements:
@@ -428,18 +443,6 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         external
         onlyGuardian
     {
-        VetoProposal storage veto = vetoProposals[reservationKey];
-
-        require(
-            veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
-            "Reserved redemption already vetoed"
-        );
-
-        uint256 objectionKey = uint256(
-            keccak256(abi.encodePacked(reservationKey, msg.sender))
-        );
-        require(!objections[objectionKey], "Guardian already objected");
-
         Reservation.ReservationRequest memory reservation = bridge.reservations(
             reservationKey
         );
@@ -449,6 +452,22 @@ contract RedemptionWatchtower is OwnableUpgradeable {
                 Reservation.ReservationState.RedemptionRequested,
             "Reserved redemption does not exist"
         );
+
+        uint256 vetoKey = _reservedVetoKey(
+            reservationKey,
+            reservation.redemptionRequestedAt
+        );
+        VetoProposal storage veto = vetoProposals[vetoKey];
+
+        require(
+            veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
+            "Reserved redemption already vetoed"
+        );
+
+        uint256 objectionKey = uint256(
+            keccak256(abi.encodePacked(vetoKey, msg.sender))
+        );
+        require(!objections[objectionKey], "Guardian already objected");
 
         if (reservation.redemptionRequestedAt >= watchtowerEnabledAt) {
             require(
@@ -462,14 +481,14 @@ contract RedemptionWatchtower is OwnableUpgradeable {
                 "Redemption veto delay period expired"
             );
         } else {
-            emit VetoPeriodCheckOmitted(reservationKey);
+            emit VetoPeriodCheckOmitted(vetoKey);
         }
 
         objections[objectionKey] = true;
         veto.redeemer = reservation.redeemer;
         veto.objectionsCount++;
 
-        emit ObjectionRaised(reservationKey, msg.sender);
+        emit ObjectionRaised(vetoKey, msg.sender);
 
         if (veto.objectionsCount == REQUIRED_OBJECTIONS_COUNT) {
             uint64 penaltyFee = vetoPenaltyFeeDivisor > 0
@@ -483,7 +502,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
             emit Banned(reservation.redeemer);
 
-            emit VetoFinalized(reservationKey);
+            emit VetoFinalized(vetoKey);
 
             // Notify the Bridge about the veto. As result of this call,
             // this contract receives the surrendered gross amount
@@ -493,6 +512,25 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             // redeemer to withdraw after the freeze period.
             bank.decreaseBalance(penaltyFee);
         }
+    }
+
+    /// @notice Derives the veto-state key for a reserved redemption request
+    ///         generation, scoping guardian objections and veto state to
+    ///         the specific request rather than the reservation as a whole.
+    /// @param reservationKey The key of the reservation.
+    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
+    ///        request was (or is about to be) made at.
+    /// @return The generation-scoped veto-state key.
+    function _reservedVetoKey(
+        uint256 reservationKey,
+        uint32 redemptionRequestedAt
+    ) internal pure returns (uint256) {
+        return
+            uint256(
+                keccak256(
+                    abi.encodePacked(reservationKey, redemptionRequestedAt)
+                )
+            );
     }
 
     /// @notice Returns the applicable veto delay for a pending reserved
@@ -517,7 +555,12 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
         return
             _redemptionDelay(
-                vetoProposals[reservationKey].objectionsCount,
+                vetoProposals[
+                    _reservedVetoKey(
+                        reservationKey,
+                        reservation.redemptionRequestedAt
+                    )
+                ].objectionsCount,
                 reservation.mintedAmount
             );
     }
@@ -692,6 +735,35 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         );
 
         if (vetoProposals[redemptionKey].objectionsCount > 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// @notice Determines whether a reserved redemption request is
+    ///         considered safe. The first two positional parameters
+    ///         (a reservation key and the request's timestamp) are part
+    ///         of the interface the Bridge calls through but are unused
+    ///         by this check.
+    /// @param balanceOwner The address of the Bank balance owner whose
+    ///        balance is getting redeemed.
+    /// @param redeemer The address that requested the redemption.
+    /// @return True if the reserved redemption request is safe, false
+    ///         otherwise. The redemption is considered safe when:
+    ///         - The balance owner is not banned,
+    ///         - The redeemer is not banned.
+    function isSafeReservedRedemption(
+        uint256,
+        uint32,
+        address balanceOwner,
+        address redeemer
+    ) external view returns (bool) {
+        if (isBanned[balanceOwner]) {
+            return false;
+        }
+
+        if (isBanned[redeemer]) {
             return false;
         }
 

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -533,6 +533,27 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             );
     }
 
+    /// @notice Public wrapper for `_reservedVetoKey`, letting a redeemer (or
+    ///         anyone) compute the exact `withdrawVetoedFunds` key for a
+    ///         reserved redemption generation without needing to consult
+    ///         event logs. `reservationKey` is known to the redeemer since
+    ///         they initiated the request; `redemptionRequestedAt` is the
+    ///         block timestamp of that request transaction, itself a
+    ///         permanent, publicly queryable fact independent of the
+    ///         Bridge's current (and, after resolution, cleared) storage.
+    /// @param reservationKey The key of the reservation the redemption
+    ///        request belonged to.
+    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
+    ///        request was made at (the block timestamp of the
+    ///        `redeemReservation`/`retryRedeemReservation` call).
+    /// @return The generation-scoped key to pass to `withdrawVetoedFunds`.
+    function reservedVetoKey(
+        uint256 reservationKey,
+        uint32 redemptionRequestedAt
+    ) external pure returns (uint256) {
+        return _reservedVetoKey(reservationKey, redemptionRequestedAt);
+    }
+
     /// @notice Returns the applicable veto delay for a pending reserved
     ///         redemption identified by the given reservation key.
     /// @param reservationKey The key of the reservation.
@@ -783,8 +804,10 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
     /// @notice Withdraws funds from a vetoed redemption request, identified
     ///         by the given redemption key.
-    /// @param redemptionKey Redemption key built as
-    ///        `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`.
+    /// @param redemptionKey For a pooled redemption veto, built as
+    ///        `keccak256(keccak256(redeemerOutputScript) | walletPubKeyHash)`;
+    ///        for a reserved redemption veto, `reservedVetoKey(reservationKey,
+    ///        redemptionRequestedAt)`.
     /// @dev Requirements:
     ///      - The veto must be finalized,
     ///      - The caller must be the redeemer of the vetoed redemption request,

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -19,6 +19,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import "./Bridge.sol";
 import "./Redemption.sol";
+import "./Reservation.sol";
 
 /// @title Redemption watchtower
 /// @notice This contract encapsulates the logic behind the redemption veto
@@ -400,6 +401,125 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             // freeze period.
             bank.decreaseBalance(penaltyFee);
         }
+    }
+
+    /// @notice Raises an objection to a pending reserved redemption
+    ///         identified by its reservation key. Works the same way as
+    ///         `raiseObjection` does for regular redemption requests: each
+    ///         pending reserved redemption has a delay period during which
+    ///         the wallet is not allowed to process it and the guardians can
+    ///         raise objections to; the third objection vetoes it. A veto
+    ///         detains the surrendered gross amount from the Bridge, freezes
+    ///         it for the freeze period, burns the penalty fee, and bans the
+    ///         redeemer. The reservation itself returns to the Active state
+    ///         on the Bridge -- the anchor outpoint was not spent, so the
+    ///         in-kind claim survives (though a banned owner cannot
+    ///         re-request until unbanned).
+    /// @param reservationKey The key of the reservation with the pending
+    ///        reserved redemption.
+    /// @dev Requirements:
+    ///      - The caller must be a redemption guardian,
+    ///      - The reserved redemption must not have been vetoed already,
+    ///      - The guardian must not have already objected to it,
+    ///      - The reserved redemption must be pending,
+    ///      - The reserved redemption must be within its veto delay period,
+    ///        unless it was requested before the watchtower was enabled.
+    function raiseReservedObjection(uint256 reservationKey)
+        external
+        onlyGuardian
+    {
+        VetoProposal storage veto = vetoProposals[reservationKey];
+
+        require(
+            veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
+            "Reserved redemption already vetoed"
+        );
+
+        uint256 objectionKey = uint256(
+            keccak256(abi.encodePacked(reservationKey, msg.sender))
+        );
+        require(!objections[objectionKey], "Guardian already objected");
+
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            reservationKey
+        );
+
+        require(
+            reservation.state ==
+                Reservation.ReservationState.RedemptionRequested,
+            "Reserved redemption does not exist"
+        );
+
+        if (reservation.redemptionRequestedAt >= watchtowerEnabledAt) {
+            require(
+                /* solhint-disable-next-line not-rely-on-time */
+                block.timestamp <
+                    reservation.redemptionRequestedAt +
+                        _redemptionDelay(
+                            veto.objectionsCount,
+                            reservation.mintedAmount
+                        ),
+                "Redemption veto delay period expired"
+            );
+        } else {
+            emit VetoPeriodCheckOmitted(reservationKey);
+        }
+
+        objections[objectionKey] = true;
+        veto.redeemer = reservation.redeemer;
+        veto.objectionsCount++;
+
+        emit ObjectionRaised(reservationKey, msg.sender);
+
+        if (veto.objectionsCount == REQUIRED_OBJECTIONS_COUNT) {
+            uint64 penaltyFee = vetoPenaltyFeeDivisor > 0
+                ? reservation.mintedAmount / vetoPenaltyFeeDivisor
+                : 0;
+
+            veto.withdrawableAmount = reservation.mintedAmount - penaltyFee;
+            /* solhint-disable-next-line not-rely-on-time */
+            veto.finalizedAt = uint32(block.timestamp);
+            isBanned[reservation.redeemer] = true;
+
+            emit Banned(reservation.redeemer);
+
+            emit VetoFinalized(reservationKey);
+
+            // Notify the Bridge about the veto. As result of this call,
+            // this contract receives the surrendered gross amount
+            // (as Bank's balance) from the Bridge.
+            bridge.notifyReservedRedemptionVeto(reservationKey);
+            // Burn the penalty fee but leave the claimable amount for the
+            // redeemer to withdraw after the freeze period.
+            bank.decreaseBalance(penaltyFee);
+        }
+    }
+
+    /// @notice Returns the applicable veto delay for a pending reserved
+    ///         redemption identified by the given reservation key.
+    /// @param reservationKey The key of the reservation.
+    /// @return Reserved redemption veto delay.
+    /// @dev If the watchtower has been disabled, the delay is always zero.
+    function getReservedRedemptionDelay(uint256 reservationKey)
+        external
+        view
+        returns (uint32)
+    {
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            reservationKey
+        );
+
+        require(
+            reservation.state ==
+                Reservation.ReservationState.RedemptionRequested,
+            "Reserved redemption does not exist"
+        );
+
+        return
+            _redemptionDelay(
+                vetoProposals[reservationKey].objectionsCount,
+                reservation.mintedAmount
+            );
     }
 
     /// @notice Returns the redemption delay for a given number of objections

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -134,6 +134,24 @@ library Reservation {
         // keccak256 hash of the length-prefixed redeemer output script the
         // pending reserved redemption must pay to.
         bytes32 redeemerOutputScriptHash;
+        // Cumulative satoshi lost to Bitcoin miner fees across all
+        // re-anchor hops of this reservation. Bounded by
+        // `Storage.maxCumulativeReanchorFee` to cap in-kind fee
+        // extraction by a Byzantine wallet performing many small
+        // re-anchors.
+        uint64 cumulativeReanchorFee;
+        // Set true when the most recent reserved redemption timeout
+        // actually slashed the custodying wallet (it was Live or
+        // MovingFunds); set false when slashing was skipped (wallet
+        // already Terminated, Closing, or Closed) or the most recent
+        // resolution was a veto rather than a timeout. Read by
+        // `ReservationVault.retryRedeemReservation` to confirm the prior
+        // request specifically ended in a wallet-fault timeout before
+        // waiving the redemption fee -- without this gate an owner could
+        // use the retry path as an ordinary fee-free first redemption, or
+        // grief wallet operators by repeatedly requesting, waiting out
+        // the timeout (slashing the wallet), and retrying for free.
+        bool lastTimeoutWasWalletFault;
         // This struct doesn't contain `__gap` property as the structure is
         // stored in a mapping, mappings store values in different slots and
         // they are not contiguous with other values.
@@ -173,6 +191,22 @@ library Reservation {
 
     event ReservedRedemptionVetoed(uint256 indexed reservationKey);
 
+    // Emitted when a reserved redemption proof lands after the request
+    // already timed out or was vetoed; the redeemer was already refunded
+    // and no further balance movement occurs.
+    event ReservedRedemptionSettled(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    // Emitted when a reserved redemption timeout occurs but the custodying
+    // wallet has already reached Closing or Closed state, so wallet-fault
+    // slashing is skipped (the redeemer is still refunded).
+    event ReservedRedemptionTimeoutSlashingSkipped(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
     event ReservationReanchored(
         uint256 indexed reservationKey,
         bytes20 indexed newWalletPubKeyHash,
@@ -180,19 +214,31 @@ library Reservation {
         uint64 newAnchorAmount
     );
 
+    // Fee-loss decomposition for off-chain accounting: `mintedAmount` is
+    // the gross claim that stays with the owner, `anchorAmount` is the
+    // anchor's value entering this dissolution, and `dissolutionFee` is
+    // the Bitcoin fee this transaction paid. The unreconciled shortfall
+    // is `mintedAmount - anchorAmount + dissolutionFee` -- see the
+    // comment preceding the `closeReservation` call in
+    // `submitReservationDissolutionProof` for why nothing is burned.
     event ReservationDissolved(
         uint256 indexed reservationKey,
         bytes20 indexed walletPubKeyHash,
-        bytes32 dissolutionTxHash
+        bytes32 dissolutionTxHash,
+        uint64 mintedAmount,
+        uint64 anchorAmount,
+        uint64 dissolutionFee
     );
 
     event ReservationParametersUpdated(
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -341,6 +387,14 @@ library Reservation {
     ///         deposit as swept blocks any future regular sweep, prevents
     ///         double acceptance, and makes the deposit outpoint recognized
     ///         as correctly spent by the fraud challenge defeat path.
+    /// @dev Does not re-check the deposit's revealed `vault` against the
+    ///      current `self.reservationVault`: the reveal-time
+    ///      classification in `pendingReservedDeposit` is what gates
+    ///      reservation treatment. If governance changes the reservation
+    ///      vault between reveal and acceptance, this deposit is still
+    ///      accepted and its credit is routed through the *current*
+    ///      vault (see `submitReservationAcceptanceProof`), not the one
+    ///      set at reveal time.
     /// @return reservationKey The deposit key of the reserved deposit, used
     ///         as the reservation key.
     function resolveAcceptedDeposit(
@@ -350,9 +404,7 @@ library Reservation {
         (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
             .parseWalletOutboundTxInput(inputVector);
 
-        reservationKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
+        reservationKey = _outpointKey(outpointTxHash, outpointIndex);
 
         Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
         require(deposit.revealedAt != 0, "Deposit not revealed");
@@ -360,10 +412,6 @@ library Reservation {
         require(
             self.pendingReservedDeposit[reservationKey].isReserved,
             "Deposit was not revealed as reserved"
-        );
-        require(
-            deposit.vault == self.reservationVault,
-            "Deposit not routed to the reservation vault"
         );
 
         /* solhint-disable-next-line not-rely-on-time */
@@ -390,9 +438,8 @@ library Reservation {
         );
     }
 
-    /// @notice Registers a new reservation: checks and adjusts the caps,
-    ///         stores the reservation record and indexes the anchor
-    ///         outpoint.
+    /// @notice Registers a new reservation: checks and adjusts the caps
+    ///         and stores the reservation record.
     function registerReservation(
         BridgeState.Storage storage self,
         uint256 reservationKey,
@@ -433,10 +480,6 @@ library Reservation {
         reservation.anchorTxOutputIndex = 0;
         reservation.state = ReservationState.Active;
 
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(anchorTxHash, uint32(0))))
-        ] = reservationKey;
-
         // slither-disable-next-line reentrancy-events
         emit ReservationAccepted(
             reservationKey,
@@ -454,8 +497,10 @@ library Reservation {
     /// @param reservationKey The key of the reservation to extend.
     /// @dev Requirements:
     ///      - The caller must be the reservation vault,
-    ///      - The reservation must be in the Active or RedemptionRequested
-    ///        state,
+    ///      - The reservation must be in the Active state (a pending
+    ///        reserved redemption may consume the anchor at any time,
+    ///        so extending it would risk paying an extension fee on a
+    ///        position about to be spent),
     ///      - The reservation must not be past its grace period.
     function extendReservation(
         BridgeState.Storage storage self,
@@ -470,8 +515,7 @@ library Reservation {
             reservationKey
         ];
         require(
-            reservation.state == ReservationState.Active ||
-                reservation.state == ReservationState.RedemptionRequested,
+            reservation.state == ReservationState.Active,
             "Reservation is not active"
         );
         require(
@@ -536,12 +580,15 @@ library Reservation {
             "Reservation is not active"
         );
 
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 redemptionRequestedAt = uint32(block.timestamp);
+
         if (self.redemptionWatchtower != address(0)) {
             require(
                 IRedemptionWatchtower(self.redemptionWatchtower)
-                    .isSafeRedemption(
-                        reservation.walletPubKeyHash,
-                        redeemerOutputScript,
+                    .isSafeReservedRedemption(
+                        reservationKey,
+                        redemptionRequestedAt,
                         self.reservationVault,
                         redeemer
                     ),
@@ -551,19 +598,9 @@ library Reservation {
 
         bytes memory redeemerOutputScriptMem = redeemerOutputScript;
 
-        // Validate the redeemer output script is a correct standard type
-        // (P2PKH, P2WPKH, P2SH or P2WSH), the same way `Redemption` does.
-        bytes memory redeemerOutputScriptPayload = redeemerOutputScriptMem
-            .extractHashAt(0, redeemerOutputScriptMem.length);
-        require(
-            redeemerOutputScriptPayload.length > 0,
-            "Redeemer output script must be a standard type"
-        );
-        require(
-            redeemerOutputScriptPayload.length != 20 ||
-                reservation.walletPubKeyHash !=
-                redeemerOutputScriptPayload.slice20(0),
-            "Redeemer output script must not point to the wallet PKH"
+        OutboundTx.validateRedeemerOutputScript(
+            redeemerOutputScriptMem,
+            reservation.walletPubKeyHash
         );
 
         reservation.state = ReservationState.RedemptionRequested;
@@ -571,8 +608,7 @@ library Reservation {
         reservation.redeemerOutputScriptHash = keccak256(
             redeemerOutputScriptMem
         );
-        /* solhint-disable-next-line not-rely-on-time */
-        reservation.redemptionRequestedAt = uint32(block.timestamp);
+        reservation.redemptionRequestedAt = redemptionRequestedAt;
         reservation.redemptionTxMaxFee = self.reservationTxMaxFee;
 
         // slither-disable-next-line reentrancy-events
@@ -624,10 +660,61 @@ library Reservation {
         ReservationRequest storage reservation = self.reservations[
             reservationKey
         ];
-        require(
-            reservation.state == ReservationState.RedemptionRequested,
-            "No pending reserved redemption"
-        );
+        if (reservation.state != ReservationState.RedemptionRequested) {
+            // The request already timed out or was vetoed and the redeemer
+            // was refunded there; acknowledge a late-arriving proof for the
+            // exact settled anchor spend without moving any further
+            // balance, mirroring the pooled redemption path's
+            // `timedOutRedemptions` mechanism. The reservation itself is
+            // terminalized here (closed) since the anchor this proof
+            // proves is now provably spent and can never be re-anchored or
+            // dissolved again.
+            BridgeState.ReservedRedemptionSettlement storage settlement = self
+                .reservedRedemptionSettlements[reservationKey];
+            require(
+                settlement.anchorTxHash != bytes32(0),
+                "No settled reserved redemption"
+            );
+
+            // The reservation may have been re-anchored since the
+            // settlement was recorded (a timeout/veto returns it to
+            // Active, which permits re-anchoring). If so, the anchor
+            // this settlement refers to is no longer the reservation's
+            // current position -- the reservation has since moved on to
+            // a live, unsettled anchor that must go through its own
+            // redemption or dissolution, not be force-closed here.
+            require(
+                reservation.anchorTxHash == settlement.anchorTxHash,
+                "Reservation anchor no longer matches the settlement"
+            );
+
+            (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+                .parseWalletOutboundTxInput(redemptionTx.inputVector);
+            require(
+                settlement.anchorTxHash == outpointTxHash && outpointIndex == 0,
+                "Wrong settled anchor outpoint"
+            );
+
+            bytes memory settlementOutput = parseSingleOutput(
+                redemptionTx.outputVector
+            );
+            require(
+                keccak256(
+                    settlementOutput.slice(8, settlementOutput.length - 8)
+                ) == settlement.redeemerOutputScriptHash,
+                "Output does not pay the settled redeemer script"
+            );
+
+            self.spentMainUTXOs[
+                _outpointKey(outpointTxHash, outpointIndex)
+            ] = true;
+
+            closeReservation(self, reservation, reservationKey);
+
+            // slither-disable-next-line reentrancy-events
+            emit ReservedRedemptionSettled(reservationKey, redemptionTxHash);
+            return;
+        }
 
         consumeAnchor(self, reservation, redemptionTx.inputVector);
 
@@ -658,7 +745,7 @@ library Reservation {
             "Output value is not within the acceptable range"
         );
 
-        closeReservation(self, reservation);
+        closeReservation(self, reservation, reservationKey);
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionCompleted(reservationKey, redemptionTxHash);
@@ -700,10 +787,20 @@ library Reservation {
                 reservation.redemptionRequestedAt + self.redemptionTimeout,
             "Redemption request has not timed out"
         );
-
         address redeemer = reservation.redeemer;
         uint64 refundAmount = reservation.mintedAmount;
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+
+        // Record a terminal settlement BEFORE clearing the reservation
+        // fields so a redemption proof that lands after this timeout can
+        // still be acknowledged and mark the anchor outpoint spent,
+        // mirroring the pooled redemption path's `timedOutRedemptions`
+        // mechanism.
+        self.reservedRedemptionSettlements[reservationKey] = BridgeState
+            .ReservedRedemptionSettlement({
+                anchorTxHash: reservation.anchorTxHash,
+                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
+            });
 
         reservation.state = ReservationState.Active;
         reservation.redeemer = address(0);
@@ -712,8 +809,32 @@ library Reservation {
         reservation.redemptionTxMaxFee = 0;
 
         // Propagate timeout consequences to the wallet: slashing and state
-        // transition follow exactly the regular redemption timeout rules.
-        self.notifyWalletRedemptionTimeout(walletPubKeyHash, walletMembersIDs);
+        // transition follow the regular redemption timeout rules, but only
+        // when the wallet is actually slashable (Live or MovingFunds). A
+        // wallet that already reached Terminated, Closing, or Closed
+        // cannot be slashed via this path -- skip the call instead of
+        // reverting so the refund below is never blocked by wallet
+        // state.
+        Wallets.WalletState walletState = self
+            .registeredWallets[walletPubKeyHash]
+            .state;
+        if (
+            walletState == Wallets.WalletState.Live ||
+            walletState == Wallets.WalletState.MovingFunds
+        ) {
+            reservation.lastTimeoutWasWalletFault = true;
+            self.notifyWalletRedemptionTimeout(
+                walletPubKeyHash,
+                walletMembersIDs
+            );
+        } else {
+            reservation.lastTimeoutWasWalletFault = false;
+            // slither-disable-next-line reentrancy-events
+            emit ReservedRedemptionTimeoutSlashingSkipped(
+                reservationKey,
+                walletPubKeyHash
+            );
+        }
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionTimedOut(reservationKey, walletPubKeyHash);
@@ -753,11 +874,21 @@ library Reservation {
 
         uint64 detainedAmount = reservation.mintedAmount;
 
+        // Record a terminal settlement BEFORE clearing the reservation
+        // fields, mirroring the timeout path above, so a redemption proof
+        // that lands after this veto can still be acknowledged.
+        self.reservedRedemptionSettlements[reservationKey] = BridgeState
+            .ReservedRedemptionSettlement({
+                anchorTxHash: reservation.anchorTxHash,
+                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
+            });
+
         reservation.state = ReservationState.Active;
         reservation.redeemer = address(0);
         reservation.redeemerOutputScriptHash = bytes32(0);
         reservation.redemptionRequestedAt = 0;
         reservation.redemptionTxMaxFee = 0;
+        reservation.lastTimeoutWasWalletFault = false;
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionVetoed(reservationKey);
@@ -786,6 +917,22 @@ library Reservation {
     ///      the custodying wallet can sign the anchor spend) and moving
     ///      reservations out must remain possible for wallets in any
     ///      lifecycle state.
+    ///
+    ///      Proof-type ambiguity: once the custody term plus grace period
+    ///      has elapsed, a single 1-input-1-output anchor spend can satisfy
+    ///      both this function's and `submitReservationDissolutionProof`'s
+    ///      output rules, and the `proofType` chosen by whichever party
+    ///      submits the SPV proof is the only discriminator between the
+    ///      two. Both entry points are reachable only through
+    ///      `Bridge.submitReservationProof`, gated to the same trusted,
+    ///      governance-controlled SPV maintainer role, so this is a
+    ///      maintainer-tooling correctness concern rather than an open
+    ///      exploit surface: the maintainer's tooling is responsible for
+    ///      choosing the `proofType` matching the wallet operator's actual
+    ///      intent. Submitting the wrong proof type either force-closes the
+    ///      reservation via dissolution or blocks an intended dissolution
+    ///      via re-anchor -- currently a trust assumption on the maintainer
+    ///      role, not an on-chain-enforced guarantee.
     function submitReservationReanchorProof(
         BridgeState.Storage storage self,
         BitcoinTx.Info calldata reanchorTx,
@@ -816,9 +963,12 @@ library Reservation {
 
         // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
         // consensus (the re-anchor output cannot exceed its input).
+        // Cache the reservation's current anchor value locally: it is
+        // read once here, then re-read when computing the cumulative
+        // re-anchor fee below. Using the local avoids a second SLOAD.
+        uint64 anchorAmount = reservation.anchorAmount;
         require(
-            reservation.anchorAmount - newAnchorAmount <=
-                self.reservationTxMaxFee,
+            anchorAmount - newAnchorAmount <= self.reservationTxMaxFee,
             "Transaction fee is too high"
         );
 
@@ -826,16 +976,25 @@ library Reservation {
         // per-transaction fee bound, keeping the anchor clear of dust and
         // preserving positive redemption value. This is deliberately a dust
         // floor rather than `reservationMinAmount`: a minimum-sized
-        // reservation must remain migratable (a `reservationMinAmount` floor
-        // combined with the proposal validator's positive-fee requirement
-        // would leave no compliant re-anchor for an exactly-minimum anchor,
-        // pinning a retiring wallet). Bounding cumulative Byzantine
-        // re-anchor grinding is deferred to the authorized-action model (an
-        // explicit migration request with nonce, owner/target authorization,
-        // and a cumulative fee budget), tracked as a follow-up.
+        // reservation must remain migratable.
         require(
             newAnchorAmount > self.reservationTxMaxFee,
             "Re-anchor amount below the dust floor"
+        );
+
+        // Cumulative re-anchor fee budget: cap the total satoshi a
+        // single reservation may lose across all re-anchor hops.
+        // Bounds Byzantine fee-grinding attacks that would otherwise
+        // split the cumulative loss into many hops each individually
+        // under `reservationTxMaxFee`. The `reservationTotalAmount`
+        // aggregate is intentionally NOT decremented on re-anchor:
+        // re-anchoring does not change `mintedAmount`, the gross claim
+        // that backs the reservation.
+        uint64 fee = anchorAmount - newAnchorAmount;
+        reservation.cumulativeReanchorFee += fee;
+        require(
+            reservation.cumulativeReanchorFee <= self.maxCumulativeReanchorFee,
+            "Cumulative re-anchor fee budget exceeded"
         );
 
         bytes20 oldWalletPubKeyHash = reservation.walletPubKeyHash;
@@ -851,20 +1010,10 @@ library Reservation {
             self.walletReservationsCount[newWalletPubKeyHash] = newCount;
         }
 
-        // The miner fee reduces the on-chain earmarked amount. The gross
-        // claim (`mintedAmount`) is unchanged; the accumulated in-kind fees
-        // are settled when the reservation is redeemed (full gross burn).
-        self.reservationTotalAmount -= (reservation.anchorAmount -
-            newAnchorAmount);
-
         reservation.walletPubKeyHash = newWalletPubKeyHash;
         reservation.anchorAmount = newAnchorAmount;
         reservation.anchorTxHash = reanchorTxHash;
         reservation.anchorTxOutputIndex = 0;
-
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
-        ] = reservationKey;
 
         emit ReservationReanchored(
             reservationKey,
@@ -876,9 +1025,12 @@ library Reservation {
 
     /// @notice Used by the wallet to prove a dissolution transaction merging
     ///         an expired reservation's anchor outpoint into the wallet's
-    ///         main UTXO. After dissolution the owner's minted balance
-    ///         simply remains an ordinary pooled claim; no balances are
-    ///         moved or burned.
+    ///         main UTXO. The anchor value rejoins the pool as an ordinary
+    ///         claim; any accrued re-anchor fee loss (the gap between the
+    ///         original minted amount and the anchor's current value) is
+    ///         simply not reconciled -- see the inline comment preceding
+    ///         the `closeReservation` call in this function's body for
+    ///         why no Bank balance is burned.
     /// @param dissolutionTx Bitcoin dissolution transaction data.
     /// @param dissolutionProof Bitcoin dissolution proof data.
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
@@ -896,6 +1048,26 @@ library Reservation {
     ///      - `dissolutionTx` must have a single P2(W)PKH output locking
     ///        funds back on the custodying wallet's public key hash; that
     ///        output becomes the wallet's new main UTXO.
+    ///
+    ///      Dissolution concurrency: dissolution proofs for multiple
+    ///      reservations on the same wallet must be submitted sequentially
+    ///      -- one at a time, each landing before the next is signed and
+    ///      submitted. If two dissolutions are signed off-chain assuming
+    ///      the same (e.g. zero) main UTXO, the first proof to land moves
+    ///      the wallet's `mainUtxoHash` forward and the second, now-stale
+    ///      transaction reverts on its input count instead of executing;
+    ///      it must be re-signed against the wallet's updated main UTXO.
+    ///      This is the same operational pattern already required by this
+    ///      codebase's MovingFunds sweep-input handling.
+    ///
+    ///      Proof-type ambiguity: see the matching note on
+    ///      `submitReservationReanchorProof` -- once the custody term plus
+    ///      grace period has elapsed, a single 1-input-1-output anchor
+    ///      spend can satisfy either function's output rules, and both are
+    ///      reachable only through the same trusted, governance-controlled
+    ///      SPV maintainer role via `Bridge.submitReservationProof`. This
+    ///      is a maintainer-tooling correctness concern, not an on-chain-
+    ///      enforced guarantee.
     ///
     ///      Note the Bridge cannot verify *when* the dissolution transaction
     ///      was signed. A wallet signing it before the grace period elapses
@@ -929,8 +1101,16 @@ library Reservation {
             "Reservation term or grace period not elapsed"
         );
 
+        // Cache the reservation's wallet identity: it is read here, again
+        // in the dissolution-output require, and in the
+        // `ReservationDissolved` event. The claim/backing pair
+        // (`mintedAmount`, `anchorAmount`) is read straight from storage
+        // in the event below rather than into locals -- this function is
+        // already at the stack limit.
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+
         Wallets.Wallet storage wallet = self.registeredWallets[
-            reservation.walletPubKeyHash
+            walletPubKeyHash
         ];
         {
             Wallets.WalletState walletState = wallet.state;
@@ -952,32 +1132,72 @@ library Reservation {
         bytes memory output = parseSingleOutput(dissolutionTx.outputVector);
         uint64 outputValue = output.extractValue();
         require(
-            self.extractPubKeyHash(output) == reservation.walletPubKeyHash,
+            self.extractPubKeyHash(output) == walletPubKeyHash,
             "Dissolution output must pay to the custodying wallet"
         );
+        // Dissolution is usually a 2-in-1-out spend (anchor + wallet
+        // main UTXO rolled into a new main UTXO), or 1-in-1-out when
+        // the wallet has no main UTXO yet; either shape's fee economics
+        // differ from the always-1-in-1-out anchor / re-anchor /
+        // redemption shapes, so the cap is the dedicated
+        // `reservationDissolutionTxMaxFee` governance parameter rather
+        // than the shared `reservationTxMaxFee`.
         require(
-            inputsTotalValue - outputValue <= self.reservationTxMaxFee,
+            inputsTotalValue - outputValue <=
+                self.reservationDissolutionTxMaxFee,
             "Transaction fee is too high"
         );
 
-        // The dissolution output becomes the wallet's new main UTXO: the
-        // reserved backing rejoins the pooled supply.
+        // The dissolution output becomes the wallet's new main UTXO,
+        // rolling the anchor's remaining value (after any re-anchor fees)
+        // together with the previous main UTXO, less this transaction's
+        // fee. No Bank balance is burned here: the Bridge itself holds no
+        // balance attributable to a dissolving reservation to burn
+        // against -- the owner's full `mintedAmount` claim was minted out
+        // through the reservation vault at acceptance time and stays with
+        // the owner regardless of later re-anchor fee loss. Reconciling
+        // that fee loss against the pool, if ever desired, requires a
+        // separate mechanism that first obtains the shortfall from the
+        // owner; it is not handled here. This mirrors the way
+        // `movingFundsTxMaxTotalFee` leaves wallet-migration fees
+        // pool-socialized rather than charging individual depositors. The
+        // `reservationTotalAmount` aggregate is decremented inside
+        // `closeReservation` against the full `mintedAmount`, and
+        // `ReservationDissolved` emits the fee-loss decomposition so the
+        // shortfall stays observable off-chain.
+
         wallet.mainUtxoHash = keccak256(
             abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
         );
 
-        closeReservation(self, reservation);
-
+        // Emitted before `closeReservation` so the claim/backing pair is
+        // read while the reservation record is still intact.
         emit ReservationDissolved(
             reservationKey,
-            reservation.walletPubKeyHash,
-            dissolutionTxHash
+            walletPubKeyHash,
+            dissolutionTxHash,
+            reservation.mintedAmount,
+            reservation.anchorAmount,
+            inputsTotalValue - outputValue
         );
+
+        closeReservation(self, reservation, reservationKey);
     }
 
     /// @notice Updates the reservation parameters, including the
     ///         reservation vault address. Deposits revealed with the
     ///         reservation vault address are treated as reserved deposits.
+    /// @param reservationDissolutionTxMaxFee New value of the dedicated
+    ///        cap on the BTC transaction fee for the dissolution shape
+    ///        (usually 2-in-1-out; 1-in-1-out when the wallet has no
+    ///        main UTXO yet); distinct from `reservationTxMaxFee` which
+    ///        caps the always-1-in-1-out anchor / re-anchor / redemption
+    ///        shapes.
+    /// @param maxCumulativeReanchorFee New value of the per-reservation
+    ///        cap on the total satoshi that may be lost across all
+    ///        re-anchor hops of a single reservation. Bounds in-kind
+    ///        fee extraction by a Byzantine wallet performing many
+    ///        small re-anchors.
     /// @dev Requirements:
     ///      - Reservation transaction max fee must be greater than zero,
     ///      - Reservation minimum amount must be greater than the
@@ -990,14 +1210,20 @@ library Reservation {
         address reservationVault,
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     ) external {
         require(
             reservationTxMaxFee > 0,
             "Reservation transaction max fee must be greater than zero"
+        );
+        require(
+            reservationDissolutionTxMaxFee > 0,
+            "Reservation dissolution transaction max fee must be greater than zero"
         );
         require(
             reservationMinAmount > reservationTxMaxFee,
@@ -1006,6 +1232,10 @@ library Reservation {
         require(
             reservationTermSeconds > 0,
             "Reservation term must be greater than zero"
+        );
+        require(
+            maxCumulativeReanchorFee > 0,
+            "Max cumulative re-anchor fee must be greater than zero"
         );
 
         if (reservationVault != self.reservationVault) {
@@ -1019,18 +1249,22 @@ library Reservation {
 
         self.reservationMinAmount = reservationMinAmount;
         self.reservationTxMaxFee = reservationTxMaxFee;
+        self.reservationDissolutionTxMaxFee = reservationDissolutionTxMaxFee;
         self.reservationTermSeconds = reservationTermSeconds;
         self.reservationGracePeriod = reservationGracePeriod;
         self.reservationMaxTotalAmount = reservationMaxTotalAmount;
         self.maxReservationsPerWallet = maxReservationsPerWallet;
+        self.maxCumulativeReanchorFee = maxCumulativeReanchorFee;
 
         emit ReservationParametersUpdated(
             reservationMinAmount,
             reservationTxMaxFee,
+            reservationDissolutionTxMaxFee,
             reservationTermSeconds,
             reservationGracePeriod,
             reservationMaxTotalAmount,
-            maxReservationsPerWallet
+            maxReservationsPerWallet,
+            maxCumulativeReanchorFee
         );
     }
 
@@ -1048,6 +1282,17 @@ library Reservation {
         );
 
         output = outputVector.extractOutputAtIndex(0);
+    }
+
+    /// @notice Derives the `spentMainUTXOs`/deposit-key mapping key for a
+    ///         Bitcoin outpoint, shared by every call site that hashes a
+    ///         transaction hash and output index pair this way.
+    function _outpointKey(bytes32 txHash, uint32 outputIndex)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(keccak256(abi.encodePacked(txHash, outputIndex)));
     }
 
     /// @notice Asserts the given input vector contains exactly one input
@@ -1069,16 +1314,13 @@ library Reservation {
             "Transaction input must point to the reservation anchor"
         );
 
-        uint256 anchorUtxoKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
+        uint256 anchorUtxoKey = _outpointKey(outpointTxHash, outpointIndex);
 
         // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
         // anchor in `spentMainUTXOs` -- the existing registry of honestly
         // spent wallet UTXOs -- makes the spend recognized by
         // `Fraud.defeatFraudChallenge` without modifying the fraud library.
         self.spentMainUTXOs[anchorUtxoKey] = true;
-        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
     }
 
     /// @notice Processes the dissolution transaction inputs: the first
@@ -1153,12 +1395,9 @@ library Reservation {
             "Transaction input must point to the reservation anchor"
         );
 
-        uint256 anchorUtxoKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
+        uint256 anchorUtxoKey = _outpointKey(outpointTxHash, outpointIndex);
         // See `consumeAnchor` for the `spentMainUTXOs` rationale.
         self.spentMainUTXOs[anchorUtxoKey] = true;
-        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
 
         nextInputIndex =
             inputStartingIndex +
@@ -1186,20 +1425,28 @@ library Reservation {
             "Transaction input must point to the wallet's main UTXO"
         );
 
-        self.spentMainUTXOs[
-            uint256(keccak256(abi.encodePacked(outpointTxHash, outpointIndex)))
-        ] = true;
+        self.spentMainUTXOs[_outpointKey(outpointTxHash, outpointIndex)] = true;
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count
-    ///         and the total reserved amount, and marks the reservation as
-    ///         Closed.
+    ///         and the total reserved amount, marks the reservation as
+    ///         Closed, and clears any terminal settlement record left by
+    ///         a prior timeout or veto so it cannot outlive the request
+    ///         generation that created it.
+    /// @dev `reservationTotalAmount` aggregates the sum of gross
+    ///      `mintedAmount` over Active reservations -- not the shrinking
+    ///      per-reservation `anchorAmount` -- so the cap tracks the
+    ///      bridge's true gross liability.
     function closeReservation(
         BridgeState.Storage storage self,
-        ReservationRequest storage reservation
+        ReservationRequest storage reservation,
+        uint256 reservationKey
     ) internal {
-        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
-        self.reservationTotalAmount -= reservation.anchorAmount;
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+        uint64 mintedAmount = reservation.mintedAmount;
+        self.walletReservationsCount[walletPubKeyHash] -= 1;
+        self.reservationTotalAmount -= mintedAmount;
         reservation.state = ReservationState.Closed;
+        delete self.reservedRedemptionSettlements[reservationKey];
     }
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -152,6 +152,18 @@ library Reservation {
         // grief wallet operators by repeatedly requesting, waiting out
         // the timeout (slashing the wallet), and retrying for free.
         bool lastTimeoutWasWalletFault;
+        // Set true while the pending reserved redemption request
+        // (`state == RedemptionRequested`) was itself initiated as a
+        // fee-free retry via `ReservationVault.retryRedeemReservation`,
+        // rather than a fresh fee-paid `redeemReservation` call. Read by
+        // `notifyReservedRedemptionTimeout` to grant at most one fee-free
+        // retry per paid redemption fee: if a retry's own request times
+        // out through wallet fault, `lastTimeoutWasWalletFault` is NOT
+        // set again, so a second retry requires a fresh fee payment.
+        // Without this, an owner could loop request -> timeout -> retry
+        // indefinitely, slashing wallet operators for free on every
+        // iteration after paying only the first redemption fee.
+        bool currentRequestIsRetry;
         // This struct doesn't contain `__gap` property as the structure is
         // stored in a mapping, mappings store values in different slots and
         // they are not contiguous with other values.
@@ -525,13 +537,16 @@ library Reservation {
             "Reservation past grace period"
         );
 
-        uint32 base = reservation.expiresAt;
-        /* solhint-disable-next-line not-rely-on-time */
-        if (base < block.timestamp) {
-            /* solhint-disable-next-line not-rely-on-time */
-            base = uint32(block.timestamp);
-        }
-        reservation.expiresAt = base + self.reservationTermSeconds;
+        // Always additive from the current `expiresAt`, even when the
+        // caller extends after expiry but still within the grace window:
+        // basing the new term on `block.timestamp` instead would hand a
+        // late extender bonus custody days (the gap between the old
+        // `expiresAt` and now) for the same flat extension fee, silently
+        // undercharging the protocol relative to the custody duration
+        // actually purchased.
+        reservation.expiresAt =
+            reservation.expiresAt +
+            self.reservationTermSeconds;
 
         emit ReservationExtended(reservationKey, reservation.expiresAt);
     }
@@ -549,19 +564,36 @@ library Reservation {
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to
     ///        lock the redeemed BTC.
+    /// @param isRetry True when this request is a fee-free retry via
+    ///        `ReservationVault.retryRedeemReservation` of a prior request
+    ///        that timed out through wallet fault; false for a fresh,
+    ///        fee-paid `redeemReservation` call.
     /// @dev Requirements:
     ///      - The caller must be the reservation vault, which must have
     ///        approved the Bridge in the Bank for the gross minted amount,
     ///      - The reservation must be in the Active state,
+    ///      - The custodying wallet must be in the Live state, matching
+    ///        the pooled redemption path's requirement -- a wallet already
+    ///        transitioning out (MovingFunds) does not accept new
+    ///        redemption requests, reserved or pooled alike,
+    ///      - If `isRetry` is true, the reservation's most recent
+    ///        redemption timeout must specifically have been caused by
+    ///        wallet fault (see `lastTimeoutWasWalletFault`), and that
+    ///        grant is consumed here so it cannot be reused,
+    ///      - The reservation's current anchor must not carry an unresolved
+    ///        terminal settlement record from a prior generation's timeout
+    ///        or veto (see the settlement-overwrite guard below),
     ///      - If the redemption watchtower is set, the request must be
     ///        considered safe by the watchtower,
-    ///      - `redeemerOutputScript` must be a standard type and must not
-    ///        pay to the custodying wallet's public key hash.
+    ///      - `redeemerOutputScript` must be a standard type and, if it
+    ///        has a 20-byte payload (P2PKH/P2WPKH), must not pay to the
+    ///        custodying wallet's public key hash.
     function requestReservedRedemption(
         BridgeState.Storage storage self,
         uint256 reservationKey,
         address redeemer,
-        bytes calldata redeemerOutputScript
+        bytes calldata redeemerOutputScript,
+        bool isRetry
     ) external {
         require(
             msg.sender == self.reservationVault,
@@ -578,6 +610,45 @@ library Reservation {
         require(
             reservation.state == ReservationState.Active,
             "Reservation is not active"
+        );
+
+        require(
+            self.registeredWallets[reservation.walletPubKeyHash].state ==
+                Wallets.WalletState.Live,
+            "Wallet must be in Live state"
+        );
+
+        if (isRetry) {
+            require(
+                reservation.lastTimeoutWasWalletFault,
+                "Previous request did not time out through wallet fault"
+            );
+            // Consume the grant immediately: this specific fee-free retry
+            // is the one payment it was earned by. `currentRequestIsRetry`
+            // (checked at the next timeout, if any) is what actually
+            // prevents chaining a second free retry off this one.
+            reservation.lastTimeoutWasWalletFault = false;
+        }
+        reservation.currentRequestIsRetry = isRetry;
+
+        // Settlement-overwrite guard: `reservedRedemptionSettlements` is a
+        // single slot per reservation key. If a prior generation's
+        // redemption timed out or was vetoed while its Bitcoin transaction
+        // was already broadcast (just not yet proven), a settlement record
+        // for the *current* anchor is still pending resolution -- allowing
+        // a new redemption request here would let this new generation's
+        // own timeout/veto overwrite that record (its `anchorTxHash` is
+        // unchanged since no re-anchor happened), permanently corrupting
+        // the redeemer output script the prior generation's late proof
+        // must match. Block same-anchor re-requests until either the
+        // pending settlement resolves via a late proof (which closes the
+        // reservation) or the anchor moves via `submitReservationReanchorProof`
+        // (which changes `anchorTxHash`, naturally invalidating the stale
+        // settlement's relevance to any future request).
+        require(
+            self.reservedRedemptionSettlements[reservationKey].anchorTxHash !=
+                reservation.anchorTxHash,
+            "Unresolved settlement exists for the current anchor"
         );
 
         /* solhint-disable-next-line not-rely-on-time */
@@ -705,6 +776,30 @@ library Reservation {
                 "Output does not pay the settled redeemer script"
             );
 
+            // Output-value range check: without this, a spend paying the
+            // settled script an arbitrarily small (even dust) value would
+            // still be accepted here -- since Bitcoin requires
+            // `sum(inputs) >= sum(outputs)` and this transaction has a
+            // single output, the difference between the anchor's value
+            // and a near-zero output would be an enormous miner fee. A
+            // wallet operator colluding with (or controlling) a mining
+            // pool could exploit this to recapture almost the entire
+            // anchor value as miner fee while the Bridge records the
+            // reservation as cleanly settled. `reservation.anchorAmount`
+            // is still the settled anchor's value here (the prior
+            // `anchorTxHash` equality check above guarantees no re-anchor
+            // happened since settlement); `self.reservationTxMaxFee` is
+            // the same governance-bounded fee tolerance used throughout
+            // the reservation lifecycle for miner-fee deductions.
+            uint64 settledAnchorAmount = reservation.anchorAmount;
+            uint64 settlementOutputValue = settlementOutput.extractValue();
+            require(
+                settlementOutputValue <= settledAnchorAmount &&
+                    settledAnchorAmount - settlementOutputValue <=
+                    self.reservationTxMaxFee,
+                "Settled output value is not within the acceptable range"
+            );
+
             self.spentMainUTXOs[
                 _outpointKey(outpointTxHash, outpointIndex)
             ] = true;
@@ -755,6 +850,40 @@ library Reservation {
         self.bank.decreaseBalance(reservation.mintedAmount);
     }
 
+    /// @notice Records a terminal settlement for the reservation's pending
+    ///         redemption request and clears the request fields, returning
+    ///         it to the Active state. Shared core of timeout and veto
+    ///         resolution -- both leave the reservation in the identical
+    ///         post-request shape, differing only in where the surrendered
+    ///         balance goes and whether wallet-fault slashing applies.
+    /// @return wasRetry Whether the just-cleared request was itself a
+    ///         fee-free retry (see `currentRequestIsRetry`).
+    function _clearPendingRedemptionRequest(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        uint256 reservationKey
+    ) internal returns (bool wasRetry) {
+        // Record a terminal settlement BEFORE clearing the reservation
+        // fields so a redemption proof that lands after this resolution
+        // can still be acknowledged and mark the anchor outpoint spent,
+        // mirroring the pooled redemption path's `timedOutRedemptions`
+        // mechanism.
+        self.reservedRedemptionSettlements[reservationKey] = BridgeState
+            .ReservedRedemptionSettlement({
+                anchorTxHash: reservation.anchorTxHash,
+                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
+            });
+
+        reservation.state = ReservationState.Active;
+        reservation.redeemer = address(0);
+        reservation.redeemerOutputScriptHash = bytes32(0);
+        reservation.redemptionRequestedAt = 0;
+        reservation.redemptionTxMaxFee = 0;
+
+        wasRetry = reservation.currentRequestIsRetry;
+        reservation.currentRequestIsRetry = false;
+    }
+
     /// @notice Notifies that a pending reserved redemption has timed out.
     ///         The surrendered balance is returned to the redeemer, the
     ///         wallet operators are slashed the same way as for a regular
@@ -791,22 +920,11 @@ library Reservation {
         uint64 refundAmount = reservation.mintedAmount;
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
 
-        // Record a terminal settlement BEFORE clearing the reservation
-        // fields so a redemption proof that lands after this timeout can
-        // still be acknowledged and mark the anchor outpoint spent,
-        // mirroring the pooled redemption path's `timedOutRedemptions`
-        // mechanism.
-        self.reservedRedemptionSettlements[reservationKey] = BridgeState
-            .ReservedRedemptionSettlement({
-                anchorTxHash: reservation.anchorTxHash,
-                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
-            });
-
-        reservation.state = ReservationState.Active;
-        reservation.redeemer = address(0);
-        reservation.redeemerOutputScriptHash = bytes32(0);
-        reservation.redemptionRequestedAt = 0;
-        reservation.redemptionTxMaxFee = 0;
+        bool timedOutRequestWasRetry = _clearPendingRedemptionRequest(
+            self,
+            reservation,
+            reservationKey
+        );
 
         // Propagate timeout consequences to the wallet: slashing and state
         // transition follow the regular redemption timeout rules, but only
@@ -814,7 +932,16 @@ library Reservation {
         // wallet that already reached Terminated, Closing, or Closed
         // cannot be slashed via this path -- skip the call instead of
         // reverting so the refund below is never blocked by wallet
-        // state.
+        // state. The wallet is slashed either way when slashable -- it
+        // genuinely failed to redeem in time regardless of whether the
+        // request was a fresh one or a retry -- but a free-retry grant
+        // (`lastTimeoutWasWalletFault = true`) is issued only when this
+        // timed-out request was NOT itself a retry: without this gate an
+        // owner could loop request -> timeout -> retry -> timeout -> retry
+        // indefinitely after paying only the first redemption fee, since
+        // each retry's own timeout would otherwise re-grant another free
+        // retry. A second retry now requires a fresh fee payment via
+        // `redeemReservation`.
         Wallets.WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;
@@ -822,7 +949,7 @@ library Reservation {
             walletState == Wallets.WalletState.Live ||
             walletState == Wallets.WalletState.MovingFunds
         ) {
-            reservation.lastTimeoutWasWalletFault = true;
+            reservation.lastTimeoutWasWalletFault = !timedOutRequestWasRetry;
             self.notifyWalletRedemptionTimeout(
                 walletPubKeyHash,
                 walletMembersIDs
@@ -874,20 +1001,10 @@ library Reservation {
 
         uint64 detainedAmount = reservation.mintedAmount;
 
-        // Record a terminal settlement BEFORE clearing the reservation
-        // fields, mirroring the timeout path above, so a redemption proof
-        // that lands after this veto can still be acknowledged.
-        self.reservedRedemptionSettlements[reservationKey] = BridgeState
-            .ReservedRedemptionSettlement({
-                anchorTxHash: reservation.anchorTxHash,
-                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
-            });
-
-        reservation.state = ReservationState.Active;
-        reservation.redeemer = address(0);
-        reservation.redeemerOutputScriptHash = bytes32(0);
-        reservation.redemptionRequestedAt = 0;
-        reservation.redemptionTxMaxFee = 0;
+        // Mirrors the timeout path's terminal-settlement recording; the
+        // returned `wasRetry` value is irrelevant here since a veto never
+        // grants a free retry regardless.
+        _clearPendingRedemptionRequest(self, reservation, reservationKey);
         reservation.lastTimeoutWasWalletFault = false;
 
         // slither-disable-next-line reentrancy-events
@@ -1040,10 +1157,12 @@ library Reservation {
     ///      - The reservation must be in the Active state (a pending
     ///        reserved redemption always wins over dissolution),
     ///      - The custody term plus grace period must have elapsed,
-    ///      - The custodying wallet must be in Live or MovingFunds state,
+    ///      - The custodying wallet must be in Live, MovingFunds or
+    ///        Terminated state,
     ///      - If the wallet has a main UTXO, `dissolutionTx` must spend
-    ///        exactly the anchor outpoint (first input) and that main UTXO
-    ///        (second input); otherwise it must spend exactly the anchor
+    ///        exactly the anchor outpoint and that main UTXO as its two
+    ///        inputs, in either order (Bitcoin does not constrain input
+    ///        ordering); otherwise it must spend exactly the anchor
     ///        outpoint,
     ///      - `dissolutionTx` must have a single P2(W)PKH output locking
     ///        funds back on the custodying wallet's public key hash; that
@@ -1114,10 +1233,25 @@ library Reservation {
         ];
         {
             Wallets.WalletState walletState = wallet.state;
+            // `Terminated` is included alongside `Live`/`MovingFunds` so a
+            // reservation that predates the wallet's termination is not
+            // permanently stranded: without this, a wallet terminated via
+            // `notifyWalletMovingFundsTimeout` (which has no reservation
+            // gate) leaves any reservation it still custodies unable to
+            // ever dissolve or close -- `reservationTotalAmount` would
+            // never reach zero and any future reservation-vault change
+            // would revert forever. Re-anchor is unaffected: its docstring
+            // already allows any source wallet state. This mirrors the
+            // existing carve-out in `Wallets.notifyWalletRedemptionTimeout`,
+            // which explicitly allows `Terminated` "in case the redemption
+            // was requested before the wallet got terminated" -- settling
+            // a pre-existing obligation, not authorizing a new action,
+            // which is what `Terminated` blocks.
             require(
                 walletState == Wallets.WalletState.Live ||
-                    walletState == Wallets.WalletState.MovingFunds,
-                "Wallet must be in Live or MovingFunds state"
+                    walletState == Wallets.WalletState.MovingFunds ||
+                    walletState == Wallets.WalletState.Terminated,
+                "Wallet must be in Live, MovingFunds or Terminated state"
             );
         }
 
@@ -1295,6 +1429,33 @@ library Reservation {
         return uint256(keccak256(abi.encodePacked(txHash, outputIndex)));
     }
 
+    /// @notice Compares the given outpoint against the reservation's
+    ///         current anchor and, if it matches, marks it spent. Shared
+    ///         core of `consumeAnchor` and `consumeAnchorInputAt`, which
+    ///         differ only in how they extract the outpoint from an input
+    ///         vector (a known-single-input vector vs. a specific offset
+    ///         within a multi-input vector).
+    function _consumeAnchorOutpoint(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        bytes32 outpointTxHash,
+        uint32 outpointIndex
+    ) internal {
+        require(
+            reservation.anchorTxHash == outpointTxHash &&
+                reservation.anchorTxOutputIndex == outpointIndex,
+            "Transaction input must point to the reservation anchor"
+        );
+
+        // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
+        // anchor in `spentMainUTXOs` -- the existing registry of honestly
+        // spent wallet UTXOs -- makes the spend recognized by
+        // `Fraud.defeatFraudChallenge` without modifying the fraud library.
+        self.spentMainUTXOs[
+            _outpointKey(outpointTxHash, outpointIndex)
+        ] = true;
+    }
+
     /// @notice Asserts the given input vector contains exactly one input
     ///         pointing to the reservation's current anchor outpoint, marks
     ///         that outpoint as correctly spent (making it recognized by the
@@ -1308,26 +1469,59 @@ library Reservation {
         (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
             .parseWalletOutboundTxInput(inputVector);
 
-        require(
-            reservation.anchorTxHash == outpointTxHash &&
-                reservation.anchorTxOutputIndex == outpointIndex,
-            "Transaction input must point to the reservation anchor"
-        );
-
-        uint256 anchorUtxoKey = _outpointKey(outpointTxHash, outpointIndex);
-
-        // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
-        // anchor in `spentMainUTXOs` -- the existing registry of honestly
-        // spent wallet UTXOs -- makes the spend recognized by
-        // `Fraud.defeatFraudChallenge` without modifying the fraud library.
-        self.spentMainUTXOs[anchorUtxoKey] = true;
+        _consumeAnchorOutpoint(self, reservation, outpointTxHash, outpointIndex);
     }
 
-    /// @notice Processes the dissolution transaction inputs: the first
-    ///         input must spend the reservation's anchor outpoint and, if
-    ///         the wallet has a main UTXO, the second input must spend
-    ///         exactly that main UTXO. Marks both consumed outpoints as
-    ///         correctly spent.
+    /// @notice Extracts the outpoint (transaction hash and output index) of
+    ///         the input at the given starting index, without asserting
+    ///         anything about it. Shared "peek" primitive used where the
+    ///         caller must inspect an outpoint before deciding what it is
+    ///         expected to be (see `processDissolutionInputs`, which cannot
+    ///         assume a fixed input order).
+    function _peekOutpointAt(bytes memory inputVector, uint256 inputStartingIndex)
+        internal
+        pure
+        returns (bytes32 outpointTxHash, uint32 outpointIndex)
+    {
+        outpointTxHash = inputVector.extractInputTxIdLeAt(inputStartingIndex);
+        outpointIndex = BTCUtils.reverseUint32(
+            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
+        );
+    }
+
+    /// @notice Compares the given outpoint against the wallet's expected
+    ///         main UTXO and, if it matches, marks it spent. Shared core
+    ///         of `consumeMainUtxoInputAt` and `processDissolutionInputs`'s
+    ///         either-order matching.
+    function _consumeMainUtxoOutpoint(
+        BridgeState.Storage storage self,
+        BitcoinTx.UTXO calldata mainUtxo,
+        bytes32 outpointTxHash,
+        uint32 outpointIndex
+    ) internal {
+        require(
+            mainUtxo.txHash == outpointTxHash &&
+                mainUtxo.txOutputIndex == outpointIndex,
+            "Transaction input must point to the wallet's main UTXO"
+        );
+
+        self.spentMainUTXOs[_outpointKey(outpointTxHash, outpointIndex)] = true;
+    }
+
+    /// @notice Processes the dissolution transaction inputs: exactly one
+    ///         input must spend the reservation's anchor outpoint and,
+    ///         if the wallet has a main UTXO, exactly one other input must
+    ///         spend that main UTXO. The two inputs may appear in either
+    ///         order -- Bitcoin does not constrain input ordering, and a
+    ///         wallet's transaction-construction tooling has no reason to
+    ///         place the anchor first. Requiring a fixed order would let
+    ///         an already-mined, fully valid dissolution transaction with
+    ///         the inputs swapped become permanently unprovable: since the
+    ///         spend is irreversible on Bitcoin once confirmed, the
+    ///         wallet's `mainUtxoHash` would never update to match Bitcoin's
+    ///         true state, silently bricking every subsequent Bitcoin
+    ///         operation for that wallet, not just this dissolution.
+    ///         Marks both consumed outpoints as correctly spent.
     /// @return inputsTotalValue Sum of all inputs values.
     function processDissolutionInputs(
         BridgeState.Storage storage self,
@@ -1344,32 +1538,57 @@ library Reservation {
             "Wrong number of dissolution transaction inputs"
         );
 
-        // The first input must spend the reservation's anchor outpoint.
-        uint256 nextInputIndex = consumeAnchorInputAt(
-            self,
-            reservation,
-            inputVector,
-            1 + varIntLength
-        );
-        inputsTotalValue = reservation.anchorAmount;
+        uint256 firstInputIndex = 1 + varIntLength;
 
-        if (mainUtxoExpected) {
-            require(
-                keccak256(
-                    abi.encodePacked(
-                        mainUtxo.txHash,
-                        mainUtxo.txOutputIndex,
-                        mainUtxo.txOutputValue
-                    )
-                ) == mainUtxoHash,
-                "Invalid main UTXO data"
-            );
-
-            consumeMainUtxoInputAt(self, inputVector, nextInputIndex, mainUtxo);
-            inputsTotalValue += mainUtxo.txOutputValue;
+        if (!mainUtxoExpected) {
+            // Single-input case: the sole input must be the anchor: no
+            // ordering ambiguity is possible.
+            consumeAnchorInputAt(self, reservation, inputVector, firstInputIndex);
+            return reservation.anchorAmount;
         }
 
-        return inputsTotalValue;
+        require(
+            keccak256(
+                abi.encodePacked(
+                    mainUtxo.txHash,
+                    mainUtxo.txOutputIndex,
+                    mainUtxo.txOutputValue
+                )
+            ) == mainUtxoHash,
+            "Invalid main UTXO data"
+        );
+
+        (bytes32 firstTxHash, uint32 firstIndex) = _peekOutpointAt(
+            inputVector,
+            firstInputIndex
+        );
+        uint256 secondInputIndex = firstInputIndex +
+            inputVector.determineInputLengthAt(firstInputIndex);
+
+        if (
+            firstTxHash == reservation.anchorTxHash &&
+            firstIndex == reservation.anchorTxOutputIndex
+        ) {
+            // First input is the anchor; second must be the main UTXO.
+            _consumeAnchorOutpoint(self, reservation, firstTxHash, firstIndex);
+            (bytes32 secondTxHash, uint32 secondIndex) = _peekOutpointAt(
+                inputVector,
+                secondInputIndex
+            );
+            _consumeMainUtxoOutpoint(self, mainUtxo, secondTxHash, secondIndex);
+        } else {
+            // First input must be the main UTXO instead; second must be
+            // the anchor. `_consumeMainUtxoOutpoint`/`_consumeAnchorOutpoint`
+            // still revert with a clear message if neither matches.
+            _consumeMainUtxoOutpoint(self, mainUtxo, firstTxHash, firstIndex);
+            (bytes32 secondTxHash, uint32 secondIndex) = _peekOutpointAt(
+                inputVector,
+                secondInputIndex
+            );
+            _consumeAnchorOutpoint(self, reservation, secondTxHash, secondIndex);
+        }
+
+        inputsTotalValue = reservation.anchorAmount + mainUtxo.txOutputValue;
     }
 
     /// @notice Asserts the input at the given starting index spends the
@@ -1389,43 +1608,11 @@ library Reservation {
             uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
         );
 
-        require(
-            reservation.anchorTxHash == outpointTxHash &&
-                reservation.anchorTxOutputIndex == outpointIndex,
-            "Transaction input must point to the reservation anchor"
-        );
-
-        uint256 anchorUtxoKey = _outpointKey(outpointTxHash, outpointIndex);
-        // See `consumeAnchor` for the `spentMainUTXOs` rationale.
-        self.spentMainUTXOs[anchorUtxoKey] = true;
+        _consumeAnchorOutpoint(self, reservation, outpointTxHash, outpointIndex);
 
         nextInputIndex =
             inputStartingIndex +
             inputVector.determineInputLengthAt(inputStartingIndex);
-    }
-
-    /// @notice Asserts the input at the given starting index spends the
-    ///         wallet's main UTXO and marks it as correctly spent.
-    function consumeMainUtxoInputAt(
-        BridgeState.Storage storage self,
-        bytes memory inputVector,
-        uint256 inputStartingIndex,
-        BitcoinTx.UTXO calldata mainUtxo
-    ) internal {
-        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
-            inputStartingIndex
-        );
-        uint32 outpointIndex = BTCUtils.reverseUint32(
-            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
-        );
-
-        require(
-            mainUtxo.txHash == outpointTxHash &&
-                mainUtxo.txOutputIndex == outpointIndex,
-            "Transaction input must point to the wallet's main UTXO"
-        );
-
-        self.spentMainUTXOs[_outpointKey(outpointTxHash, outpointIndex)] = true;
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count
@@ -1447,6 +1634,13 @@ library Reservation {
         self.walletReservationsCount[walletPubKeyHash] -= 1;
         self.reservationTotalAmount -= mintedAmount;
         reservation.state = ReservationState.Closed;
+        // Clear flags that only have meaning for an in-progress or
+        // recently-timed-out redemption request; leaving them set would be
+        // harmless (both are re-derived fresh on any future request cycle
+        // and this reservation key can never re-enter `Active`) but is
+        // stale state with no purpose once the reservation is terminal.
+        reservation.lastTimeoutWasWalletFault = false;
+        reservation.currentRequestIsRetry = false;
         delete self.reservedRedemptionSettlements[reservationKey];
     }
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -358,6 +358,10 @@ library Reservation {
         require(deposit.revealedAt != 0, "Deposit not revealed");
         require(deposit.sweptAt == 0, "Deposit already swept");
         require(
+            self.pendingReservedDeposit[reservationKey].isReserved,
+            "Deposit was not revealed as reserved"
+        );
+        require(
             deposit.vault == self.reservationVault,
             "Deposit not routed to the reservation vault"
         );

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -171,6 +171,8 @@ library Reservation {
         bytes20 indexed walletPubKeyHash
     );
 
+    event ReservedRedemptionVetoed(uint256 indexed reservationKey);
+
     event ReservationReanchored(
         uint256 indexed reservationKey,
         bytes20 indexed newWalletPubKeyHash,
@@ -705,6 +707,49 @@ library Reservation {
 
         // Return the surrendered balance to the redeemer as Bank balance.
         self.bank.transferBalance(redeemer, refundAmount);
+    }
+
+    /// @notice Notifies that a pending reserved redemption was vetoed in the
+    ///         redemption watchtower. Mirrors
+    ///         `Redemption.notifyRedemptionVeto`: the surrendered balance is
+    ///         detained and passed to the watchtower (as Bank balance) for
+    ///         further processing, the pending request is cleared, and the
+    ///         reservation returns to the Active state -- the anchor
+    ///         outpoint was not spent, so the in-kind claim survives.
+    /// @param reservationKey The key of the reservation with the vetoed
+    ///        redemption.
+    /// @dev Requirements:
+    ///      - The caller must be the redemption watchtower,
+    ///      - The reservation must have a pending reserved redemption.
+    function notifyReservedRedemptionVeto(
+        BridgeState.Storage storage self,
+        uint256 reservationKey
+    ) external {
+        require(
+            msg.sender == self.redemptionWatchtower,
+            "Caller is not the redemption watchtower"
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.RedemptionRequested,
+            "No pending reserved redemption"
+        );
+
+        uint64 detainedAmount = reservation.mintedAmount;
+
+        reservation.state = ReservationState.Active;
+        reservation.redeemer = address(0);
+        reservation.redeemerOutputScriptHash = bytes32(0);
+        reservation.redemptionRequestedAt = 0;
+        reservation.redemptionTxMaxFee = 0;
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionVetoed(reservationKey);
+
+        self.bank.transferBalance(self.redemptionWatchtower, detainedAmount);
     }
 
     /// @notice Used by the wallet to prove a re-anchor transaction moving a

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -818,15 +818,20 @@ library Reservation {
             "Transaction fee is too high"
         );
 
-        // Floor the anchor at the reservation minimum so that repeated,
-        // network-scheduled re-anchor hops cannot grind the anchored amount
-        // down toward the miner fee. Because `reservationMinAmount` is
-        // required to exceed `reservationTxMaxFee`, this also keeps the
-        // anchor safely above the redemption fee bound, preserving
-        // redemption liveness across migrations.
+        // Dust floor: the re-anchored amount must stay strictly above the
+        // per-transaction fee bound, keeping the anchor clear of dust and
+        // preserving positive redemption value. This is deliberately a dust
+        // floor rather than `reservationMinAmount`: a minimum-sized
+        // reservation must remain migratable (a `reservationMinAmount` floor
+        // combined with the proposal validator's positive-fee requirement
+        // would leave no compliant re-anchor for an exactly-minimum anchor,
+        // pinning a retiring wallet). Bounding cumulative Byzantine
+        // re-anchor grinding is deferred to the authorized-action model (an
+        // explicit migration request with nonce, owner/target authorization,
+        // and a cumulative fee budget), tracked as a follow-up.
         require(
-            newAnchorAmount >= self.reservationMinAmount,
-            "Re-anchor amount below the reservation minimum"
+            newAnchorAmount > self.reservationTxMaxFee,
+            "Re-anchor amount below the dust floor"
         );
 
         bytes20 oldWalletPubKeyHash = reservation.walletPubKeyHash;

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -638,10 +638,19 @@ library Reservation {
             );
         }
 
+        // Underflow-safe range check. `redemptionTxMaxFee` is a governable
+        // parameter, not a value derived from the proven transaction, so it
+        // may exceed `anchorAmount` after re-anchor hops shrink the anchor
+        // or after a governance fee increase. The equivalent formulation
+        // below avoids the `anchorAmount - redemptionTxMaxFee` subtraction
+        // that would otherwise revert and permanently strand the
+        // reservation. `outputValue <= anchorAmount` is guaranteed by
+        // Bitcoin consensus (an output cannot exceed its input) but is
+        // asserted defensively.
         require(
-            reservation.anchorAmount - reservation.redemptionTxMaxFee <=
-                outputValue &&
-                outputValue <= reservation.anchorAmount,
+            outputValue <= reservation.anchorAmount &&
+                reservation.anchorAmount - outputValue <=
+                reservation.redemptionTxMaxFee,
             "Output value is not within the acceptable range"
         );
 
@@ -801,10 +810,23 @@ library Reservation {
             "Target wallet must be in Live state"
         );
 
+        // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
+        // consensus (the re-anchor output cannot exceed its input).
         require(
             reservation.anchorAmount - newAnchorAmount <=
                 self.reservationTxMaxFee,
             "Transaction fee is too high"
+        );
+
+        // Floor the anchor at the reservation minimum so that repeated,
+        // network-scheduled re-anchor hops cannot grind the anchored amount
+        // down toward the miner fee. Because `reservationMinAmount` is
+        // required to exceed `reservationTxMaxFee`, this also keeps the
+        // anchor safely above the redemption fee bound, preserving
+        // redemption liveness across migrations.
+        require(
+            newAnchorAmount >= self.reservationMinAmount,
+            "Re-anchor amount below the reservation minimum"
         );
 
         bytes20 oldWalletPubKeyHash = reservation.walletPubKeyHash;

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -1,0 +1,1129 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
+import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
+
+import "./BitcoinTx.sol";
+import "./BridgeState.sol";
+import "./Deposit.sol";
+import "./Redemption.sol";
+import "./Wallets.sol";
+
+import "../bank/Bank.sol";
+
+/// @title Bridge UTXO reservations
+/// @notice The library handles the logic for reserving deposited UTXOs so
+///         that a depositor's coins are custodied without ever being
+///         commingled with the pooled supply and are returned in-kind --
+///         with an unbroken 1-input-1-output lineage -- upon redemption.
+/// @dev A reserved deposit is a regular revealed deposit routed to the
+///      designated reservation vault (`reveal.vault == reservationVault`).
+///      Instead of being swept into the wallet's main UTXO, a reserved
+///      deposit is *anchored*: the wallet performs a 1-input-1-output spend
+///      of the deposit into a fresh wallet-controlled P2(W)PKH output that
+///      carries no refund path. The Bank balance is credited only when the
+///      SPV proof of that anchor transaction is submitted. The anchor thus
+///      mirrors the sweep's refund-disabling role while dropping its
+///      consolidating role -- balances are never credited against an output
+///      the depositor could still claw back, and the coins never merge with
+///      the pooled supply.
+///
+///      The registry tracks the reservation's current anchor outpoint
+///      through optional re-anchoring hops (wallet migration) until the
+///      reservation is closed by an in-kind redemption, or -- once the
+///      custody term and grace period elapse -- dissolved into the wallet's
+///      main UTXO, at which point the owner's balance simply remains an
+///      ordinary pooled claim.
+///
+///      Claim accounting: the amount credited (`mintedAmount`) is the gross
+///      anchor output value; the per-deposit treasury fee computed at reveal
+///      time is deliberately not netted. All protocol fees are charged by
+///      the reservation vault as explicit transfers. Bitcoin miner fees are
+///      the only in-kind deductions: the anchor and any re-anchor fees
+///      reduce the on-chain `anchorAmount`, while the reserved redemption
+///      always burns the full `mintedAmount`, so supply and backing
+///      reconcile exactly when the reservation closes via redemption.
+///
+///      Fraud-defense integration: accepting a reservation marks the
+///      underlying deposit as swept (making the deposit outpoint recognized
+///      by `Fraud.defeatFraudChallenge`), and every proven consumption of an
+///      anchor outpoint (redemption, re-anchor, dissolution) records it in
+///      `spentMainUTXOs` -- the existing registry of honestly-spent,
+///      wallet-controlled outpoints the fraud defeat path consults.
+library Reservation {
+    using BridgeState for BridgeState.Storage;
+    using Wallets for BridgeState.Storage;
+    using BitcoinTx for BridgeState.Storage;
+
+    using BTCUtils for bytes;
+    using BytesLib for bytes;
+
+    /// @notice Represents the state of a reservation.
+    enum ReservationState {
+        /// @dev The reservation is unknown to the Bridge.
+        Unknown,
+        /// @dev The reservation was accepted (anchor proven, balance
+        ///      credited) and its anchor outpoint is under wallet custody.
+        Active,
+        /// @dev The owner requested an in-kind redemption of the reserved
+        ///      outpoint and surrendered the gross balance. The wallet is
+        ///      expected to spend the anchor to the redeemer script.
+        RedemptionRequested,
+        /// @dev The reservation was closed, either by a proven in-kind
+        ///      redemption or by dissolution into the wallet's main UTXO.
+        Closed
+    }
+
+    /// @notice Represents a UTXO reservation.
+    struct ReservationRequest {
+        // The reservation owner holding the in-kind redemption right. Set to
+        // the deposit's depositor at acceptance time.
+        address owner;
+        // Gross amount in satoshi credited to the owner via the reservation
+        // vault at acceptance time. This is the amount that must be
+        // surrendered and burned when the reservation is redeemed in-kind.
+        uint64 mintedAmount;
+        // UNIX timestamp the reservation was accepted at.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 acceptedAt;
+        // 20-byte public key hash of the wallet custodying the current
+        // anchor outpoint.
+        bytes20 walletPubKeyHash;
+        // Value in satoshi of the current anchor outpoint. Starts equal to
+        // `mintedAmount` and decreases by the Bitcoin miner fee on each
+        // re-anchor hop.
+        uint64 anchorAmount;
+        // UNIX timestamp the custody term expires at. Purely a contract
+        // layer fact -- the anchor output carries no timelock. After
+        // `expiresAt + reservationGracePeriod` the wallet may dissolve the
+        // reservation into its main UTXO.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 expiresAt;
+        // Hash of the Bitcoin transaction holding the current anchor output.
+        bytes32 anchorTxHash;
+        // Output index of the current anchor output. Always 0 given anchor
+        // transactions have a single output; kept for auditability.
+        uint32 anchorTxOutputIndex;
+        // Current state of the reservation.
+        ReservationState state;
+        // UNIX timestamp the pending reserved redemption was requested at.
+        // Zero when no redemption is pending.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 redemptionRequestedAt;
+        // Transaction maximum BTC fee in satoshi snapshotted at redemption
+        // request time.
+        uint64 redemptionTxMaxFee;
+        // The address able to claim the surrendered balance back should the
+        // pending reserved redemption time out.
+        address redeemer;
+        // keccak256 hash of the length-prefixed redeemer output script the
+        // pending reserved redemption must pay to.
+        bytes32 redeemerOutputScriptHash;
+        // This struct doesn't contain `__gap` property as the structure is
+        // stored in a mapping, mappings store values in different slots and
+        // they are not contiguous with other values.
+    }
+
+    event ReservationAccepted(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        address indexed owner,
+        bytes32 anchorTxHash,
+        uint64 anchorAmount,
+        uint32 expiresAt
+    );
+
+    event ReservationExtended(
+        uint256 indexed reservationKey,
+        uint32 newExpiresAt
+    );
+
+    event ReservedRedemptionRequested(
+        uint256 indexed reservationKey,
+        address indexed redeemer,
+        bytes redeemerOutputScript,
+        uint64 mintedAmount,
+        uint64 txMaxFee
+    );
+
+    event ReservedRedemptionCompleted(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    event ReservedRedemptionTimedOut(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
+    event ReservationReanchored(
+        uint256 indexed reservationKey,
+        bytes20 indexed newWalletPubKeyHash,
+        bytes32 newAnchorTxHash,
+        uint64 newAnchorAmount
+    );
+
+    event ReservationDissolved(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        bytes32 dissolutionTxHash
+    );
+
+    event ReservationParametersUpdated(
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    );
+
+    event ReservationVaultUpdated(address reservationVault);
+
+    /// @notice Represents the type of a reservation lifecycle SPV proof.
+    enum ProofType {
+        /// @dev Proof of the anchor transaction accepting a reserved
+        ///      deposit. `mainUtxo` and `reservationKey` parameters are
+        ///      ignored; the reservation key is derived from the spent
+        ///      deposit outpoint.
+        Acceptance,
+        /// @dev Proof of an in-kind reserved redemption transaction.
+        ///      `mainUtxo` parameter is ignored.
+        Redemption,
+        /// @dev Proof of a re-anchor transaction moving the anchor outpoint
+        ///      to another wallet. `mainUtxo` parameter is ignored.
+        Reanchor,
+        /// @dev Proof of a dissolution transaction merging an expired
+        ///      reservation's anchor into the wallet's main UTXO.
+        Dissolution
+    }
+
+    /// @notice Single entry point for all reservation lifecycle SPV proofs.
+    ///         Dispatches to the appropriate handler based on `proofType`.
+    ///         Consolidated into one external function to preserve the
+    ///         Bridge contract's EIP-170 deployment size margin.
+    /// @param proofType The type of the submitted proof, see `ProofType`.
+    /// @param txInfo Bitcoin transaction data.
+    /// @param proof Bitcoin proof data.
+    /// @param mainUtxo Data of the wallet's main UTXO; only used for
+    ///        `Dissolution` proofs and ignored otherwise.
+    /// @param reservationKey The key of the target reservation; ignored for
+    ///        `Acceptance` proofs where the key is derived from the spent
+    ///        deposit outpoint.
+    function submitReservationProof(
+        BridgeState.Storage storage self,
+        uint8 proofType,
+        BitcoinTx.Info calldata txInfo,
+        BitcoinTx.Proof calldata proof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey
+    ) external {
+        ProofType parsedProofType = ProofType(proofType);
+
+        if (parsedProofType == ProofType.Acceptance) {
+            submitReservationAcceptanceProof(self, txInfo, proof);
+        } else if (parsedProofType == ProofType.Redemption) {
+            submitReservedRedemptionProof(self, txInfo, proof, reservationKey);
+        } else if (parsedProofType == ProofType.Reanchor) {
+            submitReservationReanchorProof(self, txInfo, proof, reservationKey);
+        } else {
+            submitReservationDissolutionProof(
+                self,
+                txInfo,
+                proof,
+                mainUtxo,
+                reservationKey
+            );
+        }
+    }
+
+    /// @notice Used by the wallet to prove the BTC anchor transaction of a
+    ///         reserved deposit and to credit the owner's balance
+    ///         accordingly. The anchor is only accepted if it satisfies SPV
+    ///         proof.
+    ///
+    ///         The anchor transaction must spend exactly the revealed
+    ///         reserved deposit as its sole input and create exactly one
+    ///         P2(W)PKH output controlled by a registered wallet. Proving it
+    ///         marks the deposit as swept (blocking any regular sweep and
+    ///         enabling fraud challenge defeats for the deposit outpoint),
+    ///         registers the reservation and credits the gross anchor value
+    ///         to the depositor through the reservation vault.
+    /// @param anchorTx Bitcoin anchor transaction data.
+    /// @param anchorProof Bitcoin anchor proof data.
+    /// @dev Requirements:
+    ///      - The reservation vault must be set,
+    ///      - `anchorTx` must have exactly one input pointing to a revealed,
+    ///        unswept deposit routed to the reservation vault,
+    ///      - `anchorTx` must have exactly one P2(W)PKH output locking funds
+    ///        on a 20-byte public key hash of a Live or MovingFunds wallet,
+    ///      - The anchor output value must respect the reservation minimum
+    ///        amount, the per-transaction max fee, and the reservation caps.
+    function submitReservationAcceptanceProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata anchorTx,
+        BitcoinTx.Proof calldata anchorProof
+    ) internal {
+        require(
+            self.reservationVault != address(0),
+            "Reservations are disabled"
+        );
+
+        bytes32 anchorTxHash = self.validateProof(anchorTx, anchorProof);
+
+        uint256 reservationKey = resolveAcceptedDeposit(
+            self,
+            anchorTx.inputVector
+        );
+
+        (bytes20 walletPubKeyHash, uint64 anchorAmount) = processAnchorOutput(
+            self,
+            anchorTx.outputVector
+        );
+
+        Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
+
+        require(
+            anchorAmount >= self.reservationMinAmount,
+            "Reservation amount too small"
+        );
+        // The difference between the deposit value and the anchor output
+        // value is the Bitcoin miner fee of the anchor transaction -- the
+        // only in-kind deduction the reservation lifecycle allows.
+        require(
+            deposit.amount - anchorAmount <= self.reservationTxMaxFee,
+            "Transaction fee is too high"
+        );
+
+        registerReservation(
+            self,
+            reservationKey,
+            deposit.depositor,
+            walletPubKeyHash,
+            anchorAmount,
+            anchorTxHash
+        );
+
+        // Credit the gross anchored amount through the reservation vault.
+        // The per-deposit treasury fee computed at reveal time is
+        // deliberately ignored: reservation claims are minted gross and all
+        // protocol fees are charged as explicit transfers by the vault.
+        address[] memory depositors = new address[](1);
+        depositors[0] = deposit.depositor;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = anchorAmount;
+        self.bank.increaseBalanceAndCall(
+            self.reservationVault,
+            depositors,
+            amounts
+        );
+    }
+
+    /// @notice Resolves the reserved deposit spent by the anchor transaction
+    ///         input vector, validates it and marks it as swept. Marking the
+    ///         deposit as swept blocks any future regular sweep, prevents
+    ///         double acceptance, and makes the deposit outpoint recognized
+    ///         as correctly spent by the fraud challenge defeat path.
+    /// @return reservationKey The deposit key of the reserved deposit, used
+    ///         as the reservation key.
+    function resolveAcceptedDeposit(
+        BridgeState.Storage storage self,
+        bytes memory inputVector
+    ) internal returns (uint256 reservationKey) {
+        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+            .parseWalletOutboundTxInput(inputVector);
+
+        reservationKey = uint256(
+            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+        );
+
+        Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
+        require(deposit.revealedAt != 0, "Deposit not revealed");
+        require(deposit.sweptAt == 0, "Deposit already swept");
+        require(
+            deposit.vault == self.reservationVault,
+            "Deposit not routed to the reservation vault"
+        );
+
+        /* solhint-disable-next-line not-rely-on-time */
+        deposit.sweptAt = uint32(block.timestamp);
+    }
+
+    /// @notice Parses the anchor transaction single output and validates it
+    ///         is controlled by a Live or MovingFunds wallet.
+    function processAnchorOutput(
+        BridgeState.Storage storage self,
+        bytes memory outputVector
+    ) internal view returns (bytes20 walletPubKeyHash, uint64 anchorAmount) {
+        bytes memory anchorOutput = parseSingleOutput(outputVector);
+        walletPubKeyHash = self.extractPubKeyHash(anchorOutput);
+        anchorAmount = anchorOutput.extractValue();
+
+        Wallets.WalletState walletState = self
+            .registeredWallets[walletPubKeyHash]
+            .state;
+        require(
+            walletState == Wallets.WalletState.Live ||
+                walletState == Wallets.WalletState.MovingFunds,
+            "Anchor wallet must be in Live or MovingFunds state"
+        );
+    }
+
+    /// @notice Registers a new reservation: checks and adjusts the caps,
+    ///         stores the reservation record and indexes the anchor
+    ///         outpoint.
+    function registerReservation(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        address owner,
+        bytes20 walletPubKeyHash,
+        uint64 anchorAmount,
+        bytes32 anchorTxHash
+    ) internal {
+        uint64 newTotal = self.reservationTotalAmount + anchorAmount;
+        require(
+            newTotal <= self.reservationMaxTotalAmount,
+            "Total reserved amount cap exceeded"
+        );
+        self.reservationTotalAmount = newTotal;
+
+        uint32 walletCount = self.walletReservationsCount[walletPubKeyHash] + 1;
+        require(
+            walletCount <= self.maxReservationsPerWallet,
+            "Wallet reservations cap exceeded"
+        );
+        self.walletReservationsCount[walletPubKeyHash] = walletCount;
+
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 expiresAt = uint32(block.timestamp) +
+            self.reservationTermSeconds;
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        reservation.owner = owner;
+        reservation.mintedAmount = anchorAmount;
+        /* solhint-disable-next-line not-rely-on-time */
+        reservation.acceptedAt = uint32(block.timestamp);
+        reservation.walletPubKeyHash = walletPubKeyHash;
+        reservation.anchorAmount = anchorAmount;
+        reservation.expiresAt = expiresAt;
+        reservation.anchorTxHash = anchorTxHash;
+        reservation.anchorTxOutputIndex = 0;
+        reservation.state = ReservationState.Active;
+
+        self.reservationsByAnchorUtxo[
+            uint256(keccak256(abi.encodePacked(anchorTxHash, uint32(0))))
+        ] = reservationKey;
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservationAccepted(
+            reservationKey,
+            walletPubKeyHash,
+            owner,
+            anchorTxHash,
+            anchorAmount,
+            expiresAt
+        );
+    }
+
+    /// @notice Extends the custody term of a reservation by the current
+    ///         reservation term length. The custody fee for the extension is
+    ///         collected by the reservation vault before this call.
+    /// @param reservationKey The key of the reservation to extend.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation vault,
+    ///      - The reservation must be in the Active or RedemptionRequested
+    ///        state,
+    ///      - The reservation must not be past its grace period.
+    function extendReservation(
+        BridgeState.Storage storage self,
+        uint256 reservationKey
+    ) external {
+        require(
+            msg.sender == self.reservationVault,
+            "Caller is not the reservation vault"
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.Active ||
+                reservation.state == ReservationState.RedemptionRequested,
+            "Reservation is not active"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <=
+                uint256(reservation.expiresAt) + self.reservationGracePeriod,
+            "Reservation past grace period"
+        );
+
+        uint32 base = reservation.expiresAt;
+        /* solhint-disable-next-line not-rely-on-time */
+        if (base < block.timestamp) {
+            /* solhint-disable-next-line not-rely-on-time */
+            base = uint32(block.timestamp);
+        }
+        reservation.expiresAt = base + self.reservationTermSeconds;
+
+        emit ReservationExtended(reservationKey, reservation.expiresAt);
+    }
+
+    /// @notice Requests an in-kind redemption of a reservation: the wallet
+    ///         is expected to spend exactly the reservation's anchor
+    ///         outpoint to the redeemer output script in a 1-input-1-output
+    ///         transaction. The gross minted amount is taken from the
+    ///         reservation vault's Bank balance and held by the Bridge until
+    ///         the redemption is proven (burned) or times out (returned to
+    ///         the redeemer).
+    /// @param reservationKey The key of the reservation to redeem.
+    /// @param redeemer The address able to claim the surrendered balance
+    ///        back if the redemption times out.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to
+    ///        lock the redeemed BTC.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation vault, which must have
+    ///        approved the Bridge in the Bank for the gross minted amount,
+    ///      - The reservation must be in the Active state,
+    ///      - If the redemption watchtower is set, the request must be
+    ///        considered safe by the watchtower,
+    ///      - `redeemerOutputScript` must be a standard type and must not
+    ///        pay to the custodying wallet's public key hash.
+    function requestReservedRedemption(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript
+    ) external {
+        require(
+            msg.sender == self.reservationVault,
+            "Caller is not the reservation vault"
+        );
+        require(
+            redeemer != address(0),
+            "Redeemer must not be the zero address"
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.Active,
+            "Reservation is not active"
+        );
+
+        if (self.redemptionWatchtower != address(0)) {
+            require(
+                IRedemptionWatchtower(self.redemptionWatchtower)
+                    .isSafeRedemption(
+                        reservation.walletPubKeyHash,
+                        redeemerOutputScript,
+                        self.reservationVault,
+                        redeemer
+                    ),
+                "Redemption request rejected by the watchtower"
+            );
+        }
+
+        bytes memory redeemerOutputScriptMem = redeemerOutputScript;
+
+        // Validate the redeemer output script is a correct standard type
+        // (P2PKH, P2WPKH, P2SH or P2WSH), the same way `Redemption` does.
+        bytes memory redeemerOutputScriptPayload = redeemerOutputScriptMem
+            .extractHashAt(0, redeemerOutputScriptMem.length);
+        require(
+            redeemerOutputScriptPayload.length > 0,
+            "Redeemer output script must be a standard type"
+        );
+        require(
+            redeemerOutputScriptPayload.length != 20 ||
+                reservation.walletPubKeyHash !=
+                redeemerOutputScriptPayload.slice20(0),
+            "Redeemer output script must not point to the wallet PKH"
+        );
+
+        reservation.state = ReservationState.RedemptionRequested;
+        reservation.redeemer = redeemer;
+        reservation.redeemerOutputScriptHash = keccak256(
+            redeemerOutputScriptMem
+        );
+        /* solhint-disable-next-line not-rely-on-time */
+        reservation.redemptionRequestedAt = uint32(block.timestamp);
+        reservation.redemptionTxMaxFee = self.reservationTxMaxFee;
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionRequested(
+            reservationKey,
+            redeemer,
+            redeemerOutputScript,
+            reservation.mintedAmount,
+            reservation.redemptionTxMaxFee
+        );
+
+        self.bank.transferBalanceFrom(
+            msg.sender,
+            address(this),
+            reservation.mintedAmount
+        );
+    }
+
+    /// @notice Used by the wallet to prove the BTC reserved redemption
+    ///         transaction and close the reservation. The transaction must
+    ///         spend exactly the reservation's anchor outpoint as its sole
+    ///         input and pay the requested redeemer output script as its
+    ///         sole output. The full gross minted amount is burned: the
+    ///         difference between the burned amount and the BTC paid out is
+    ///         the Bitcoin miner fee (plus any re-anchor fees accrued
+    ///         in-kind during custody), so supply and backing reconcile
+    ///         exactly.
+    /// @param redemptionTx Bitcoin reserved redemption transaction data.
+    /// @param redemptionProof Bitcoin reserved redemption proof data.
+    /// @param reservationKey The key of the reservation being redeemed.
+    /// @dev Requirements:
+    ///      - The reservation must have a pending reserved redemption,
+    ///      - `redemptionTx` must spend the reservation's current anchor
+    ///        outpoint as its sole input,
+    ///      - `redemptionTx` must have a single output paying the requested
+    ///        redeemer output script with a value within the acceptable
+    ///        range.
+    function submitReservedRedemptionProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata redemptionTx,
+        BitcoinTx.Proof calldata redemptionProof,
+        uint256 reservationKey
+    ) internal {
+        bytes32 redemptionTxHash = self.validateProof(
+            redemptionTx,
+            redemptionProof
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.RedemptionRequested,
+            "No pending reserved redemption"
+        );
+
+        consumeAnchor(self, reservation, redemptionTx.inputVector);
+
+        bytes memory output = parseSingleOutput(redemptionTx.outputVector);
+        uint64 outputValue = output.extractValue();
+
+        {
+            bytes memory outputScript = output.slice(8, output.length - 8);
+            require(
+                keccak256(outputScript) == reservation.redeemerOutputScriptHash,
+                "Output does not pay the requested redeemer script"
+            );
+        }
+
+        require(
+            reservation.anchorAmount - reservation.redemptionTxMaxFee <=
+                outputValue &&
+                outputValue <= reservation.anchorAmount,
+            "Output value is not within the acceptable range"
+        );
+
+        closeReservation(self, reservation);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionCompleted(reservationKey, redemptionTxHash);
+
+        // Burn the gross minted amount held by the Bridge since the
+        // redemption request.
+        self.bank.decreaseBalance(reservation.mintedAmount);
+    }
+
+    /// @notice Notifies that a pending reserved redemption has timed out.
+    ///         The surrendered balance is returned to the redeemer, the
+    ///         wallet operators are slashed the same way as for a regular
+    ///         redemption timeout, and the reservation returns to the
+    ///         Active state -- the anchor outpoint was not spent, so the
+    ///         in-kind claim survives and the redemption can be re-requested.
+    /// @param reservationKey The key of the reservation with the timed out
+    ///        redemption.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members.
+    /// @dev Requirements:
+    ///      - The reservation must have a pending reserved redemption,
+    ///      - The amount of time defined by `redemptionTimeout` must have
+    ///        passed since the reserved redemption was requested.
+    function notifyReservedRedemptionTimeout(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.RedemptionRequested,
+            "No pending reserved redemption"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp >
+                reservation.redemptionRequestedAt + self.redemptionTimeout,
+            "Redemption request has not timed out"
+        );
+
+        address redeemer = reservation.redeemer;
+        uint64 refundAmount = reservation.mintedAmount;
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+
+        reservation.state = ReservationState.Active;
+        reservation.redeemer = address(0);
+        reservation.redeemerOutputScriptHash = bytes32(0);
+        reservation.redemptionRequestedAt = 0;
+        reservation.redemptionTxMaxFee = 0;
+
+        // Propagate timeout consequences to the wallet: slashing and state
+        // transition follow exactly the regular redemption timeout rules.
+        self.notifyWalletRedemptionTimeout(walletPubKeyHash, walletMembersIDs);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionTimedOut(reservationKey, walletPubKeyHash);
+
+        // Return the surrendered balance to the redeemer as Bank balance.
+        self.bank.transferBalance(redeemer, refundAmount);
+    }
+
+    /// @notice Used by the wallet to prove a re-anchor transaction moving a
+    ///         reservation's anchor outpoint to another (or a fresh output
+    ///         of the same) wallet in a 1-input-1-output spend. Used during
+    ///         wallet migration so reservations never pin retiring wallets.
+    /// @param reanchorTx Bitcoin re-anchor transaction data.
+    /// @param reanchorProof Bitcoin re-anchor proof data.
+    /// @param reservationKey The key of the reservation being re-anchored.
+    /// @dev Requirements:
+    ///      - The reservation must be in the Active state (a pending
+    ///        reserved redemption blocks re-anchoring),
+    ///      - `reanchorTx` must spend the current anchor outpoint as its
+    ///        sole input and create a single P2(W)PKH output controlled by
+    ///        a Live wallet,
+    ///      - The value difference (Bitcoin miner fee) must not exceed the
+    ///        reservation transaction max fee.
+    ///
+    ///      The source wallet state is deliberately not restricted: the
+    ///      ability to produce the transaction is enforced by Bitcoin (only
+    ///      the custodying wallet can sign the anchor spend) and moving
+    ///      reservations out must remain possible for wallets in any
+    ///      lifecycle state.
+    function submitReservationReanchorProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata reanchorTx,
+        BitcoinTx.Proof calldata reanchorProof,
+        uint256 reservationKey
+    ) internal {
+        bytes32 reanchorTxHash = self.validateProof(reanchorTx, reanchorProof);
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.Active,
+            "Reservation is not active"
+        );
+
+        consumeAnchor(self, reservation, reanchorTx.inputVector);
+
+        bytes memory output = parseSingleOutput(reanchorTx.outputVector);
+        bytes20 newWalletPubKeyHash = self.extractPubKeyHash(output);
+        uint64 newAnchorAmount = output.extractValue();
+
+        require(
+            self.registeredWallets[newWalletPubKeyHash].state ==
+                Wallets.WalletState.Live,
+            "Target wallet must be in Live state"
+        );
+
+        require(
+            reservation.anchorAmount - newAnchorAmount <=
+                self.reservationTxMaxFee,
+            "Transaction fee is too high"
+        );
+
+        bytes20 oldWalletPubKeyHash = reservation.walletPubKeyHash;
+        if (oldWalletPubKeyHash != newWalletPubKeyHash) {
+            self.walletReservationsCount[oldWalletPubKeyHash] -= 1;
+            uint32 newCount = self.walletReservationsCount[
+                newWalletPubKeyHash
+            ] + 1;
+            require(
+                newCount <= self.maxReservationsPerWallet,
+                "Wallet reservations cap exceeded"
+            );
+            self.walletReservationsCount[newWalletPubKeyHash] = newCount;
+        }
+
+        // The miner fee reduces the on-chain earmarked amount. The gross
+        // claim (`mintedAmount`) is unchanged; the accumulated in-kind fees
+        // are settled when the reservation is redeemed (full gross burn).
+        self.reservationTotalAmount -= (reservation.anchorAmount -
+            newAnchorAmount);
+
+        reservation.walletPubKeyHash = newWalletPubKeyHash;
+        reservation.anchorAmount = newAnchorAmount;
+        reservation.anchorTxHash = reanchorTxHash;
+        reservation.anchorTxOutputIndex = 0;
+
+        self.reservationsByAnchorUtxo[
+            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
+        ] = reservationKey;
+
+        emit ReservationReanchored(
+            reservationKey,
+            newWalletPubKeyHash,
+            reanchorTxHash,
+            newAnchorAmount
+        );
+    }
+
+    /// @notice Used by the wallet to prove a dissolution transaction merging
+    ///         an expired reservation's anchor outpoint into the wallet's
+    ///         main UTXO. After dissolution the owner's minted balance
+    ///         simply remains an ordinary pooled claim; no balances are
+    ///         moved or burned.
+    /// @param dissolutionTx Bitcoin dissolution transaction data.
+    /// @param dissolutionProof Bitcoin dissolution proof data.
+    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
+    ///        the Ethereum chain. Ignored if the wallet has no main UTXO.
+    /// @param reservationKey The key of the reservation being dissolved.
+    /// @dev Requirements:
+    ///      - The reservation must be in the Active state (a pending
+    ///        reserved redemption always wins over dissolution),
+    ///      - The custody term plus grace period must have elapsed,
+    ///      - The custodying wallet must be in Live or MovingFunds state,
+    ///      - If the wallet has a main UTXO, `dissolutionTx` must spend
+    ///        exactly the anchor outpoint (first input) and that main UTXO
+    ///        (second input); otherwise it must spend exactly the anchor
+    ///        outpoint,
+    ///      - `dissolutionTx` must have a single P2(W)PKH output locking
+    ///        funds back on the custodying wallet's public key hash; that
+    ///        output becomes the wallet's new main UTXO.
+    ///
+    ///      Note the Bridge cannot verify *when* the dissolution transaction
+    ///      was signed. A wallet signing it before the grace period elapses
+    ///      cannot prove it here (this function reverts), so such a spend is
+    ///      an undefeatable fraud challenge target until the grace period
+    ///      passes -- premature dissolution is deterred economically by the
+    ///      fraud slashing machinery.
+    function submitReservationDissolutionProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata dissolutionTx,
+        BitcoinTx.Proof calldata dissolutionProof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey
+    ) internal {
+        bytes32 dissolutionTxHash = self.validateProof(
+            dissolutionTx,
+            dissolutionProof
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.Active,
+            "Reservation is not active"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp >
+                uint256(reservation.expiresAt) + self.reservationGracePeriod,
+            "Reservation term or grace period not elapsed"
+        );
+
+        Wallets.Wallet storage wallet = self.registeredWallets[
+            reservation.walletPubKeyHash
+        ];
+        {
+            Wallets.WalletState walletState = wallet.state;
+            require(
+                walletState == Wallets.WalletState.Live ||
+                    walletState == Wallets.WalletState.MovingFunds,
+                "Wallet must be in Live or MovingFunds state"
+            );
+        }
+
+        uint64 inputsTotalValue = processDissolutionInputs(
+            self,
+            reservation,
+            dissolutionTx.inputVector,
+            wallet.mainUtxoHash,
+            mainUtxo
+        );
+
+        bytes memory output = parseSingleOutput(dissolutionTx.outputVector);
+        uint64 outputValue = output.extractValue();
+        require(
+            self.extractPubKeyHash(output) == reservation.walletPubKeyHash,
+            "Dissolution output must pay to the custodying wallet"
+        );
+        require(
+            inputsTotalValue - outputValue <= self.reservationTxMaxFee,
+            "Transaction fee is too high"
+        );
+
+        // The dissolution output becomes the wallet's new main UTXO: the
+        // reserved backing rejoins the pooled supply.
+        wallet.mainUtxoHash = keccak256(
+            abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
+        );
+
+        closeReservation(self, reservation);
+
+        emit ReservationDissolved(
+            reservationKey,
+            reservation.walletPubKeyHash,
+            dissolutionTxHash
+        );
+    }
+
+    /// @notice Updates the reservation parameters, including the
+    ///         reservation vault address. Deposits revealed with the
+    ///         reservation vault address are treated as reserved deposits.
+    /// @dev Requirements:
+    ///      - Reservation transaction max fee must be greater than zero,
+    ///      - Reservation minimum amount must be greater than the
+    ///        reservation transaction max fee,
+    ///      - Reservation term must be greater than zero,
+    ///      - The reservation vault can only be changed while there are no
+    ///        active reservations (total reserved amount is zero).
+    function updateReservationParameters(
+        BridgeState.Storage storage self,
+        address reservationVault,
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    ) external {
+        require(
+            reservationTxMaxFee > 0,
+            "Reservation transaction max fee must be greater than zero"
+        );
+        require(
+            reservationMinAmount > reservationTxMaxFee,
+            "Reservation minimum amount must be greater than the reservation TX max fee"
+        );
+        require(
+            reservationTermSeconds > 0,
+            "Reservation term must be greater than zero"
+        );
+
+        if (reservationVault != self.reservationVault) {
+            require(
+                self.reservationTotalAmount == 0,
+                "Active reservations exist"
+            );
+            self.reservationVault = reservationVault;
+            emit ReservationVaultUpdated(reservationVault);
+        }
+
+        self.reservationMinAmount = reservationMinAmount;
+        self.reservationTxMaxFee = reservationTxMaxFee;
+        self.reservationTermSeconds = reservationTermSeconds;
+        self.reservationGracePeriod = reservationGracePeriod;
+        self.reservationMaxTotalAmount = reservationMaxTotalAmount;
+        self.maxReservationsPerWallet = maxReservationsPerWallet;
+
+        emit ReservationParametersUpdated(
+            reservationMinAmount,
+            reservationTxMaxFee,
+            reservationTermSeconds,
+            reservationGracePeriod,
+            reservationMaxTotalAmount,
+            maxReservationsPerWallet
+        );
+    }
+
+    /// @notice Parses the given output vector and returns its single output.
+    ///         Reverts if the vector does not contain exactly one output.
+    function parseSingleOutput(bytes memory outputVector)
+        internal
+        pure
+        returns (bytes memory output)
+    {
+        (, uint256 outputsCount) = outputVector.parseVarInt();
+        require(
+            outputsCount == 1,
+            "Reservation transaction must have a single output"
+        );
+
+        output = outputVector.extractOutputAtIndex(0);
+    }
+
+    /// @notice Asserts the given input vector contains exactly one input
+    ///         pointing to the reservation's current anchor outpoint, marks
+    ///         that outpoint as correctly spent (making it recognized by the
+    ///         fraud challenge defeat path) and clears its anchor index
+    ///         entry.
+    function consumeAnchor(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        bytes memory inputVector
+    ) internal {
+        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+            .parseWalletOutboundTxInput(inputVector);
+
+        require(
+            reservation.anchorTxHash == outpointTxHash &&
+                reservation.anchorTxOutputIndex == outpointIndex,
+            "Transaction input must point to the reservation anchor"
+        );
+
+        uint256 anchorUtxoKey = uint256(
+            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+        );
+
+        // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
+        // anchor in `spentMainUTXOs` -- the existing registry of honestly
+        // spent wallet UTXOs -- makes the spend recognized by
+        // `Fraud.defeatFraudChallenge` without modifying the fraud library.
+        self.spentMainUTXOs[anchorUtxoKey] = true;
+        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
+    }
+
+    /// @notice Processes the dissolution transaction inputs: the first
+    ///         input must spend the reservation's anchor outpoint and, if
+    ///         the wallet has a main UTXO, the second input must spend
+    ///         exactly that main UTXO. Marks both consumed outpoints as
+    ///         correctly spent.
+    /// @return inputsTotalValue Sum of all inputs values.
+    function processDissolutionInputs(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        bytes memory inputVector,
+        bytes32 mainUtxoHash,
+        BitcoinTx.UTXO calldata mainUtxo
+    ) internal returns (uint64 inputsTotalValue) {
+        bool mainUtxoExpected = mainUtxoHash != bytes32(0);
+
+        (uint256 varIntLength, uint256 inputsCount) = inputVector.parseVarInt();
+        require(
+            inputsCount == (mainUtxoExpected ? 2 : 1),
+            "Wrong number of dissolution transaction inputs"
+        );
+
+        // The first input must spend the reservation's anchor outpoint.
+        uint256 nextInputIndex = consumeAnchorInputAt(
+            self,
+            reservation,
+            inputVector,
+            1 + varIntLength
+        );
+        inputsTotalValue = reservation.anchorAmount;
+
+        if (mainUtxoExpected) {
+            require(
+                keccak256(
+                    abi.encodePacked(
+                        mainUtxo.txHash,
+                        mainUtxo.txOutputIndex,
+                        mainUtxo.txOutputValue
+                    )
+                ) == mainUtxoHash,
+                "Invalid main UTXO data"
+            );
+
+            consumeMainUtxoInputAt(self, inputVector, nextInputIndex, mainUtxo);
+            inputsTotalValue += mainUtxo.txOutputValue;
+        }
+
+        return inputsTotalValue;
+    }
+
+    /// @notice Asserts the input at the given starting index spends the
+    ///         reservation's current anchor outpoint, marks that outpoint as
+    ///         correctly spent and clears its anchor index entry.
+    /// @return nextInputIndex Starting index of the next input.
+    function consumeAnchorInputAt(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        bytes memory inputVector,
+        uint256 inputStartingIndex
+    ) internal returns (uint256 nextInputIndex) {
+        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
+            inputStartingIndex
+        );
+        uint32 outpointIndex = BTCUtils.reverseUint32(
+            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
+        );
+
+        require(
+            reservation.anchorTxHash == outpointTxHash &&
+                reservation.anchorTxOutputIndex == outpointIndex,
+            "Transaction input must point to the reservation anchor"
+        );
+
+        uint256 anchorUtxoKey = uint256(
+            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+        );
+        // See `consumeAnchor` for the `spentMainUTXOs` rationale.
+        self.spentMainUTXOs[anchorUtxoKey] = true;
+        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
+
+        nextInputIndex =
+            inputStartingIndex +
+            inputVector.determineInputLengthAt(inputStartingIndex);
+    }
+
+    /// @notice Asserts the input at the given starting index spends the
+    ///         wallet's main UTXO and marks it as correctly spent.
+    function consumeMainUtxoInputAt(
+        BridgeState.Storage storage self,
+        bytes memory inputVector,
+        uint256 inputStartingIndex,
+        BitcoinTx.UTXO calldata mainUtxo
+    ) internal {
+        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
+            inputStartingIndex
+        );
+        uint32 outpointIndex = BTCUtils.reverseUint32(
+            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
+        );
+
+        require(
+            mainUtxo.txHash == outpointTxHash &&
+                mainUtxo.txOutputIndex == outpointIndex,
+            "Transaction input must point to the wallet's main UTXO"
+        );
+
+        self.spentMainUTXOs[
+            uint256(keccak256(abi.encodePacked(outpointTxHash, outpointIndex)))
+        ] = true;
+    }
+
+    /// @notice Closes a reservation: adjusts the wallet reservation count
+    ///         and the total reserved amount, and marks the reservation as
+    ///         Closed.
+    function closeReservation(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation
+    ) internal {
+        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
+        self.reservationTotalAmount -= reservation.anchorAmount;
+        reservation.state = ReservationState.Closed;
+    }
+}

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -1451,9 +1451,7 @@ library Reservation {
         // anchor in `spentMainUTXOs` -- the existing registry of honestly
         // spent wallet UTXOs -- makes the spend recognized by
         // `Fraud.defeatFraudChallenge` without modifying the fraud library.
-        self.spentMainUTXOs[
-            _outpointKey(outpointTxHash, outpointIndex)
-        ] = true;
+        self.spentMainUTXOs[_outpointKey(outpointTxHash, outpointIndex)] = true;
     }
 
     /// @notice Asserts the given input vector contains exactly one input
@@ -1469,7 +1467,12 @@ library Reservation {
         (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
             .parseWalletOutboundTxInput(inputVector);
 
-        _consumeAnchorOutpoint(self, reservation, outpointTxHash, outpointIndex);
+        _consumeAnchorOutpoint(
+            self,
+            reservation,
+            outpointTxHash,
+            outpointIndex
+        );
     }
 
     /// @notice Extracts the outpoint (transaction hash and output index) of
@@ -1478,11 +1481,10 @@ library Reservation {
     ///         caller must inspect an outpoint before deciding what it is
     ///         expected to be (see `processDissolutionInputs`, which cannot
     ///         assume a fixed input order).
-    function _peekOutpointAt(bytes memory inputVector, uint256 inputStartingIndex)
-        internal
-        pure
-        returns (bytes32 outpointTxHash, uint32 outpointIndex)
-    {
+    function _peekOutpointAt(
+        bytes memory inputVector,
+        uint256 inputStartingIndex
+    ) internal pure returns (bytes32 outpointTxHash, uint32 outpointIndex) {
         outpointTxHash = inputVector.extractInputTxIdLeAt(inputStartingIndex);
         outpointIndex = BTCUtils.reverseUint32(
             uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
@@ -1543,7 +1545,12 @@ library Reservation {
         if (!mainUtxoExpected) {
             // Single-input case: the sole input must be the anchor: no
             // ordering ambiguity is possible.
-            consumeAnchorInputAt(self, reservation, inputVector, firstInputIndex);
+            consumeAnchorInputAt(
+                self,
+                reservation,
+                inputVector,
+                firstInputIndex
+            );
             return reservation.anchorAmount;
         }
 
@@ -1565,27 +1572,31 @@ library Reservation {
         uint256 secondInputIndex = firstInputIndex +
             inputVector.determineInputLengthAt(firstInputIndex);
 
+        // `_peekOutpointAt` is pure; peek the second input once up front so
+        // the two branches below do not each declare a same-named local.
+        (bytes32 secondTxHash, uint32 secondIndex) = _peekOutpointAt(
+            inputVector,
+            secondInputIndex
+        );
+
         if (
             firstTxHash == reservation.anchorTxHash &&
             firstIndex == reservation.anchorTxOutputIndex
         ) {
             // First input is the anchor; second must be the main UTXO.
             _consumeAnchorOutpoint(self, reservation, firstTxHash, firstIndex);
-            (bytes32 secondTxHash, uint32 secondIndex) = _peekOutpointAt(
-                inputVector,
-                secondInputIndex
-            );
             _consumeMainUtxoOutpoint(self, mainUtxo, secondTxHash, secondIndex);
         } else {
             // First input must be the main UTXO instead; second must be
             // the anchor. `_consumeMainUtxoOutpoint`/`_consumeAnchorOutpoint`
             // still revert with a clear message if neither matches.
             _consumeMainUtxoOutpoint(self, mainUtxo, firstTxHash, firstIndex);
-            (bytes32 secondTxHash, uint32 secondIndex) = _peekOutpointAt(
-                inputVector,
-                secondInputIndex
+            _consumeAnchorOutpoint(
+                self,
+                reservation,
+                secondTxHash,
+                secondIndex
             );
-            _consumeAnchorOutpoint(self, reservation, secondTxHash, secondIndex);
         }
 
         inputsTotalValue = reservation.anchorAmount + mainUtxo.txOutputValue;
@@ -1608,7 +1619,12 @@ library Reservation {
             uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
         );
 
-        _consumeAnchorOutpoint(self, reservation, outpointTxHash, outpointIndex);
+        _consumeAnchorOutpoint(
+            self,
+            reservation,
+            outpointTxHash,
+            outpointIndex
+        );
 
         nextInputIndex =
             inputStartingIndex +

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -22,6 +22,7 @@ import "./BitcoinTx.sol";
 import "./Bridge.sol";
 import "./Deposit.sol";
 import "./Redemption.sol";
+import "./Reservation.sol";
 import "./MovingFunds.sol";
 import "./Wallets.sol";
 
@@ -268,6 +269,9 @@ contract WalletProposalValidator {
 
         address proposalVault = address(0);
 
+        (address reservationVault, , , , , , , ) = bridge
+            .reservationParameters();
+
         uint256[] memory processedDepositKeys = new uint256[](
             proposal.depositsKeys.length
         );
@@ -299,6 +303,14 @@ contract WalletProposalValidator {
             );
 
             require(depositRequest.sweptAt == 0, "Deposit already swept");
+
+            // Deposits routed to the reservation vault are anchored via the
+            // reservation flow and must never be swept.
+            require(
+                reservationVault == address(0) ||
+                    depositRequest.vault != reservationVault,
+                "Reserved deposits must not be swept"
+            );
 
             validateDepositExtraInfo(
                 depositKey,
@@ -896,5 +908,347 @@ contract WalletProposalValidator {
         );
 
         return true;
+    }
+
+    /// @notice Helper structure representing a reservation anchor proposal.
+    struct ReservationAnchorProposal {
+        // 20-byte public key hash of the wallet performing the anchor.
+        bytes20 walletPubKeyHash;
+        // Key of the reserved deposit to anchor.
+        DepositKey depositKey;
+        // Proposed BTC fee for the anchor transaction.
+        uint256 anchorTxFee;
+    }
+
+    /// @notice Helper structure representing a reserved redemption proposal.
+    struct ReservedRedemptionProposal {
+        // 20-byte public key hash of the wallet custodying the reservation.
+        bytes20 walletPubKeyHash;
+        // Key of the reservation with the pending reserved redemption.
+        uint256 reservationKey;
+        // Proposed BTC fee for the reserved redemption transaction.
+        uint256 redemptionTxFee;
+    }
+
+    /// @notice Helper structure representing a reservation re-anchor
+    ///         proposal.
+    struct ReservationReanchorProposal {
+        // 20-byte public key hash of the wallet custodying the reservation.
+        bytes20 sourceWalletPubKeyHash;
+        // Key of the reservation to re-anchor.
+        uint256 reservationKey;
+        // 20-byte public key hash of the wallet receiving the anchor.
+        bytes20 targetWalletPubKeyHash;
+        // Proposed BTC fee for the re-anchor transaction.
+        uint256 reanchorTxFee;
+    }
+
+    /// @notice Helper structure representing a reservation dissolution
+    ///         proposal.
+    struct ReservationDissolutionProposal {
+        // 20-byte public key hash of the wallet custodying the reservation.
+        bytes20 walletPubKeyHash;
+        // Key of the reservation to dissolve.
+        uint256 reservationKey;
+        // Proposed BTC fee for the dissolution transaction.
+        uint256 dissolutionTxFee;
+    }
+
+    /// @notice View function encapsulating the main rules of a valid
+    ///         reservation anchor proposal.
+    /// @param proposal The anchor proposal to validate.
+    /// @param depositExtraInfo Deposit extra info required to perform the
+    ///        validation.
+    /// @return True if the proposal is valid. Reverts otherwise.
+    /// @dev Requirements:
+    ///      - Reservations must be enabled (reservation vault set),
+    ///      - The wallet must be in the Live or MovingFunds state,
+    ///      - The deposit must be revealed, old enough, not swept, and
+    ///        routed to the reservation vault,
+    ///      - The proposed fee must be positive, within the reservation
+    ///        transaction max fee, and must leave an anchor amount above
+    ///        the reservation minimum,
+    ///      - The deposit extra info must be valid and preserve the refund
+    ///        safety margin,
+    ///      - The deposit must be controlled by the proposal wallet.
+    function validateReservationAnchorProposal(
+        ReservationAnchorProposal calldata proposal,
+        DepositExtraInfo calldata depositExtraInfo
+    ) external view returns (bool) {
+        (
+            address reservationVault,
+            uint64 reservationMinAmount,
+            uint64 reservationTxMaxFee,
+            ,
+            ,
+            ,
+            ,
+
+        ) = bridge.reservationParameters();
+
+        require(reservationVault != address(0), "Reservations are disabled");
+
+        requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
+
+        uint256 depositKeyUint = uint256(
+            keccak256(
+                abi.encodePacked(
+                    proposal.depositKey.fundingTxHash,
+                    proposal.depositKey.fundingOutputIndex
+                )
+            )
+        );
+
+        Deposit.DepositRequest memory depositRequest = bridge.deposits(
+            depositKeyUint
+        );
+
+        require(depositRequest.revealedAt != 0, "Deposit not revealed");
+
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp > depositRequest.revealedAt + DEPOSIT_MIN_AGE,
+            "Deposit min age not achieved yet"
+        );
+
+        require(depositRequest.sweptAt == 0, "Deposit already swept");
+
+        require(
+            depositRequest.vault == reservationVault,
+            "Deposit not routed to the reservation vault"
+        );
+
+        require(
+            proposal.anchorTxFee > 0,
+            "Proposed transaction fee cannot be zero"
+        );
+        require(
+            proposal.anchorTxFee <= reservationTxMaxFee,
+            "Proposed transaction fee is too high"
+        );
+        require(
+            depositRequest.amount - proposal.anchorTxFee >=
+                reservationMinAmount,
+            "Anchor amount below the reservation minimum"
+        );
+
+        validateDepositExtraInfo(
+            proposal.depositKey,
+            depositRequest.depositor,
+            depositRequest.extraData,
+            depositExtraInfo
+        );
+
+        uint32 depositRefundableTimestamp = BTCUtils.reverseUint32(
+            uint32(depositExtraInfo.refundLocktime)
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <
+                depositRefundableTimestamp - DEPOSIT_REFUND_SAFETY_MARGIN,
+            "Deposit refund safety margin is not preserved"
+        );
+
+        require(
+            depositExtraInfo.walletPubKeyHash == proposal.walletPubKeyHash,
+            "Deposit controlled by different wallet"
+        );
+
+        return true;
+    }
+
+    /// @notice View function encapsulating the main rules of a valid
+    ///         reserved redemption proposal.
+    /// @param proposal The reserved redemption proposal to validate.
+    /// @return True if the proposal is valid. Reverts otherwise.
+    /// @dev Requirements:
+    ///      - The wallet must be in the Live or MovingFunds state,
+    ///      - The reservation must have a pending reserved redemption and
+    ///        must be custodied by the proposal wallet,
+    ///      - The request must be old enough, i.e. at least
+    ///        `REDEMPTION_REQUEST_MIN_AGE` or the watchtower veto delay
+    ///        (whichever is greater) elapsed since request time,
+    ///      - The request must have the timeout safety margin preserved,
+    ///      - The proposed fee must be positive and within the max fee
+    ///        snapshotted by the request.
+    function validateReservedRedemptionProposal(
+        ReservedRedemptionProposal calldata proposal
+    ) external view returns (bool) {
+        requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
+
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            proposal.reservationKey
+        );
+
+        require(
+            reservation.state ==
+                Reservation.ReservationState.RedemptionRequested,
+            "No pending reserved redemption"
+        );
+        require(
+            reservation.walletPubKeyHash == proposal.walletPubKeyHash,
+            "Reservation custodied by different wallet"
+        );
+
+        uint32 requestMinAge = REDEMPTION_REQUEST_MIN_AGE;
+        address watchtower = bridge.getRedemptionWatchtower();
+        if (watchtower != address(0)) {
+            uint32 delay = IRedemptionWatchtower(watchtower)
+                .getReservedRedemptionDelay(proposal.reservationKey);
+            if (delay > requestMinAge) {
+                requestMinAge = delay;
+            }
+        }
+
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp > reservation.redemptionRequestedAt + requestMinAge,
+            "Reserved redemption min age not achieved yet"
+        );
+
+        (, , , , uint32 redemptionTimeout, , ) = bridge.redemptionParameters();
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <
+                reservation.redemptionRequestedAt +
+                    redemptionTimeout -
+                    REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN,
+            "Redemption request timeout safety margin is not preserved"
+        );
+
+        require(
+            proposal.redemptionTxFee > 0,
+            "Proposed transaction fee cannot be zero"
+        );
+        require(
+            proposal.redemptionTxFee <= reservation.redemptionTxMaxFee,
+            "Proposed transaction fee is too high"
+        );
+
+        return true;
+    }
+
+    /// @notice View function encapsulating the main rules of a valid
+    ///         reservation re-anchor proposal.
+    /// @param proposal The re-anchor proposal to validate.
+    /// @return True if the proposal is valid. Reverts otherwise.
+    /// @dev Requirements:
+    ///      - The reservation must be Active and custodied by the source
+    ///        wallet,
+    ///      - The target wallet must be in the Live state,
+    ///      - The proposed fee must be positive and within the reservation
+    ///        transaction max fee.
+    ///
+    ///      The source wallet state is deliberately not restricted, mirroring
+    ///      `Reservation.submitReservationReanchorProof`: moving reservations
+    ///      out must remain possible for wallets in any lifecycle state.
+    function validateReservationReanchorProposal(
+        ReservationReanchorProposal calldata proposal
+    ) external view returns (bool) {
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            proposal.reservationKey
+        );
+
+        require(
+            reservation.state == Reservation.ReservationState.Active,
+            "Reservation is not active"
+        );
+        require(
+            reservation.walletPubKeyHash == proposal.sourceWalletPubKeyHash,
+            "Reservation custodied by different wallet"
+        );
+
+        require(
+            bridge.wallets(proposal.targetWalletPubKeyHash).state ==
+                Wallets.WalletState.Live,
+            "Target wallet must be in Live state"
+        );
+
+        (, , uint64 reservationTxMaxFee, , , , , ) = bridge
+            .reservationParameters();
+        require(
+            proposal.reanchorTxFee > 0,
+            "Proposed transaction fee cannot be zero"
+        );
+        require(
+            proposal.reanchorTxFee <= reservationTxMaxFee,
+            "Proposed transaction fee is too high"
+        );
+
+        return true;
+    }
+
+    /// @notice View function encapsulating the main rules of a valid
+    ///         reservation dissolution proposal.
+    /// @param proposal The dissolution proposal to validate.
+    /// @return True if the proposal is valid. Reverts otherwise.
+    /// @dev Requirements:
+    ///      - The wallet must be in the Live or MovingFunds state,
+    ///      - The reservation must be Active, custodied by the proposal
+    ///        wallet, and past its custody term plus grace period,
+    ///      - The proposed fee must be positive and within the reservation
+    ///        transaction max fee.
+    function validateReservationDissolutionProposal(
+        ReservationDissolutionProposal calldata proposal
+    ) external view returns (bool) {
+        requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
+
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            proposal.reservationKey
+        );
+
+        require(
+            reservation.state == Reservation.ReservationState.Active,
+            "Reservation is not active"
+        );
+        require(
+            reservation.walletPubKeyHash == proposal.walletPubKeyHash,
+            "Reservation custodied by different wallet"
+        );
+
+        (
+            ,
+            ,
+            uint64 reservationTxMaxFee,
+            ,
+            uint32 reservationGracePeriod,
+            ,
+            ,
+
+        ) = bridge.reservationParameters();
+
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp >
+                uint256(reservation.expiresAt) + reservationGracePeriod,
+            "Reservation term or grace period not elapsed"
+        );
+
+        require(
+            proposal.dissolutionTxFee > 0,
+            "Proposed transaction fee cannot be zero"
+        );
+        require(
+            proposal.dissolutionTxFee <= reservationTxMaxFee,
+            "Proposed transaction fee is too high"
+        );
+
+        return true;
+    }
+
+    /// @notice Reverts unless the given wallet is in the Live or MovingFunds
+    ///         state.
+    function requireWalletLiveOrMovingFunds(bytes20 walletPubKeyHash)
+        internal
+        view
+    {
+        Wallets.WalletState walletState = bridge
+            .wallets(walletPubKeyHash)
+            .state;
+        require(
+            walletState == Wallets.WalletState.Live ||
+                walletState == Wallets.WalletState.MovingFunds,
+            "Wallet is not in Live or MovingFunds state"
+        );
     }
 }

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -980,6 +980,8 @@ contract WalletProposalValidator {
             ,
             ,
             ,
+            ,
+            ,
 
         ) = bridge.reservationParameters();
 
@@ -1166,7 +1168,7 @@ contract WalletProposalValidator {
             "Target wallet must be in Live state"
         );
 
-        (, , uint64 reservationTxMaxFee, , , , , ) = bridge
+        (, , uint64 reservationTxMaxFee, , , , , , , ) = bridge
             .reservationParameters();
         require(
             proposal.reanchorTxFee > 0,
@@ -1211,9 +1213,11 @@ contract WalletProposalValidator {
         (
             ,
             ,
-            uint64 reservationTxMaxFee,
+            ,
+            uint64 reservationDissolutionTxMaxFee,
             ,
             uint32 reservationGracePeriod,
+            ,
             ,
             ,
 
@@ -1231,7 +1235,7 @@ contract WalletProposalValidator {
             "Proposed transaction fee cannot be zero"
         );
         require(
-            proposal.dissolutionTxFee <= reservationTxMaxFee,
+            proposal.dissolutionTxFee <= reservationDissolutionTxMaxFee,
             "Proposed transaction fee is too high"
         );
 

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -1030,9 +1030,16 @@ contract WalletProposalValidator {
             proposal.anchorTxFee <= reservationTxMaxFee,
             "Proposed transaction fee is too high"
         );
+        // Addition-based formulation avoids `depositRequest.amount -
+        // proposal.anchorTxFee` underflowing (and reverting with an
+        // unreadable Panic(0x11)) when the proposed fee exceeds a small
+        // deposit's amount; this is mathematically equivalent for every
+        // case that does not underflow, and correctly evaluates to false
+        // (yielding the clear message below) for every case that would
+        // have underflowed.
         require(
-            depositRequest.amount - proposal.anchorTxFee >=
-                reservationMinAmount,
+            depositRequest.amount >=
+                reservationMinAmount + proposal.anchorTxFee,
             "Anchor amount below the reservation minimum"
         );
 
@@ -1187,15 +1194,32 @@ contract WalletProposalValidator {
     /// @param proposal The dissolution proposal to validate.
     /// @return True if the proposal is valid. Reverts otherwise.
     /// @dev Requirements:
-    ///      - The wallet must be in the Live or MovingFunds state,
+    ///      - The wallet must be in the Live, MovingFunds, or Terminated
+    ///        state -- Terminated is included alongside `Reservation`
+    ///        library's dissolution wallet-state check so a reservation
+    ///        that predates the wallet's termination is not permanently
+    ///        stranded (see `Reservation.submitReservationDissolutionProof`),
     ///      - The reservation must be Active, custodied by the proposal
     ///        wallet, and past its custody term plus grace period,
     ///      - The proposed fee must be positive and within the reservation
-    ///        transaction max fee.
+    ///        dissolution transaction max fee (`reservationDissolutionTxMaxFee`).
     function validateReservationDissolutionProposal(
         ReservationDissolutionProposal calldata proposal
     ) external view returns (bool) {
-        requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
+        // Deliberately not `requireWalletLiveOrMovingFunds`: dissolution
+        // must also be provable for a Terminated wallet so a reservation
+        // it still custodies is not permanently unable to close. See
+        // `Reservation.submitReservationDissolutionProof`'s matching
+        // wallet-state check for the full rationale.
+        Wallets.WalletState dissolutionWalletState = bridge
+            .wallets(proposal.walletPubKeyHash)
+            .state;
+        require(
+            dissolutionWalletState == Wallets.WalletState.Live ||
+                dissolutionWalletState == Wallets.WalletState.MovingFunds ||
+                dissolutionWalletState == Wallets.WalletState.Terminated,
+            "Wallet is not in Live, MovingFunds or Terminated state"
+        );
 
         Reservation.ReservationRequest memory reservation = bridge.reservations(
             proposal.reservationKey

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -269,9 +269,6 @@ contract WalletProposalValidator {
 
         address proposalVault = address(0);
 
-        (address reservationVault, , , , , , , ) = bridge
-            .reservationParameters();
-
         uint256[] memory processedDepositKeys = new uint256[](
             proposal.depositsKeys.length
         );
@@ -304,11 +301,10 @@ contract WalletProposalValidator {
 
             require(depositRequest.sweptAt == 0, "Deposit already swept");
 
-            // Deposits routed to the reservation vault are anchored via the
-            // reservation flow and must never be swept.
+            // Deposits classified as reserved when revealed are anchored via
+            // the reservation flow and must never be swept.
             require(
-                reservationVault == address(0) ||
-                    depositRequest.vault != reservationVault,
+                !bridge.isReservedDeposit(depositKeyUint),
                 "Reserved deposits must not be swept"
             );
 
@@ -1012,6 +1008,11 @@ contract WalletProposalValidator {
         );
 
         require(depositRequest.sweptAt == 0, "Deposit already swept");
+
+        require(
+            bridge.isReservedDeposit(depositKeyUint),
+            "Deposit was not revealed as reserved"
+        );
 
         require(
             depositRequest.vault == reservationVault,

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -303,6 +303,7 @@ contract WalletProposalValidator {
 
             // Deposits classified as reserved when revealed are anchored via
             // the reservation flow and must never be swept.
+            // slither-disable-next-line calls-loop
             require(
                 !bridge.isReservedDeposit(depositKeyUint),
                 "Reserved deposits must not be swept"

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -375,6 +375,14 @@ library Wallets {
             "Closing period has not elapsed yet"
         );
 
+        // A wallet still custodying reservation anchors must not close
+        // ultimately; its reservations must first be re-anchored to other
+        // wallets or dissolved into the main UTXO.
+        require(
+            self.walletReservationsCount[walletPubKeyHash] == 0,
+            "Wallet still custodies reservations"
+        );
+
         finalizeWalletClosing(self, walletPubKeyHash);
     }
 

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -6,9 +6,29 @@ import "../bridge/BitcoinTx.sol";
 import "../bridge/Bridge.sol";
 import "../bridge/MovingFunds.sol";
 import "../bridge/RebateStaking.sol";
+import "../bridge/Reservation.sol";
 import "../bridge/Wallets.sol";
 
 contract BridgeStub is Bridge {
+    function setReservation(
+        uint256 reservationKey,
+        Reservation.ReservationRequest calldata reservation
+    ) external {
+        self.reservations[reservationKey] = reservation;
+        self.walletReservationsCount[reservation.walletPubKeyHash] += 1;
+        self.reservationTotalAmount += reservation.anchorAmount;
+        self.reservationsByAnchorUtxo[
+            uint256(
+                keccak256(
+                    abi.encodePacked(
+                        reservation.anchorTxHash,
+                        reservation.anchorTxOutputIndex
+                    )
+                )
+            )
+        ] = reservationKey;
+    }
+
     function setSweptDeposits(BitcoinTx.UTXO[] calldata utxos) external {
         for (uint256 i = 0; i < utxos.length; i++) {
             uint256 utxoKey = uint256(

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -16,17 +16,7 @@ contract BridgeStub is Bridge {
     ) external {
         self.reservations[reservationKey] = reservation;
         self.walletReservationsCount[reservation.walletPubKeyHash] += 1;
-        self.reservationTotalAmount += reservation.anchorAmount;
-        self.reservationsByAnchorUtxo[
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        reservation.anchorTxHash,
-                        reservation.anchorTxOutputIndex
-                    )
-                )
-            )
-        ] = reservationKey;
+        self.reservationTotalAmount += reservation.mintedAmount;
     }
 
     function setSweptDeposits(BitcoinTx.UTXO[] calldata utxos) external {

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import "./IVault.sol";
+import "./TBTCVault.sol";
+import "../bank/Bank.sol";
+import "../bridge/Reservation.sol";
+import "../token/TBTC.sol";
+
+/// @notice Minimal interface of the Bridge functions the reservation vault
+///         interacts with.
+interface IReservationBridge {
+    function reservations(uint256 reservationKey)
+        external
+        view
+        returns (Reservation.ReservationRequest memory);
+
+    function requestReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript
+    ) external;
+
+    function extendReservation(uint256 reservationKey) external;
+
+    function treasury() external view returns (address);
+}
+
+/// @title Reservation vault
+/// @notice The reservation vault is the liability-side companion of the
+///         Bridge's `Reservation` library. Deposits revealed with this vault
+///         address are treated as UTXO reservations: instead of being swept
+///         into the pooled supply, they are anchored by the wallet and
+///         redeemable in-kind. When the Bridge proves a reservation's anchor
+///         transaction, it credits the gross anchored amount to this vault,
+///         which mints TBTC gross to the reservation owner and collects all
+///         protocol fees as explicit TBTC transfers -- reservation claims
+///         are never netted, so the claim surrendered at redemption always
+///         equals the sats earmarked on-chain.
+///
+///         Fee schedule (basis points of the gross amount, all governable):
+///         - initiation: charged when the acceptance credit is processed;
+///           covers the mint leg and the first custody term,
+///         - extension: charged per custody term extension,
+///         - redemption: charged when the in-kind redemption is requested.
+///
+///         Wiring requirements: governance must mark this vault as trusted
+///         in the Bridge (`setVaultStatus`) so deposits can be revealed with
+///         it, and must set it as the Bridge's reservation vault via
+///         `updateReservationParameters`.
+/// @dev The vault deliberately keeps no claim registry of its own -- the
+///      Bridge's reservation records are the single source of truth and are
+///      consulted for ownership checks.
+contract ReservationVault is IVault, Ownable {
+    using SafeERC20 for IERC20;
+
+    /// @notice Multiplier to convert satoshi to TBTC token units.
+    uint256 public constant SATOSHI_MULTIPLIER = 10**10;
+
+    /// @notice Basis points divisor for fee computations.
+    uint256 public constant BASIS_POINTS = 10000;
+
+    /// @notice Upper sanity bound for each fee parameter, in basis points.
+    uint256 public constant MAX_FEE_BASIS_POINTS = 500;
+
+    Bank public immutable bank;
+    TBTCVault public immutable tbtcVault;
+    TBTC public immutable tbtcToken;
+    IReservationBridge public immutable bridge;
+
+    /// @notice Initiation fee in basis points of the gross anchored amount,
+    ///         charged when the acceptance credit is processed. Covers the
+    ///         mint leg and the first custody term.
+    uint16 public initiationFeeBps;
+    /// @notice Extension fee in basis points of the gross amount, charged
+    ///         per custody term extension.
+    uint16 public extensionFeeBps;
+    /// @notice Redemption fee in basis points of the gross amount, charged
+    ///         when the in-kind redemption is requested.
+    uint16 public redemptionFeeBps;
+
+    event ReservationCreditProcessed(
+        address indexed owner,
+        uint256 satAmount,
+        uint256 feeTbtc
+    );
+
+    event CustodyExtended(
+        uint256 indexed reservationKey,
+        address indexed owner,
+        uint256 feeTbtc
+    );
+
+    event ReservedRedemptionInitiated(
+        uint256 indexed reservationKey,
+        address indexed owner,
+        uint256 grossTbtc,
+        uint256 feeTbtc
+    );
+
+    event FeesUpdated(
+        uint16 initiationFeeBps,
+        uint16 extensionFeeBps,
+        uint16 redemptionFeeBps
+    );
+
+    modifier onlyBank() {
+        require(msg.sender == address(bank), "Caller is not the Bank");
+        _;
+    }
+
+    constructor(
+        Bank _bank,
+        TBTCVault _tbtcVault,
+        IReservationBridge _bridge
+    ) {
+        require(
+            address(_bank) != address(0),
+            "Bank can not be the zero address"
+        );
+        require(
+            address(_tbtcVault) != address(0),
+            "TBTCVault can not be the zero address"
+        );
+        require(
+            address(_bridge) != address(0),
+            "Bridge can not be the zero address"
+        );
+
+        bank = _bank;
+        tbtcVault = _tbtcVault;
+        tbtcToken = _tbtcVault.tbtcToken();
+        bridge = _bridge;
+
+        // Draft fee schedule from the UTXO reservation design:
+        // 40 bps all-in at initiation (20 bps mint leg + first-year
+        // custody), 20 bps per extension year, 20 bps at redemption. The
+        // reserved lane thereby strictly dominates the pooled path's
+        // 20 bps + 20 bps round trip at every holding horizon.
+        initiationFeeBps = 40;
+        extensionFeeBps = 20;
+        redemptionFeeBps = 20;
+    }
+
+    /// @notice Called by the Bank when the Bridge proves a reservation's
+    ///         anchor transaction and credits the gross anchored amount to
+    ///         this vault. Mints TBTC gross and forwards it to the
+    ///         reservation owner minus the initiation fee, which is
+    ///         transferred to the Bridge treasury.
+    /// @dev The gross amount is always minted so the total TBTC supply
+    ///      created against the reservation equals the sats earmarked
+    ///      on-chain; the fee is an explicit transfer, never a netted
+    ///      credit.
+    function receiveBalanceIncrease(
+        address[] calldata depositors,
+        uint256[] calldata depositedAmounts
+    ) external override onlyBank {
+        require(depositors.length != 0, "No depositors specified");
+
+        address treasury = bridge.treasury();
+
+        for (uint256 i = 0; i < depositors.length; i++) {
+            uint256 satAmount = depositedAmounts[i];
+            uint256 grossTbtc = satAmount * SATOSHI_MULTIPLIER;
+
+            // Convert the Bank balance credited by the Bridge into TBTC
+            // minted to this vault.
+            bank.approveBalance(address(tbtcVault), satAmount);
+            tbtcVault.mint(grossTbtc);
+
+            uint256 fee = (grossTbtc * initiationFeeBps) / BASIS_POINTS;
+            if (fee > 0) {
+                IERC20(tbtcToken).safeTransfer(treasury, fee);
+            }
+            IERC20(tbtcToken).safeTransfer(depositors[i], grossTbtc - fee);
+
+            // slither-disable-next-line reentrancy-events
+            emit ReservationCreditProcessed(depositors[i], satAmount, fee);
+        }
+    }
+
+    /// @notice Requests an in-kind redemption of the caller's reservation.
+    ///         The caller surrenders the gross minted TBTC amount plus the
+    ///         redemption fee; the vault unmints the gross amount and asks
+    ///         the Bridge to have the wallet spend exactly the reservation's
+    ///         anchor outpoint to the given redeemer script.
+    /// @param reservationKey The key of the reservation to redeem.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner,
+    ///      - The caller must have approved this vault for
+    ///        `mintedAmount * SATOSHI_MULTIPLIER * (1 + redemptionFeeBps/10000)`
+    ///        TBTC.
+    ///
+    ///      Should the redemption time out, the Bridge returns the
+    ///      surrendered gross amount to the caller as Bank balance; the
+    ///      caller can re-mint TBTC via the TBTC vault and request the
+    ///      redemption again.
+    function redeemReservation(
+        uint256 reservationKey,
+        bytes calldata redeemerOutputScript
+    ) external {
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            reservationKey
+        );
+        require(
+            reservation.owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+
+        uint256 grossTbtc = uint256(reservation.mintedAmount) *
+            SATOSHI_MULTIPLIER;
+        uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
+
+        IERC20(tbtcToken).safeTransferFrom(
+            msg.sender,
+            address(this),
+            grossTbtc + fee
+        );
+        if (fee > 0) {
+            IERC20(tbtcToken).safeTransfer(bridge.treasury(), fee);
+        }
+
+        // Unmint the gross TBTC back into Bank balance and let the Bridge
+        // take it when registering the reserved redemption request.
+        IERC20(tbtcToken).safeIncreaseAllowance(address(tbtcVault), grossTbtc);
+        tbtcVault.unmint(grossTbtc);
+        bank.approveBalance(address(bridge), reservation.mintedAmount);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionInitiated(
+            reservationKey,
+            msg.sender,
+            grossTbtc,
+            fee
+        );
+
+        bridge.requestReservedRedemption(
+            reservationKey,
+            msg.sender,
+            redeemerOutputScript
+        );
+    }
+
+    /// @notice Extends the custody term of the caller's reservation by one
+    ///         term length, charging the extension fee in TBTC.
+    /// @param reservationKey The key of the reservation to extend.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner,
+    ///      - The caller must have approved this vault for the extension
+    ///        fee in TBTC.
+    function extendCustody(uint256 reservationKey) external {
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            reservationKey
+        );
+        require(
+            reservation.owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+
+        uint256 fee = (uint256(reservation.mintedAmount) *
+            SATOSHI_MULTIPLIER *
+            extensionFeeBps) / BASIS_POINTS;
+        if (fee > 0) {
+            IERC20(tbtcToken).safeTransferFrom(
+                msg.sender,
+                bridge.treasury(),
+                fee
+            );
+        }
+
+        // slither-disable-next-line reentrancy-events
+        emit CustodyExtended(reservationKey, msg.sender, fee);
+
+        bridge.extendReservation(reservationKey);
+    }
+
+    /// @notice Updates the vault fee parameters.
+    /// @dev Requirements:
+    ///      - The caller must be the vault owner (governance),
+    ///      - Each fee must not exceed `MAX_FEE_BASIS_POINTS`.
+    function updateFees(
+        uint16 _initiationFeeBps,
+        uint16 _extensionFeeBps,
+        uint16 _redemptionFeeBps
+    ) external onlyOwner {
+        require(
+            _initiationFeeBps <= MAX_FEE_BASIS_POINTS &&
+                _extensionFeeBps <= MAX_FEE_BASIS_POINTS &&
+                _redemptionFeeBps <= MAX_FEE_BASIS_POINTS,
+            "Fee exceeds the maximum"
+        );
+
+        initiationFeeBps = _initiationFeeBps;
+        extensionFeeBps = _extensionFeeBps;
+        redemptionFeeBps = _redemptionFeeBps;
+
+        emit FeesUpdated(
+            _initiationFeeBps,
+            _extensionFeeBps,
+            _redemptionFeeBps
+        );
+    }
+
+    /// @notice The reservation vault does not support the balance approval
+    ///         flow; reserved redemptions are initiated via
+    ///         `redeemReservation`.
+    function receiveBalanceApproval(
+        address,
+        uint256,
+        bytes calldata
+    ) external pure override {
+        revert("Balance approvals not supported");
+    }
+}

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -35,7 +35,8 @@ interface IReservationBridge {
     function requestReservedRedemption(
         uint256 reservationKey,
         address redeemer,
-        bytes calldata redeemerOutputScript
+        bytes calldata redeemerOutputScript,
+        bool isRetry
     ) external;
 
     function extendReservation(uint256 reservationKey) external;
@@ -310,7 +311,8 @@ contract ReservationVault is IVault, Ownable {
         bridge.requestReservedRedemption(
             reservationKey,
             msg.sender,
-            redeemerOutputScript
+            redeemerOutputScript,
+            false
         );
     }
 
@@ -353,7 +355,10 @@ contract ReservationVault is IVault, Ownable {
     ///         balance -- the state a timed-out reserved redemption leaves
     ///         the owner in (the Bridge refunds the surrendered amount as
     ///         Bank balance). The caller surrenders the gross minted amount
-    ///         as Bank balance and pays the redemption fee in TBTC.
+    ///         as Bank balance; no TBTC fee is charged on this call -- it
+    ///         was already collected by the original `redeemReservation`
+    ///         call, and this retry exists only because that prior request
+    ///         timed out through the wallet's fault.
     /// @param reservationKey The key of the reservation to redeem.
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
@@ -363,16 +368,18 @@ contract ReservationVault is IVault, Ownable {
     ///        must specifically have been caused by wallet fault (the
     ///        Bridge's `lastTimeoutWasWalletFault` marker) -- otherwise
     ///        this path would let an owner use it as an ordinary
-    ///        fee-free first redemption, or grief wallet operators for
-    ///        free by repeatedly requesting, waiting out the timeout
-    ///        (slashing the wallet), and retrying,
+    ///        fee-free first redemption,
     ///      - The caller must have approved this vault in the Bank for the
     ///        gross minted amount (`Bank.approveBalance`).
     ///
-    ///      The redemption fee is not re-charged: it was collected by the
-    ///      original `redeemReservation` call and the retry only exists
-    ///      because the previous request timed out through the wallet's
-    ///      fault.
+    ///      This grants at most one fee-free retry per paid redemption
+    ///      fee: the Bridge consumes `lastTimeoutWasWalletFault` when this
+    ///      call's own request is registered, and does not re-grant it if
+    ///      that request also times out through wallet fault -- a second
+    ///      retry requires a fresh `redeemReservation` fee payment. Without
+    ///      this, an owner could loop request -> timeout -> retry
+    ///      indefinitely, slashing wallet operators for free on every
+    ///      iteration after paying only the first redemption fee.
     function retryRedeemReservation(
         uint256 reservationKey,
         bytes calldata redeemerOutputScript
@@ -411,7 +418,8 @@ contract ReservationVault is IVault, Ownable {
         bridge.requestReservedRedemption(
             reservationKey,
             msg.sender,
-            redeemerOutputScript
+            redeemerOutputScript,
+            true
         );
     }
 

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -59,7 +59,8 @@ interface IReservationBridge {
 ///         - initiation: charged when the acceptance credit is processed;
 ///           covers the mint leg and the first custody term,
 ///         - extension: charged per custody term extension,
-///         - redemption: charged when the in-kind redemption is requested.
+///         - redemption: free by default; the parameter is retained for
+///           governance.
 ///
 ///         Wiring requirements: governance must mark this vault as trusted
 ///         in the Bridge (`setVaultStatus`) so deposits can be revealed with
@@ -93,7 +94,9 @@ contract ReservationVault is IVault, Ownable {
     ///         per custody term extension.
     uint16 public extensionFeeBps;
     /// @notice Redemption fee in basis points of the gross amount, charged
-    ///         when the in-kind redemption is requested.
+    ///         when the in-kind redemption is requested. Zero by default:
+    ///         redemption is exit-neutral, custody is paid for via the
+    ///         initiation and extension fees.
     uint16 public redemptionFeeBps;
 
     event ReservationCreditProcessed(
@@ -151,12 +154,15 @@ contract ReservationVault is IVault, Ownable {
 
         // Draft fee schedule from the UTXO reservation design:
         // 40 bps all-in at initiation (20 bps mint leg + first-year
-        // custody), 20 bps per extension year, 20 bps at redemption. The
-        // reserved lane thereby strictly dominates the pooled path's
-        // 20 bps + 20 bps round trip at every holding horizon.
+        // custody), 20 bps per extension year, free redemption --
+        // custody-style pay-to-hold pricing that is never cheaper than the
+        // pooled path's 20 bps + 20 bps round trip (parity at a one-year
+        // hold, premium beyond). The minimum reservation size, not this
+        // schedule, is the governance dial that keeps the carry fee
+        // covering per-position lifecycle costs.
         initiationFeeBps = 40;
         extensionFeeBps = 20;
-        redemptionFeeBps = 20;
+        redemptionFeeBps = 0;
     }
 
     /// @notice Called by the Bank when the Bridge proves a reservation's

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -59,8 +59,9 @@ interface IReservationBridge {
 ///         - initiation: charged when the acceptance credit is processed;
 ///           covers the mint leg and the first custody term,
 ///         - extension: charged per custody term extension,
-///         - redemption: free by default; the parameter is retained for
-///           governance.
+///         - redemption: charged when the in-kind redemption is requested;
+///           priced at parity with the pooled redemption fee. Not re-charged
+///           on retries after wallet-fault timeouts.
 ///
 ///         Wiring requirements: governance must mark this vault as trusted
 ///         in the Bridge (`setVaultStatus`) so deposits can be revealed with
@@ -94,9 +95,9 @@ contract ReservationVault is IVault, Ownable {
     ///         per custody term extension.
     uint16 public extensionFeeBps;
     /// @notice Redemption fee in basis points of the gross amount, charged
-    ///         when the in-kind redemption is requested. Zero by default:
-    ///         redemption is exit-neutral, custody is paid for via the
-    ///         initiation and extension fees.
+    ///         when the in-kind redemption is requested. Priced at parity
+    ///         with the pooled redemption fee; not re-charged on retries
+    ///         after wallet-fault timeouts.
     uint16 public redemptionFeeBps;
 
     event ReservationCreditProcessed(
@@ -152,17 +153,18 @@ contract ReservationVault is IVault, Ownable {
         tbtcToken = _tbtcVault.tbtcToken();
         bridge = _bridge;
 
-        // Draft fee schedule from the UTXO reservation design:
-        // 40 bps all-in at initiation (20 bps mint leg + first-year
-        // custody), 20 bps per extension year, free redemption --
-        // custody-style pay-to-hold pricing that is never cheaper than the
-        // pooled path's 20 bps + 20 bps round trip (parity at a one-year
-        // hold, premium beyond). The minimum reservation size, not this
-        // schedule, is the governance dial that keeps the carry fee
-        // covering per-position lifecycle costs.
+        // Fee schedule (see the UTXO reservation design): the endpoints
+        // are priced at parity with the pooled path -- a 20 bps mint leg
+        // inside the 40 bps initiation fee and a 20 bps redemption fee --
+        // so the only premium being purchased is the 20 bps/yr custody fee
+        // (the remainder of the initiation fee prepays the first year). An
+        // N-year holding pays 40 + 20N bps against the pooled 40 bps round
+        // trip: strictly premium at every horizon. The minimum reservation
+        // size, not this schedule, is the governance dial that keeps the
+        // carry fee covering per-position lifecycle costs.
         initiationFeeBps = 40;
         extensionFeeBps = 20;
-        redemptionFeeBps = 0;
+        redemptionFeeBps = 20;
     }
 
     /// @notice Called by the Bank when the Bridge proves a reservation's
@@ -320,9 +322,12 @@ contract ReservationVault is IVault, Ownable {
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
     ///      - The caller must have approved this vault in the Bank for the
-    ///        gross minted amount (`Bank.approveBalance`),
-    ///      - The caller must have approved this vault for the redemption
-    ///        fee in TBTC.
+    ///        gross minted amount (`Bank.approveBalance`).
+    ///
+    ///      The redemption fee is not re-charged: it was collected by the
+    ///      original `redeemReservation` call and the retry only exists
+    ///      because the previous request timed out through the wallet's
+    ///      fault.
     function retryRedeemReservation(
         uint256 reservationKey,
         bytes calldata redeemerOutputScript
@@ -337,14 +342,11 @@ contract ReservationVault is IVault, Ownable {
 
         uint256 grossTbtc = uint256(reservation.mintedAmount) *
             SATOSHI_MULTIPLIER;
-        uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
-        if (fee > 0) {
-            IERC20(tbtcToken).safeTransferFrom(
-                msg.sender,
-                bridge.treasury(),
-                fee
-            );
-        }
+
+        // The redemption fee was already collected by the original
+        // redeemReservation call; a retry only exists because the previous
+        // request timed out through the wallet's fault, so it is not
+        // re-charged.
 
         bank.transferBalanceFrom(
             msg.sender,
@@ -358,7 +360,7 @@ contract ReservationVault is IVault, Ownable {
             reservationKey,
             msg.sender,
             grossTbtc,
-            fee
+            0
         );
 
         bridge.requestReservedRedemption(

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -222,8 +222,11 @@ contract ReservationVault is IVault, Ownable {
     /// @param reservationKey The key of the reservation to redeem.
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param maxFeeTbtc Upper bound on the TBTC fee the caller accepts;
+    ///        an unexpected fee update reverts instead of overcharging.
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
+    ///      - The fee must not exceed `maxFeeTbtc`,
     ///      - The caller must have approved this vault for
     ///        `mintedAmount * SATOSHI_MULTIPLIER * (1 + redemptionFeeBps/10000)`
     ///        TBTC.
@@ -234,7 +237,8 @@ contract ReservationVault is IVault, Ownable {
     ///      redemption again.
     function redeemReservation(
         uint256 reservationKey,
-        bytes calldata redeemerOutputScript
+        bytes calldata redeemerOutputScript,
+        uint256 maxFeeTbtc
     ) external {
         Reservation.ReservationRequest memory reservation = bridge.reservations(
             reservationKey
@@ -247,6 +251,7 @@ contract ReservationVault is IVault, Ownable {
         uint256 grossTbtc = uint256(reservation.mintedAmount) *
             SATOSHI_MULTIPLIER;
         uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
+        require(fee <= maxFeeTbtc, "Fee exceeds the caller's bound");
 
         IERC20(tbtcToken).safeTransferFrom(
             msg.sender,

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -174,25 +174,35 @@ contract ReservationVault is IVault, Ownable {
     ) external override onlyBank {
         require(depositors.length != 0, "No depositors specified");
 
-        address treasury = bridge.treasury();
+        uint256 totalSat = 0;
+        for (uint256 i = 0; i < depositedAmounts.length; i++) {
+            totalSat += depositedAmounts[i];
+        }
+
+        // Convert the whole Bank balance credited by the Bridge into TBTC
+        // minted to this vault in a single mint, then distribute it.
+        bank.approveBalance(address(tbtcVault), totalSat);
+        tbtcVault.mint(totalSat * SATOSHI_MULTIPLIER);
+
+        uint256 totalFee = 0;
 
         for (uint256 i = 0; i < depositors.length; i++) {
-            uint256 satAmount = depositedAmounts[i];
-            uint256 grossTbtc = satAmount * SATOSHI_MULTIPLIER;
-
-            // Convert the Bank balance credited by the Bridge into TBTC
-            // minted to this vault.
-            bank.approveBalance(address(tbtcVault), satAmount);
-            tbtcVault.mint(grossTbtc);
-
+            uint256 grossTbtc = depositedAmounts[i] * SATOSHI_MULTIPLIER;
             uint256 fee = (grossTbtc * initiationFeeBps) / BASIS_POINTS;
-            if (fee > 0) {
-                IERC20(tbtcToken).safeTransfer(treasury, fee);
-            }
+            totalFee += fee;
+
             IERC20(tbtcToken).safeTransfer(depositors[i], grossTbtc - fee);
 
             // slither-disable-next-line reentrancy-events
-            emit ReservationCreditProcessed(depositors[i], satAmount, fee);
+            emit ReservationCreditProcessed(
+                depositors[i],
+                depositedAmounts[i],
+                fee
+            );
+        }
+
+        if (totalFee > 0) {
+            IERC20(tbtcToken).safeTransfer(bridge.treasury(), totalFee);
         }
     }
 
@@ -291,6 +301,65 @@ contract ReservationVault is IVault, Ownable {
         emit CustodyExtended(reservationKey, msg.sender, fee);
 
         bridge.extendReservation(reservationKey);
+    }
+
+    /// @notice Re-requests an in-kind redemption using the caller's Bank
+    ///         balance -- the state a timed-out reserved redemption leaves
+    ///         the owner in (the Bridge refunds the surrendered amount as
+    ///         Bank balance). The caller surrenders the gross minted amount
+    ///         as Bank balance and pays the redemption fee in TBTC.
+    /// @param reservationKey The key of the reservation to redeem.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner,
+    ///      - The caller must have approved this vault in the Bank for the
+    ///        gross minted amount (`Bank.approveBalance`),
+    ///      - The caller must have approved this vault for the redemption
+    ///        fee in TBTC.
+    function retryRedeemReservation(
+        uint256 reservationKey,
+        bytes calldata redeemerOutputScript
+    ) external {
+        Reservation.ReservationRequest memory reservation = bridge.reservations(
+            reservationKey
+        );
+        require(
+            reservation.owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+
+        uint256 grossTbtc = uint256(reservation.mintedAmount) *
+            SATOSHI_MULTIPLIER;
+        uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
+        if (fee > 0) {
+            IERC20(tbtcToken).safeTransferFrom(
+                msg.sender,
+                bridge.treasury(),
+                fee
+            );
+        }
+
+        bank.transferBalanceFrom(
+            msg.sender,
+            address(this),
+            reservation.mintedAmount
+        );
+        bank.approveBalance(address(bridge), reservation.mintedAmount);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionInitiated(
+            reservationKey,
+            msg.sender,
+            grossTbtc,
+            fee
+        );
+
+        bridge.requestReservedRedemption(
+            reservationKey,
+            msg.sender,
+            redeemerOutputScript
+        );
     }
 
     /// @notice Updates the vault fee parameters.

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -69,7 +69,13 @@ interface IReservationBridge {
 ///         `updateReservationParameters`.
 /// @dev The vault deliberately keeps no claim registry of its own -- the
 ///      Bridge's reservation records are the single source of truth and are
-///      consulted for ownership checks.
+///      consulted for ownership checks. A reservation's `owner` is set once
+///      at acceptance and has no reassignment path anywhere in the Bridge
+///      or this vault: reservation positions are deliberately
+///      non-transferable, even though the TBTC minted against a reservation
+///      is freely transferable. Key rotation or entity restructuring on the
+///      owner side therefore requires redeeming and re-establishing the
+///      reservation rather than transferring it directly.
 contract ReservationVault is IVault, Ownable {
     using SafeERC20 for IERC20;
 
@@ -176,6 +182,18 @@ contract ReservationVault is IVault, Ownable {
     ///      created against the reservation equals the sats earmarked
     ///      on-chain; the fee is an explicit transfer, never a netted
     ///      credit.
+    ///
+    ///      Known limitation: this function cannot distinguish an
+    ///      acceptance credit from an ordinary pooled sweep credit. A
+    ///      deposit revealed to this vault's address before a vault swap,
+    ///      or after this vault is de-designated but still trusted by the
+    ///      Bridge, lands here as an ordinary multi-depositor credit and
+    ///      is charged the initiation fee for what is really a pooled
+    ///      deposit with no reservation record. This is accepted current
+    ///      behavior (see the reveal-time classification tests) -- fixing
+    ///      it properly requires the Bridge to pass an explicit
+    ///      discriminator through the shared `IVault.receiveBalanceIncrease`
+    ///      interface, a change affecting every vault, not just this one.
     function receiveBalanceIncrease(
         address[] calldata depositors,
         uint256[] calldata depositedAmounts
@@ -214,6 +232,23 @@ contract ReservationVault is IVault, Ownable {
         }
     }
 
+    /// @notice Fetches a reservation and validates the caller owns it.
+    /// @param reservationKey The key of the reservation.
+    /// @return reservation The validated reservation struct.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner.
+    function _ownedReservation(uint256 reservationKey)
+        internal
+        view
+        returns (Reservation.ReservationRequest memory reservation)
+    {
+        reservation = bridge.reservations(reservationKey);
+        require(
+            reservation.owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+    }
+
     /// @notice Requests an in-kind redemption of the caller's reservation.
     ///         The caller surrenders the gross minted TBTC amount plus the
     ///         redemption fee; the vault unmints the gross amount and asks
@@ -240,12 +275,8 @@ contract ReservationVault is IVault, Ownable {
         bytes calldata redeemerOutputScript,
         uint256 maxFeeTbtc
     ) external {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
+        Reservation.ReservationRequest memory reservation = _ownedReservation(
             reservationKey
-        );
-        require(
-            reservation.owner == msg.sender,
-            "Caller is not the reservation owner"
         );
 
         uint256 grossTbtc = uint256(reservation.mintedAmount) *
@@ -286,22 +317,24 @@ contract ReservationVault is IVault, Ownable {
     /// @notice Extends the custody term of the caller's reservation by one
     ///         term length, charging the extension fee in TBTC.
     /// @param reservationKey The key of the reservation to extend.
+    /// @param maxFeeTbtc Upper bound on the TBTC fee the caller accepts; an
+    ///        unexpected fee update reverts instead of overcharging.
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
+    ///      - The fee must not exceed `maxFeeTbtc`,
     ///      - The caller must have approved this vault for the extension
     ///        fee in TBTC.
-    function extendCustody(uint256 reservationKey) external {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
+    function extendCustody(uint256 reservationKey, uint256 maxFeeTbtc)
+        external
+    {
+        Reservation.ReservationRequest memory reservation = _ownedReservation(
             reservationKey
-        );
-        require(
-            reservation.owner == msg.sender,
-            "Caller is not the reservation owner"
         );
 
         uint256 fee = (uint256(reservation.mintedAmount) *
             SATOSHI_MULTIPLIER *
             extensionFeeBps) / BASIS_POINTS;
+        require(fee <= maxFeeTbtc, "Fee exceeds the caller's bound");
         if (fee > 0) {
             IERC20(tbtcToken).safeTransferFrom(
                 msg.sender,
@@ -326,6 +359,13 @@ contract ReservationVault is IVault, Ownable {
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
+    ///      - The reservation's most recent reserved redemption timeout
+    ///        must specifically have been caused by wallet fault (the
+    ///        Bridge's `lastTimeoutWasWalletFault` marker) -- otherwise
+    ///        this path would let an owner use it as an ordinary
+    ///        fee-free first redemption, or grief wallet operators for
+    ///        free by repeatedly requesting, waiting out the timeout
+    ///        (slashing the wallet), and retrying,
     ///      - The caller must have approved this vault in the Bank for the
     ///        gross minted amount (`Bank.approveBalance`).
     ///
@@ -337,12 +377,12 @@ contract ReservationVault is IVault, Ownable {
         uint256 reservationKey,
         bytes calldata redeemerOutputScript
     ) external {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
+        Reservation.ReservationRequest memory reservation = _ownedReservation(
             reservationKey
         );
         require(
-            reservation.owner == msg.sender,
-            "Caller is not the reservation owner"
+            reservation.lastTimeoutWasWalletFault,
+            "Previous request did not time out through wallet fault"
         );
 
         uint256 grossTbtc = uint256(reservation.mintedAmount) *

--- a/solidity/deploy/06_deploy_bridge.ts
+++ b/solidity/deploy/06_deploy_bridge.ts
@@ -39,6 +39,7 @@ const func: DeployFunction = async function deployBridge(
   })
   const Fraud = await deploy("Fraud", deployOptions)
   const MovingFunds = await deploy("MovingFunds", deployOptions)
+  const Reservation = await deploy("Reservation", deployOptions)
 
   const [bridge, proxyDeployment] = await helpers.upgrades.deployProxy(
     "Bridge",
@@ -62,6 +63,7 @@ const func: DeployFunction = async function deployBridge(
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
+          Reservation: Reservation.address,
         },
       },
       proxyOpts: {
@@ -82,6 +84,7 @@ const func: DeployFunction = async function deployBridge(
     await helpers.etherscan.verify(Wallets)
     await helpers.etherscan.verify(Fraud)
     await helpers.etherscan.verify(MovingFunds)
+    await helpers.etherscan.verify(Reservation)
 
     // We use `verify` instead of `verify:verify` as the `verify` task is defined
     // in "@openzeppelin/hardhat-upgrades" to perform Etherscan verification

--- a/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
+++ b/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
@@ -46,6 +46,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Wallets = await get("Wallets")
   const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
+  const Reservation = await get("Reservation")
 
   const Bridge = await deployments.get("Bridge")
 
@@ -56,6 +57,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     Wallets: Wallets.address,
     Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
+    Reservation: Reservation.address,
   }
 
   const bridgeFactory = await ethers.getContractFactory("Bridge", {

--- a/solidity/deploy/81_upgrade_bridge_v2_vault_fix.ts
+++ b/solidity/deploy/81_upgrade_bridge_v2_vault_fix.ts
@@ -57,6 +57,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Wallets = await get("Wallets")
   const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
+  const Reservation = await get("Reservation")
 
   log("Using existing libraries:")
   log(`  Deposit: ${Deposit.address}`)
@@ -85,6 +86,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
+          Reservation: Reservation.address,
         },
       },
       proxyOpts: {

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs_DEPRECATED.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs_DEPRECATED.ts
@@ -141,6 +141,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Wallets = await get("Wallets")
   const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
+  const Reservation = await get("Reservation")
 
   console.log("✓ Using existing DepositSweep at:", DepositSweep.address)
   console.log("✓ Using existing Wallets at:", Wallets.address)
@@ -167,6 +168,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       Wallets: Wallets.address,
       Fraud: Fraud.address,
       MovingFunds: MovingFunds.address,
+      Reservation: Reservation.address,
     },
   })
 
@@ -385,6 +387,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
+          Reservation: Reservation.address,
         },
       })
     } catch (error) {

--- a/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
+++ b/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
@@ -75,6 +75,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       "MovingFunds",
       bridgeArtifact.libraries?.MovingFunds
     ),
+    Reservation: await resolveAddress(
+      "Reservation",
+      bridgeArtifact.libraries?.Reservation
+    ),
   }
 
   const currentBridge = await ethers.getContractAt("Bridge", bridgeAddress)

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -336,6 +336,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Wallets = await get("Wallets")
   const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
+  const Reservation = await get("Reservation")
 
   console.log("Existing library addresses:")
   console.log(`  DepositSweep: ${DepositSweep.address}`)
@@ -355,6 +356,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     Wallets: Wallets.address,
     Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
+    Reservation: Reservation.address,
   }
 
   const bridgeImpl = await deploy("BridgeTIP109Implementation", {

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -136,6 +136,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const Wallets = await get("Wallets")
   const Fraud = await get("Fraud")
   const MovingFunds = await get("MovingFunds")
+  const Reservation = await get("Reservation")
 
   // --- Step 4: Deploy new Bridge implementation ---
   // Linked to existing Deposit + new Redemption + unchanged libs.
@@ -147,6 +148,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     Wallets: Wallets.address,
     Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
+    Reservation: Reservation.address,
   }
 
   const bridgeImpl = await deploy("BridgeTIP109HotfixImplementation", {

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -31,4 +31,4 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 export default func
 
 func.tags = ["ReservationVault"]
-func.dependencies = ["Bank", "TBTCVault"]
+func.dependencies = ["Bank", "TBTCVault", "Bridge"]

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -17,9 +17,10 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   })
 
   // NOTE: To activate reservations, governance must additionally:
-  // 1. Mark the vault as trusted: `Bridge.setVaultStatus(vault, true)`,
-  // 2. Wire it as the reservation vault and set the parameters:
-  //    `Bridge.updateReservationParameters(vault, ...)`.
+  // 1. While the vault remains untrusted, stage and finalize the reservation
+  //    vault and parameters through `BridgeGovernance`,
+  // 2. As the final activation step, mark the vault as trusted through
+  //    `BridgeGovernance.setVaultStatus(vault, true)`.
   // Neither action is performed by this script.
 
   if (hre.network.tags.etherscan) {
@@ -30,4 +31,4 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 export default func
 
 func.tags = ["ReservationVault"]
-func.dependencies = ["Bank", "TBTCVault", "Bridge"]
+func.dependencies = ["Bank", "TBTCVault"]

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -31,4 +31,4 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
 export default func
 
 func.tags = ["ReservationVault"]
-func.dependencies = ["Bank", "TBTCVault", "Bridge"]
+func.dependencies = ["Bank", "TBTCVault"]

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -1,0 +1,33 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
+  const { deployments, getNamedAccounts, helpers } = hre
+  const { deployer } = await getNamedAccounts()
+
+  const Bank = await deployments.get("Bank")
+  const TBTCVault = await deployments.get("TBTCVault")
+  const Bridge = await deployments.get("Bridge")
+
+  const reservationVault = await deployments.deploy("ReservationVault", {
+    from: deployer,
+    args: [Bank.address, TBTCVault.address, Bridge.address],
+    log: true,
+    waitConfirmations: 1,
+  })
+
+  // NOTE: To activate reservations, governance must additionally:
+  // 1. Mark the vault as trusted: `Bridge.setVaultStatus(vault, true)`,
+  // 2. Wire it as the reservation vault and set the parameters:
+  //    `Bridge.updateReservationParameters(vault, ...)`.
+  // Neither action is performed by this script.
+
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(reservationVault)
+  }
+}
+
+export default func
+
+func.tags = ["ReservationVault"]
+func.dependencies = ["Bank", "TBTCVault", "Bridge"]

--- a/solidity/deploy/96_transfer_reservation_vault_ownership.ts
+++ b/solidity/deploy/96_transfer_reservation_vault_ownership.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, helpers } = hre
+  const { deployer, governance } = await getNamedAccounts()
+
+  await helpers.ownable.transferOwnership(
+    "ReservationVault",
+    governance,
+    deployer
+  )
+}
+
+export default func
+
+func.tags = ["ReservationVaultOwnership"]
+func.dependencies = ["ReservationVault"]
+func.runAtTheEnd = true

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -75,7 +75,11 @@ const config: HardhatUserConfig = {
       "contracts/bridge/BridgeGovernance.sol": bridgeGovernanceCompilerConfig,
       // Reduce the number of optimizer runs to preserve the Bridge's
       // EIP-170 deployment margin after adding the reservation entry
-      // points. DRAFT NOTE: this trades runtime gas for code size; the
+      // points. The runtime-gas cost of this is effectively nil: the Bridge
+      // is a thin dispatch shell over linked libraries (Deposit,
+      // DepositSweep, Redemption, Reservation) that stay at runs=1000, so a
+      // measured runs=1000-vs-100 diff over the deposit/redemption/
+      // reservation hot paths is 0-8 gas (noise). DRAFT NOTE: the durable
       // alternative is a router-style refactor moving entry points out of
       // the Bridge (as done on the P2TR activation track).
       "contracts/bridge/Bridge.sol": {

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -73,6 +73,20 @@ const config: HardhatUserConfig = {
       "@keep-network/ecdsa/contracts/WalletRegistry.sol":
         ecdsaSolidityCompilerConfig,
       "contracts/bridge/BridgeGovernance.sol": bridgeGovernanceCompilerConfig,
+      // Reduce the number of optimizer runs to preserve the Bridge's
+      // EIP-170 deployment margin after adding the reservation entry
+      // points. DRAFT NOTE: this trades runtime gas for code size; the
+      // alternative is a router-style refactor moving entry points out of
+      // the Bridge (as done on the P2TR activation track).
+      "contracts/bridge/Bridge.sol": {
+        version: "0.8.17",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 100,
+          },
+        },
+      },
       "contracts/cross-chain/wormhole/L1BTCDepositorNttWithExecutor.sol": {
         version: "0.8.17",
         settings: {

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -75,19 +75,24 @@ const config: HardhatUserConfig = {
       "contracts/bridge/BridgeGovernance.sol": bridgeGovernanceCompilerConfig,
       // Reduce the number of optimizer runs to preserve the Bridge's
       // EIP-170 deployment margin after adding the reservation entry
-      // points. The runtime-gas cost of this is effectively nil: the Bridge
-      // is a thin dispatch shell over linked libraries (Deposit,
-      // DepositSweep, Redemption, Reservation) that stay at runs=1000, so a
-      // measured runs=1000-vs-100 diff over the deposit/redemption/
-      // reservation hot paths is 0-8 gas (noise). DRAFT NOTE: the durable
-      // alternative is a router-style refactor moving entry points out of
-      // the Bridge (as done on the P2TR activation track).
+      // points. Further reduced from 100 to 90 after the reserved
+      // redemption timeout/veto correctness fixes (settlement records,
+      // wallet-state-independent refund) grew the `reservations()`
+      // getter's struct-copy bytecode past the 100-runs margin. The
+      // runtime-gas cost of this is effectively nil: the Bridge is a
+      // thin dispatch shell over linked libraries (Deposit, DepositSweep,
+      // Redemption, Reservation) that stay at runs=1000, so a measured
+      // runs=1000-vs-100 diff over the deposit/redemption/reservation
+      // hot paths is 0-8 gas (noise); runs=100-vs-90 is smaller still.
+      // DRAFT NOTE: the durable alternative is a router-style refactor
+      // moving entry points out of the Bridge (as done on the P2TR
+      // activation track).
       "contracts/bridge/Bridge.sol": {
         version: "0.8.17",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 100,
+            runs: 90,
           },
         },
       },

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -75,24 +75,43 @@ const config: HardhatUserConfig = {
       "contracts/bridge/BridgeGovernance.sol": bridgeGovernanceCompilerConfig,
       // Reduce the number of optimizer runs to preserve the Bridge's
       // EIP-170 deployment margin after adding the reservation entry
-      // points. Further reduced from 100 to 90 after the reserved
-      // redemption timeout/veto correctness fixes (settlement records,
-      // wallet-state-independent refund) grew the `reservations()`
-      // getter's struct-copy bytecode past the 100-runs margin. The
-      // runtime-gas cost of this is effectively nil: the Bridge is a
-      // thin dispatch shell over linked libraries (Deposit, DepositSweep,
-      // Redemption, Reservation) that stay at runs=1000, so a measured
-      // runs=1000-vs-100 diff over the deposit/redemption/reservation
-      // hot paths is 0-8 gas (noise); runs=100-vs-90 is smaller still.
-      // DRAFT NOTE: the durable alternative is a router-style refactor
-      // moving entry points out of the Bridge (as done on the P2TR
-      // activation track).
+      // points. Progressively reduced (100 -> 90 -> 1) as correctness
+      // fixes (settlement-overwrite guard, Terminated-wallet dissolution,
+      // one-free-retry accounting, dust-value validation) added real new
+      // logic; runs=1 is the floor. The runtime-gas cost is effectively
+      // nil: the Bridge is a thin dispatch shell over linked libraries
+      // (Deposit, DepositSweep, Redemption) that stay at runs=1000, so a
+      // measured runs=1000-vs-100 diff over the deposit/redemption hot
+      // paths was 0-8 gas (noise); runs=1 is smaller still. The durable
+      // alternative remains a router-style refactor moving entry points
+      // out of the Bridge (as done on the P2TR activation track) -- once
+      // runs=1 stops being enough, there is no lower lever left to pull.
       "contracts/bridge/Bridge.sol": {
         version: "0.8.17",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 90,
+            runs: 1,
+          },
+        },
+      },
+      // Reservation's external functions (requestReservedRedemption,
+      // notifyReservedRedemptionTimeout/Veto, extendReservation,
+      // updateReservationParameters) deploy as their own standalone
+      // library contract, separate from the internal-function bytecode
+      // Bridge.sol inlines. Without this override that standalone
+      // deployment fell back to the default runs=1000, pushing it past
+      // the EIP-170 limit on its own after the settlement-overwrite,
+      // Terminated-wallet, one-free-retry, and dust-value correctness
+      // fixes added real new logic. Matches Bridge.sol's runs=1 for the
+      // same reason: this is a thin dispatch shell, not a gas-critical
+      // hot loop.
+      "contracts/bridge/Reservation.sol": {
+        version: "0.8.17",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 1,
           },
         },
       },

--- a/solidity/test/bridge/Bridge.RebateRecovery.test.ts
+++ b/solidity/test/bridge/Bridge.RebateRecovery.test.ts
@@ -46,8 +46,7 @@ describe("Bridge - Rebate staking recovery upgrade", () => {
       Wallets: (await helpers.contracts.getContract("Wallets")).address,
       Fraud: (await helpers.contracts.getContract("Fraud")).address,
       MovingFunds: (await helpers.contracts.getContract("MovingFunds")).address,
-      Reservation: (await helpers.contracts.getContract("Reservation"))
-        .address,
+      Reservation: (await helpers.contracts.getContract("Reservation")).address,
     }
 
     const bridgeFactory = await ethers.getContractFactory("BridgeStub", {

--- a/solidity/test/bridge/Bridge.RebateRecovery.test.ts
+++ b/solidity/test/bridge/Bridge.RebateRecovery.test.ts
@@ -46,6 +46,8 @@ describe("Bridge - Rebate staking recovery upgrade", () => {
       Wallets: (await helpers.contracts.getContract("Wallets")).address,
       Fraud: (await helpers.contracts.getContract("Fraud")).address,
       MovingFunds: (await helpers.contracts.getContract("MovingFunds")).address,
+      Reservation: (await helpers.contracts.getContract("Reservation"))
+        .address,
     }
 
     const bridgeFactory = await ethers.getContractFactory("BridgeStub", {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -137,6 +137,123 @@ describe("Bridge - Reservation", () => {
     }
   }
 
+  // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
+  // SPV proof validation checks transaction structure, merkle inclusion,
+  // and header work against the relay difficulty -- it does not execute
+  // Bitcoin scripts. Fixtures below use regtest-style compact bits
+  // (0x207fffff), whose integer difficulty is 0, with the relay mocked to
+  // report difficulty 0, so headers are minable in a couple of tries.
+
+  const REGTEST_BITS_LE = "ffff7f20"
+  const REGTEST_TARGET = BigNumber.from("0x7fffff").mul(
+    BigNumber.from(2).pow(8 * (0x20 - 3))
+  )
+
+  const reverseHex = (hex: string): string =>
+    hex.replace(/^0x/, "").match(/../g)!.reverse().join("")
+
+  const hash256 = (hexData: string): string =>
+    ethers.utils.sha256(ethers.utils.sha256(hexData))
+
+  const toLE = (value: number | BigNumber, byteLength: number): string =>
+    reverseHex(
+      BigNumber.from(value)
+        .toHexString()
+        .slice(2)
+        .padStart(byteLength * 2, "0")
+    )
+
+  const compactSize = (n: number): string => {
+    if (n >= 0xfd) {
+      throw new Error("compactSize > 252 not supported in fixtures")
+    }
+    return n.toString(16).padStart(2, "0")
+  }
+
+  interface FixtureTxIn {
+    txHash: string
+    index: number
+  }
+
+  interface FixtureTxOut {
+    valueSat: BigNumber | number
+    script: string // raw script hex, no 0x, no length prefix
+  }
+
+  function buildTx(inputs: FixtureTxIn[], outputs: FixtureTxOut[]) {
+    const inputVector = `0x${compactSize(inputs.length)}${inputs
+      .map((i) => `${i.txHash.slice(2)}${toLE(i.index, 4)}00ffffffff`)
+      .join("")}`
+    const outputVector = `0x${compactSize(outputs.length)}${outputs
+      .map(
+        (o) =>
+          `${toLE(BigNumber.from(o.valueSat), 8)}${compactSize(
+            o.script.length / 2
+          )}${o.script}`
+      )
+      .join("")}`
+    const info = {
+      version: "0x01000000",
+      inputVector,
+      outputVector,
+      locktime: "0x00000000",
+    }
+    const txHash = hash256(
+      `0x01000000${inputVector.slice(2)}${outputVector.slice(2)}00000000`
+    )
+    return { info, txHash }
+  }
+
+  function mineHeader(merkleRoot: string): string {
+    const prevBlock = ethers.utils
+      .hexlify(ethers.utils.randomBytes(32))
+      .slice(2)
+    const base = `20000000${prevBlock}${merkleRoot.slice(
+      2
+    )}662a2c68${REGTEST_BITS_LE}`
+    for (let nonce = 0; ; nonce++) {
+      const header = `0x${base}${toLE(nonce, 4)}`
+      if (
+        BigNumber.from(`0x${reverseHex(hash256(header))}`).lte(REGTEST_TARGET)
+      ) {
+        return header
+      }
+    }
+  }
+
+  // Builds an SPV proof for a transaction assumed to share a two-leaf
+  // block with a synthetic coinbase.
+  function proofFor(txHash: string) {
+    const coinbasePreimage = ethers.utils.sha256(ethers.utils.randomBytes(32))
+    const coinbaseTxId = ethers.utils.sha256(coinbasePreimage)
+    const merkleRoot = hash256(`0x${coinbaseTxId.slice(2)}${txHash.slice(2)}`)
+    return {
+      merkleProof: coinbaseTxId,
+      txIndexInBlock: 1,
+      bitcoinHeaders: mineHeader(merkleRoot),
+      coinbasePreimage,
+      coinbaseProof: txHash,
+    }
+  }
+
+  const buildDepositScript = (
+    depositor: string,
+    blinding: string,
+    walletPkh: string,
+    refundPkh: string,
+    locktime: string
+  ): string =>
+    `14${depositor.slice(2)}7508${blinding.slice(2)}7576a914${walletPkh
+      .slice(2)
+      .toLowerCase()}8763ac6776a914${refundPkh.slice(2)}8804${locktime.slice(
+      2
+    )}b175ac68`
+
+  const p2wshScript = (script: string): string =>
+    `0020${ethers.utils.sha256(`0x${script}`).slice(2)}`
+
+  const p2wpkhScript = (pkh: string): string => `0014${pkh.slice(2)}`
+
   describe("updateReservationParameters", () => {
     before(async () => {
       await createSnapshot()
@@ -755,124 +872,336 @@ describe("Bridge - Reservation", () => {
     })
   })
 
-  describe("reservation SPV proofs", () => {
-    // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
-    // SPV proof validation checks transaction structure, merkle inclusion,
-    // and header work against the relay difficulty -- it does not execute
-    // Bitcoin scripts. Fixtures below use regtest-style compact bits
-    // (0x207fffff), whose integer difficulty is 0, with the relay mocked to
-    // report difficulty 0, so headers are minable in a couple of tries.
+  describe("RedemptionWatchtower reserved veto flow", () => {
+    const reservationKey = 666
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const amountSat = BigNumber.from(100000000)
+    const redeemerOutputScript =
+      "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+    let redemptionWatchtower: Contract
+    let guardianSigners: SignerWithAddress[]
 
-    const REGTEST_BITS_LE = "ffff7f20"
-    const REGTEST_TARGET = BigNumber.from("0x7fffff").mul(
-      BigNumber.from(2).pow(8 * (0x20 - 3))
-    )
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
 
-    const reverseHex = (hex: string): string =>
-      hex.replace(/^0x/, "").match(/../g)!.reverse().join("")
-
-    const hash256 = (hexData: string): string =>
-      ethers.utils.sha256(ethers.utils.sha256(hexData))
-
-    const toLE = (value: number | BigNumber, byteLength: number): string =>
-      reverseHex(
-        BigNumber.from(value)
-          .toHexString()
-          .slice(2)
-          .padStart(byteLength * 2, "0")
+      redemptionWatchtower = await helpers.contracts.getContract(
+        "RedemptionWatchtower"
       )
 
-    const compactSize = (n: number): string => {
-      if (n >= 0xfd) {
-        throw new Error("compactSize > 252 not supported in fixtures")
-      }
-      return n.toString(16).padStart(2, "0")
-    }
-
-    interface FixtureTxIn {
-      txHash: string
-      index: number
-    }
-
-    interface FixtureTxOut {
-      valueSat: BigNumber | number
-      script: string // raw script hex, no 0x, no length prefix
-    }
-
-    function buildTx(inputs: FixtureTxIn[], outputs: FixtureTxOut[]) {
-      const inputVector = `0x${compactSize(inputs.length)}${inputs
-        .map((i) => `${i.txHash.slice(2)}${toLE(i.index, 4)}00ffffffff`)
-        .join("")}`
-      const outputVector = `0x${compactSize(outputs.length)}${outputs
-        .map(
-          (o) =>
-            `${toLE(BigNumber.from(o.valueSat), 8)}${compactSize(
-              o.script.length / 2
-            )}${o.script}`
+      // Enable the watchtower with three guardians and wire it into the
+      // Bridge.
+      guardianSigners = (await ethers.getSigners()).slice(10, 13)
+      if ((await redemptionWatchtower.watchtowerEnabledAt()) === 0) {
+        const watchtowerOwner = await impersonateContract(
+          await redemptionWatchtower.owner()
         )
-        .join("")}`
-      const info = {
-        version: "0x01000000",
-        inputVector,
-        outputVector,
-        locktime: "0x00000000",
-      }
-      const txHash = hash256(
-        `0x01000000${inputVector.slice(2)}${outputVector.slice(2)}00000000`
-      )
-      return { info, txHash }
-    }
-
-    function mineHeader(merkleRoot: string): string {
-      const prevBlock = ethers.utils
-        .hexlify(ethers.utils.randomBytes(32))
-        .slice(2)
-      const base = `20000000${prevBlock}${merkleRoot.slice(
-        2
-      )}662a2c68${REGTEST_BITS_LE}`
-      for (let nonce = 0; ; nonce++) {
-        const header = `0x${base}${toLE(nonce, 4)}`
-        if (
-          BigNumber.from(`0x${reverseHex(hash256(header))}`).lte(REGTEST_TARGET)
-        ) {
-          return header
+        await redemptionWatchtower.connect(watchtowerOwner).enableWatchtower(
+          governance.address,
+          guardianSigners.map((g) => g.address)
+        )
+      } else {
+        const manager = await impersonateContract(
+          await redemptionWatchtower.manager()
+        )
+        for (let i = 0; i < guardianSigners.length; i++) {
+          // eslint-disable-next-line no-await-in-loop
+          if (
+            !(await redemptionWatchtower.isGuardian(guardianSigners[i].address))
+          ) {
+            // eslint-disable-next-line no-await-in-loop
+            await redemptionWatchtower
+              .connect(manager)
+              .addGuardian(guardianSigners[i].address)
+          }
         }
       }
-    }
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(redemptionWatchtower.address)
 
-    // Builds an SPV proof for a transaction assumed to share a two-leaf
-    // block with a synthetic coinbase.
-    function proofFor(txHash: string) {
-      const coinbasePreimage = ethers.utils.sha256(ethers.utils.randomBytes(32))
-      const coinbaseTxId = ethers.utils.sha256(coinbasePreimage)
-      const merkleRoot = hash256(`0x${coinbaseTxId.slice(2)}${txHash.slice(2)}`)
-      return {
-        merkleProof: coinbaseTxId,
-        txIndexInBlock: 1,
-        bitcoinHeaders: mineHeader(merkleRoot),
-        coinbasePreimage,
-        coinbaseProof: txHash,
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          reservationKey,
+          thirdParty.address,
+          redeemerOutputScript
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("vetoes a reserved redemption after three guardian objections", async () => {
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(reservationKey)
+      await redemptionWatchtower
+        .connect(guardianSigners[1])
+        .raiseReservedObjection(reservationKey)
+
+      const tx = await redemptionWatchtower
+        .connect(guardianSigners[2])
+        .raiseReservedObjection(reservationKey)
+
+      await expect(tx)
+        .to.emit(redemptionWatchtower, "VetoFinalized")
+        .withArgs(reservationKey)
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionVetoed")
+        .withArgs(reservationKey)
+      await expect(tx)
+        .to.emit(redemptionWatchtower, "Banned")
+        .withArgs(thirdParty.address)
+
+      // The reservation survives the veto as Active.
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1)
+
+      // Default penalty is 100%: the whole detained amount is burned.
+      const veto = await redemptionWatchtower.vetoProposals(reservationKey)
+      expect(veto.withdrawableAmount).to.equal(0)
+      expect(await bank.balanceOf(redemptionWatchtower.address)).to.equal(0)
+
+      // The banned owner cannot re-request through the vault: the
+      // isSafeRedemption gate now rejects them.
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            reservationKey,
+            thirdParty.address,
+            redeemerOutputScript
+          )
+      ).to.be.revertedWith("Redemption request rejected by the watchtower")
+    })
+  })
+
+  describe("WalletProposalValidator", () => {
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
+    const blindingFactor = "0xf9f0c90d00039523"
+    const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
+    const amountSat = BigNumber.from(100000000)
+
+    let validator: Contract
+    let futureRefundLocktime: string
+    let fundingTx: { info: any; txHash: string }
+    let depositKey: { fundingTxHash: string; fundingOutputIndex: number }
+    let depositExtraInfo: any
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      const ValidatorFactory = await ethers.getContractFactory(
+        "WalletProposalValidator"
+      )
+      validator = await ValidatorFactory.deploy(bridge.address)
+
+      await bridge.setDepositDustThreshold(10000)
+      await bridge.setDepositTxMaxFee(2000)
+      await bridge.setDepositRevealAheadPeriod(0)
+
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      // A refund locktime comfortably in the future (400 days), as 4-byte LE.
+      futureRefundLocktime = `0x${toLE(
+        (await lastBlockTime()) + 400 * 24 * 3600,
+        4
+      )}`
+
+      const depositScript = buildDepositScript(
+        thirdParty.address,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        futureRefundLocktime
+      )
+      fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: BigNumber.from(3000000),
+            script: p2wshScript(depositScript),
+          },
+        ]
+      )
+
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime: futureRefundLocktime,
+        vault: reservationVault.address,
+      })
+
+      depositKey = { fundingTxHash: fundingTx.txHash, fundingOutputIndex: 0 }
+      depositExtraInfo = {
+        fundingTx: fundingTx.info,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime: futureRefundLocktime,
       }
-    }
 
-    const buildDepositScript = (
-      depositor: string,
-      blinding: string,
-      walletPkh: string,
-      refundPkh: string,
-      locktime: string
-    ): string =>
-      `14${depositor.slice(2)}7508${blinding.slice(2)}7576a914${walletPkh
-        .slice(2)
-        .toLowerCase()}8763ac6776a914${refundPkh.slice(2)}8804${locktime.slice(
-        2
-      )}b175ac68`
+      // Let the deposit exceed DEPOSIT_MIN_AGE (2 hours).
+      await increaseTime(7300)
+    })
 
-    const p2wshScript = (script: string): string =>
-      `0020${ethers.utils.sha256(`0x${script}`).slice(2)}`
+    after(async () => {
+      await restoreSnapshot()
+    })
 
-    const p2wpkhScript = (pkh: string): string => `0014${pkh.slice(2)}`
+    it("rejects sweep proposals containing reserved deposits", async () => {
+      await expect(
+        validator.validateDepositSweepProposal(
+          {
+            walletPubKeyHash,
+            depositsKeys: [depositKey],
+            sweepTxFee: 1500,
+            depositsRevealBlocks: [0],
+          },
+          [depositExtraInfo]
+        )
+      ).to.be.revertedWith("Reserved deposits must not be swept")
+    })
 
+    it("validates a reservation anchor proposal", async () => {
+      expect(
+        await validator.validateReservationAnchorProposal(
+          { walletPubKeyHash, depositKey, anchorTxFee: 1500 },
+          depositExtraInfo
+        )
+      ).to.be.true
+
+      await expect(
+        validator.validateReservationAnchorProposal(
+          { walletPubKeyHash, depositKey, anchorTxFee: 0 },
+          depositExtraInfo
+        )
+      ).to.be.revertedWith("Proposed transaction fee cannot be zero")
+
+      await expect(
+        validator.validateReservationAnchorProposal(
+          { walletPubKeyHash, depositKey, anchorTxFee: 2001 },
+          depositExtraInfo
+        )
+      ).to.be.revertedWith("Proposed transaction fee is too high")
+    })
+
+    it("validates reserved redemption, re-anchor and dissolution proposals", async () => {
+      const reservationKey = 12321
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      // Re-anchor: valid toward a Live target wallet.
+      await bridge.setWallet(secondWalletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      expect(
+        await validator.validateReservationReanchorProposal({
+          sourceWalletPubKeyHash: walletPubKeyHash,
+          reservationKey,
+          targetWalletPubKeyHash: secondWalletPubKeyHash,
+          reanchorTxFee: 1500,
+        })
+      ).to.be.true
+
+      // Dissolution: rejected before term + grace elapse.
+      await expect(
+        validator.validateReservationDissolutionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          dissolutionTxFee: 1500,
+        })
+      ).to.be.revertedWith("Reservation term or grace period not elapsed")
+
+      // Reserved redemption: request through the vault, wait past min age.
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          reservationKey,
+          thirdParty.address,
+          "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+        )
+
+      await increaseTime(601)
+
+      expect(
+        await validator.validateReservedRedemptionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          redemptionTxFee: 1500,
+        })
+      ).to.be.true
+
+      await expect(
+        validator.validateReservedRedemptionProposal({
+          walletPubKeyHash: secondWalletPubKeyHash,
+          reservationKey,
+          redemptionTxFee: 1500,
+        })
+      ).to.be.revertedWith("Reservation custodied by different wallet")
+    })
+  })
+
+  describe("reservation SPV proofs", () => {
     // ---- Scenario constants ----
 
     const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -650,7 +650,7 @@ describe("Bridge - Reservation", () => {
         await expect(
           reservationVault
             .connect(governance)
-            .redeemReservation(reservationKey, redeemerOutputScript)
+            .redeemReservation(reservationKey, redeemerOutputScript, 0)
         ).to.be.revertedWith("Caller is not the reservation owner")
       })
 
@@ -664,7 +664,7 @@ describe("Bridge - Reservation", () => {
 
         const tx = await reservationVault
           .connect(thirdParty)
-          .redeemReservation(reservationKey, redeemerOutputScript)
+          .redeemReservation(reservationKey, redeemerOutputScript, fee)
 
         await expect(tx)
           .to.emit(reservationVault, "ReservedRedemptionInitiated")
@@ -676,6 +676,83 @@ describe("Bridge - Reservation", () => {
         )
         expect((await bridge.reservations(reservationKey)).state).to.equal(2)
         expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
+      })
+
+      it("should reject a stale fee quote after governance update and accept the exact bound", async () => {
+        const exposedReservationKey = 998
+        const quotedFee = grossTbtc.mul(20).div(10000)
+        const updatedFee = grossTbtc.mul(500).div(10000)
+
+        await bridge.setReservation(
+          exposedReservationKey,
+          await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            amountSat
+          )
+        )
+
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address],
+            [amountSat.mul(2)]
+          )
+        await tbtc
+          .connect(thirdParty)
+          .approve(reservationVault.address, ethers.constants.MaxUint256)
+
+        const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+
+        await reservationVault.connect(deployer).updateFees(40, 20, 500)
+
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .redeemReservation(
+              exposedReservationKey,
+              redeemerOutputScript,
+              quotedFee
+            )
+        ).to.be.revertedWith("Fee exceeds the caller's bound")
+
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          ownerBalanceBefore
+        )
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore
+        )
+        expect(
+          (await bridge.reservations(exposedReservationKey)).state
+        ).to.equal(1)
+
+        const tx = await reservationVault
+          .connect(thirdParty)
+          .redeemReservation(
+            exposedReservationKey,
+            redeemerOutputScript,
+            updatedFee
+          )
+
+        await expect(tx)
+          .to.emit(reservationVault, "ReservedRedemptionInitiated")
+          .withArgs(
+            exposedReservationKey,
+            thirdParty.address,
+            grossTbtc,
+            updatedFee
+          )
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore.add(updatedFee)
+        )
+        expect(
+          (await bridge.reservations(exposedReservationKey)).state
+        ).to.equal(2)
+
+        await reservationVault.connect(deployer).updateFees(40, 20, 20)
       })
     })
   })
@@ -1426,7 +1503,7 @@ describe("Bridge - Reservation", () => {
         .approve(reservationVault.address, grossTbtc.add(redemptionFee))
       await reservationVault
         .connect(thirdParty)
-        .redeemReservation(reservationKey, redeemerScript)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
       const redemptionTx = buildTx(
         [{ txHash: anchorTx.txHash, index: 0 }],
         [
@@ -1489,7 +1566,7 @@ describe("Bridge - Reservation", () => {
         .approve(reservationVault.address, grossTbtc.add(redemptionFee))
       await reservationVault
         .connect(thirdParty)
-        .redeemReservation(reservationKey, redeemerScript)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
 
       // Pay the full anchor value out (zero miner fee). The old lower bound
       // `anchorAmount - redemptionTxMaxFee` would revert on underflow here.

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -654,8 +654,9 @@ describe("Bridge - Reservation", () => {
         ).to.be.revertedWith("Caller is not the reservation owner")
       })
 
-      it("should surrender gross TBTC, charge the fee, and register the redemption", async () => {
-        const fee = grossTbtc.mul(20).div(10000)
+      it("should surrender gross TBTC and register the redemption", async () => {
+        // Redemption is free by default; the exit leg is exit-neutral.
+        const fee = BigNumber.from(0)
         const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
 
         await tbtc
@@ -804,7 +805,7 @@ describe("Bridge - Reservation", () => {
     })
 
     it("retries the redemption from Bank balance", async () => {
-      const fee = grossTbtc.mul(20).div(10000)
+      const fee = BigNumber.from(0)
       await bank
         .connect(thirdParty)
         .approveBalance(reservationVault.address, amountSat)
@@ -1399,7 +1400,7 @@ describe("Bridge - Reservation", () => {
       // balance held by the Bridge.
       const supplyBefore = await tbtc.totalSupply()
 
-      const redemptionFee = grossTbtc.mul(20).div(10000)
+      const redemptionFee = BigNumber.from(0)
       await tbtc
         .connect(thirdParty)
         .approve(reservationVault.address, grossTbtc.add(redemptionFee))

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -725,8 +725,12 @@ describe("Bridge - Reservation", () => {
       await createSnapshot()
       await wireReservations()
 
-      // A Terminated wallet lets the timeout path skip slashing and state
-      // transitions, isolating the reservation bookkeeping under test.
+      // Live at request time, since `requestReservedRedemption` now
+      // requires a Live wallet (matching the pooled redemption path).
+      // The "should register the redemption..." test below transitions
+      // this wallet to Terminated between the request and the timeout
+      // call, to exercise the timeout path's "skip slashing" branch for
+      // a wallet that died while a redemption was in flight.
       await bridge.setWallet(walletPubKeyHash, {
         ecdsaWalletID: ethers.utils.randomBytes(32),
         mainUtxoHash: ZERO_BYTES32,
@@ -735,7 +739,7 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
 
@@ -764,7 +768,8 @@ describe("Bridge - Reservation", () => {
             reservationKey,
             thirdParty.address,
             redeemerOutputScript
-          )
+          ,
+            false)
       ).to.be.revertedWith("Caller is not the reservation vault")
     })
 
@@ -779,7 +784,8 @@ describe("Bridge - Reservation", () => {
           reservationKey,
           thirdParty.address,
           redeemerOutputScript
-        )
+        ,
+          false)
 
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionRequested")
@@ -802,8 +808,26 @@ describe("Bridge - Reservation", () => {
             reservationKey,
             thirdParty.address,
             redeemerOutputScript
-          )
+          ,
+            false)
       ).to.be.revertedWith("Reservation is not active")
+
+      // The wallet dies (Terminated) while the redemption is in flight --
+      // this is what actually exercises the timeout path's "skip
+      // slashing" branch, since a wallet can no longer be Live/MovingFunds
+      // by the time this fires yet the redemption was validly requested
+      // against it earlier while it was still Live.
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
 
       // Timeout: the redeemer gets the balance back and the reservation
       // survives as Active.
@@ -868,7 +892,8 @@ describe("Bridge - Reservation", () => {
           liveReservationKey,
           thirdParty.address,
           redeemerOutputScript
-        )
+        ,
+          false)
 
       const { redemptionTimeout } = await bridge.redemptionParameters()
       await increaseTime(redemptionTimeout + 1)
@@ -896,6 +921,21 @@ describe("Bridge - Reservation", () => {
       const vaultSigner = await impersonateContract(reservationVault.address)
       const bridgeSigner = await impersonateContract(bridge.address)
 
+      // The prior test transitions this wallet to Terminated mid-flight;
+      // restore it to Live since only output-script validation is under
+      // test here.
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
       const guardKey = 890
       await bridge.setReservation(
         guardKey,
@@ -913,7 +953,8 @@ describe("Bridge - Reservation", () => {
             guardKey,
             thirdParty.address,
             `0x160014${walletPubKeyHash.substring(2)}`
-          )
+          ,
+            false)
       ).to.be.revertedWith(
         "Redeemer output script must not point to the wallet PKH"
       )
@@ -926,7 +967,8 @@ describe("Bridge - Reservation", () => {
             guardKey,
             thirdParty.address,
             `0x1976a914${walletPubKeyHash.substring(2)}88ac`
-          )
+          ,
+            false)
       ).to.be.revertedWith(
         "Redeemer output script must not point to the wallet PKH"
       )
@@ -935,6 +977,20 @@ describe("Bridge - Reservation", () => {
     it("should revert when the redeemer output script is not a standard type", async () => {
       const vaultSigner = await impersonateContract(reservationVault.address)
       const bridgeSigner = await impersonateContract(bridge.address)
+
+      // See the previous test: this wallet was left Terminated by the
+      // earlier timeout test in this describe.
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
 
       const guardKey = 891
       await bridge.setReservation(
@@ -952,7 +1008,8 @@ describe("Bridge - Reservation", () => {
             guardKey,
             thirdParty.address,
             "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
-          )
+          ,
+            false)
       ).to.be.revertedWith("Redeemer output script must be a standard type")
     })
   })
@@ -1060,6 +1117,18 @@ describe("Bridge - Reservation", () => {
         "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
 
       before(async () => {
+        // `requestReservedRedemption` requires a Live wallet.
+        await bridge.setWallet(walletPubKeyHash, {
+          ecdsaWalletID: ethers.utils.randomBytes(32),
+          mainUtxoHash: ZERO_BYTES32,
+          pendingRedemptionsValue: 0,
+          createdAt: await lastBlockTime(),
+          movingFundsRequestedAt: 0,
+          closingStartedAt: 0,
+          pendingMovedFundsSweepRequestsCount: 0,
+          state: walletState.Live,
+          movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+        })
         await bridge.setReservation(
           reservationKey,
           await activeReservation(
@@ -1142,7 +1211,7 @@ describe("Bridge - Reservation", () => {
         const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
         const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
 
-        await reservationVault.connect(deployer).updateFees(40, 20, 500)
+        await reservationVault.connect(governance).updateFees(40, 20, 500)
 
         await expect(
           reservationVault
@@ -1187,7 +1256,7 @@ describe("Bridge - Reservation", () => {
           (await bridge.reservations(exposedReservationKey)).state
         ).to.equal(2)
 
-        await reservationVault.connect(deployer).updateFees(40, 20, 20)
+        await reservationVault.connect(governance).updateFees(40, 20, 20)
       })
     })
 
@@ -1259,13 +1328,13 @@ describe("Bridge - Reservation", () => {
     describe("updateFees", () => {
       it("should revert when a fee parameter exceeds the maximum", async () => {
         await expect(
-          reservationVault.connect(deployer).updateFees(501, 20, 20)
+          reservationVault.connect(governance).updateFees(501, 20, 20)
         ).to.be.revertedWith("Fee exceeds the maximum")
         await expect(
-          reservationVault.connect(deployer).updateFees(40, 501, 20)
+          reservationVault.connect(governance).updateFees(40, 501, 20)
         ).to.be.revertedWith("Fee exceeds the maximum")
         await expect(
-          reservationVault.connect(deployer).updateFees(40, 20, 501)
+          reservationVault.connect(governance).updateFees(40, 20, 501)
         ).to.be.revertedWith("Fee exceeds the maximum")
       })
     })
@@ -1290,7 +1359,7 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
       await bridge.setReservation(
@@ -1310,7 +1379,8 @@ describe("Bridge - Reservation", () => {
           reservationKey,
           thirdParty.address,
           redeemerOutputScript
-        )
+        ,
+          false)
 
       // Wire the watchtower only after the request so the
       // isSafeRedemption gate does not call an EOA.
@@ -1366,7 +1436,7 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
       await bridge.setReservation(reservationKey, {
@@ -1579,7 +1649,7 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
       await bridge.setReservation(
@@ -1599,7 +1669,8 @@ describe("Bridge - Reservation", () => {
           reservationKey,
           thirdParty.address,
           redeemerOutputScript
-        )
+        ,
+          false)
     })
 
     after(async () => {
@@ -1644,8 +1715,12 @@ describe("Bridge - Reservation", () => {
       expect(veto.withdrawableAmount).to.equal(0)
       expect(await bank.balanceOf(redemptionWatchtower.address)).to.equal(0)
 
-      // The banned owner cannot re-request through the vault: the
-      // isSafeRedemption gate now rejects them.
+      // The banned owner cannot re-request through the vault. The
+      // settlement-overwrite guard fires first here (this same anchor
+      // still carries the unresolved settlement the veto just recorded);
+      // the watchtower's own ban is separately confirmed above via the
+      // "Banned" event and would independently reject this same owner
+      // once the reservation is re-anchored to a fresh, unsettled anchor.
       const vaultSigner = await impersonateContract(reservationVault.address)
       await expect(
         bridge
@@ -1654,8 +1729,9 @@ describe("Bridge - Reservation", () => {
             reservationKey,
             thirdParty.address,
             redeemerOutputScript
-          )
-      ).to.be.revertedWith("Redemption request rejected by the watchtower")
+          ,
+            false)
+      ).to.be.revertedWith("Unresolved settlement exists for the current anchor")
     })
 
     it("should revert when the reserved redemption does not exist", async () => {
@@ -1693,7 +1769,8 @@ describe("Bridge - Reservation", () => {
           freshKey,
           governance.address,
           redeemerOutputScript
-        )
+        ,
+          false)
 
       await redemptionWatchtower
         .connect(guardianSigners[0])
@@ -1754,7 +1831,7 @@ describe("Bridge - Reservation", () => {
       await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
       await bridge
         .connect(vaultSigner)
-        .requestReservedRedemption(freshKey, owner, redeemerOutputScript)
+        .requestReservedRedemption(freshKey, owner, redeemerOutputScript, false)
 
       // First generation: one guardian objects, below the 3-objection
       // veto threshold, then the request times out without being
@@ -1771,18 +1848,40 @@ describe("Bridge - Reservation", () => {
 
       expect((await bridge.reservations(freshKey)).state).to.equal(1) // Active
 
-      // Second generation: re-request. The guardian who objected against
-      // generation 1 must be able to object again, and the new
-      // generation must start with zero objections -- a stale
-      // `objectionsCount` from the resolved generation 1 must not carry
-      // over and bias or block generation 2.
+      // The timeout moved the wallet from Live to MovingFunds (the same
+      // `moveFunds` transition the pooled redemption path triggers on a
+      // wallet's first missed deadline) -- `requestReservedRedemption`
+      // now requires Live, so generation 2 must first move to a healthy
+      // wallet. Simulate the contractual effect of a re-anchor (a full
+      // SPV proof is exercised elsewhere) by pointing the reservation at
+      // a fresh Live wallet directly via the stub setter, preserving the
+      // same `reservationKey` -- what actually matters for this test is
+      // that the watchtower's per-generation state is isolated by
+      // `(reservationKey, redemptionRequestedAt)`, not by the wallet.
+      const secondGenWalletPubKeyHash =
+        "0xa1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+      await bridge.setWallet(secondGenWalletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setReservation(freshKey, {
+        ...(await activeReservation(owner, secondGenWalletPubKeyHash, amountSat)),
+      })
+
       await bank
         .connect(bridgeSigner)
         .increaseBalance(reservationVault.address, amountSat)
       await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
       await bridge
         .connect(vaultSigner)
-        .requestReservedRedemption(freshKey, owner, redeemerOutputScript)
+        .requestReservedRedemption(freshKey, owner, redeemerOutputScript, false)
 
       const { redemptionRequestedAt } = await bridge.reservations(freshKey)
       const secondGenVetoKey = ethers.utils.solidityKeccak256(
@@ -1983,7 +2082,8 @@ describe("Bridge - Reservation", () => {
           reservationKey,
           thirdParty.address,
           "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
-        )
+        ,
+          false)
 
       await increaseTime(601)
 

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -906,9 +906,10 @@ describe("Bridge - Reservation", () => {
         )
         for (let i = 0; i < guardianSigners.length; i++) {
           // eslint-disable-next-line no-await-in-loop
-          if (
-            !(await redemptionWatchtower.isGuardian(guardianSigners[i].address))
-          ) {
+          const alreadyGuardian = await redemptionWatchtower.isGuardian(
+            guardianSigners[i].address
+          )
+          if (!alreadyGuardian) {
             // eslint-disable-next-line no-await-in-loop
             await redemptionWatchtower
               .connect(manager)

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -357,12 +357,12 @@ describe("Bridge - Reservation", () => {
   })
 
   describe("deposit sweep guard", () => {
-    before(async () => {
+    beforeEach(async () => {
       await createSnapshot()
       await wireReservations()
     })
 
-    after(async () => {
+    afterEach(async () => {
       await restoreSnapshot()
     })
 
@@ -400,6 +400,27 @@ describe("Bridge - Reservation", () => {
       })
       await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
 
+      const depositKey = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.hash, reveal.fundingOutputIndex]
+      )
+      expect(await bridge.isReservedDeposit(depositKey)).to.be.true
+
+      // Moving the configured reservation vault away must not make this
+      // reveal-time reserved deposit eligible for an ordinary sweep.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          tbtcVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET
+        )
+      expect(await bridge.isReservedDeposit(depositKey)).to.be.true
+
       await expect(
         bridge
           .connect(spvMaintainer)
@@ -410,6 +431,154 @@ describe("Bridge - Reservation", () => {
             data.vault
           )
       ).to.be.revertedWith("Reserved deposits must not be swept")
+    })
+
+    it("should sweep an ordinary deposit after its vault becomes the reservation vault", async () => {
+      const data: DepositSweepTestData = JSON.parse(
+        JSON.stringify(SingleP2WSHDeposit)
+      )
+      // The deposit is ordinary at reveal time because the reservation vault
+      // is still `reservationVault`. Governance then repurposes its trusted
+      // vault as the reservation vault before the sweep is proven.
+      data.deposits[0].reveal.vault = tbtcVault.address
+      data.vault = tbtcVault.address
+
+      relay.getCurrentEpochDifficulty.returns(data.chainDifficulty)
+      relay.getPrevEpochDifficulty.returns(data.chainDifficulty)
+
+      await bridge.setDepositDustThreshold(10000)
+      await bridge.setDepositTxMaxFee(2000)
+      await bridge.setDepositRevealAheadPeriod(0)
+
+      const { fundingTx, depositor, reveal } = data.deposits[0]
+      await bridge.setWallet(reveal.walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      const depositorSigner = await impersonateAccount(depositor, {
+        from: governance,
+        value: 10,
+      })
+      await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
+
+      const depositKey = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.hash, reveal.fundingOutputIndex]
+      )
+      expect(await bridge.isReservedDeposit(depositKey)).to.be.false
+
+      // Build a fresh ordinary deposit with a future refund deadline so the
+      // wallet proposal validator can exercise the same migration path.
+      const validatorBlindingFactor = "0xf9f0c90d00039523"
+      const validatorRefundPubKeyHash =
+        "0x28e081f285138ccbe389c1eb8985716230129f89"
+      const validatorRefundLocktime = `0x${toLE(
+        (await lastBlockTime()) + 400 * 24 * 3600,
+        4
+      )}`
+      const validatorFundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: BigNumber.from(3000000),
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                validatorBlindingFactor,
+                reveal.walletPubKeyHash as string,
+                validatorRefundPubKeyHash,
+                validatorRefundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(validatorFundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor: validatorBlindingFactor,
+        walletPubKeyHash: reveal.walletPubKeyHash,
+        refundPubKeyHash: validatorRefundPubKeyHash,
+        refundLocktime: validatorRefundLocktime,
+        vault: tbtcVault.address,
+      })
+      const validatorDepositKey = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [validatorFundingTx.txHash, 0]
+      )
+      expect(await bridge.isReservedDeposit(validatorDepositKey)).to.be.false
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          tbtcVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET
+        )
+
+      // Classification is a reveal-time fact, not a live vault-address
+      // comparison.
+      expect(await bridge.isReservedDeposit(depositKey)).to.be.false
+      expect(await bridge.isReservedDeposit(validatorDepositKey)).to.be.false
+
+      await increaseTime(7300)
+      const ValidatorFactory = await ethers.getContractFactory(
+        "WalletProposalValidator"
+      )
+      const validator = await ValidatorFactory.deploy(bridge.address)
+      expect(
+        await validator.validateDepositSweepProposal(
+          {
+            walletPubKeyHash: reveal.walletPubKeyHash,
+            depositsKeys: [
+              {
+                fundingTxHash: validatorFundingTx.txHash,
+                fundingOutputIndex: 0,
+              },
+            ],
+            sweepTxFee: 1500,
+            depositsRevealBlocks: [0],
+          },
+          [
+            {
+              fundingTx: validatorFundingTx.info,
+              blindingFactor: validatorBlindingFactor,
+              walletPubKeyHash: reveal.walletPubKeyHash,
+              refundPubKeyHash: validatorRefundPubKeyHash,
+              refundLocktime: validatorRefundLocktime,
+            },
+          ]
+        )
+      ).to.be.true
+
+      // Let the ordinary TBTC vault mint the swept deposit balance.
+      const tbtcOwner = await impersonateContract(await tbtc.owner())
+      await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+
+      await bridge
+        .connect(spvMaintainer)
+        .submitDepositSweepProof(
+          data.sweepTx,
+          data.sweepProof,
+          data.mainUtxo,
+          data.vault
+        )
     })
   })
 
@@ -1436,6 +1605,8 @@ describe("Bridge - Reservation", () => {
       const { anchorTx, acceptTx, reservationKey } =
         await makeAcceptedReservation()
 
+      expect(await bridge.isReservedDeposit(reservationKey)).to.be.true
+
       await expect(acceptTx)
         .to.emit(bridge, "ReservationAccepted")
         .withArgs(
@@ -1474,6 +1645,69 @@ describe("Bridge - Reservation", () => {
             0
           )
       ).to.be.revertedWith("Deposit already swept")
+    })
+
+    it("does not accept an ordinary deposit after its vault becomes the reservation vault", async () => {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: tbtcVault.address,
+      })
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          tbtcVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET
+        )
+
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            0
+          )
+      ).to.be.revertedWith("Deposit was not revealed as reserved")
     })
 
     it("rejects an anchor paying an excessive miner fee", async () => {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1493,9 +1493,13 @@ describe("Bridge - Reservation", () => {
         .withArgs(reservationKey, redemptionTx.txHash)
     })
 
-    it("rejects a re-anchor that drops below the reservation minimum", async () => {
-      // Accept a reservation whose anchor sits at the reservation minimum,
-      // so a single fee-capped hop can push it below the floor.
+    it("allows a minimum-sized reservation to migrate (H-08 regression)", async () => {
+      // A reservation whose anchor sits at the reservation minimum must
+      // still be migratable with a positive fee. The earlier
+      // `>= reservationMinAmount` re-anchor floor, combined with the
+      // proposal validator's positive-fee requirement, left no compliant
+      // re-anchor for an exactly-minimum anchor and would have pinned a
+      // retiring wallet. The dust floor (`> reservationTxMaxFee`) fixes it.
       const minAmount = BigNumber.from(RESERVATION_MIN_AMOUNT)
       const depositAmt = minAmount.add(RESERVATION_TX_MAX_FEE)
       const fundingTx = buildTx(
@@ -1550,41 +1554,12 @@ describe("Bridge - Reservation", () => {
 
       await liveWallet(secondWalletPubKeyHash)
 
-      // Fee of 1 sat keeps the hop within the per-hop cap, but the resulting
-      // anchor (min - 1) sits below the reservation minimum.
-      const belowMin = minAmount.sub(1)
+      // Migrate with a 1-sat fee: the anchor stays above the dust floor.
+      const migrated = minAmount.sub(1)
       const reanchorTx = buildTx(
         [{ txHash: anchorTx.txHash, index: 0 }],
-        [{ valueSat: belowMin, script: p2wpkhScript(secondWalletPubKeyHash) }]
+        [{ valueSat: migrated, script: p2wpkhScript(secondWalletPubKeyHash) }]
       )
-      await expect(
-        bridge
-          .connect(spvMaintainer)
-          .submitReservationProof(
-            ProofType.Reanchor,
-            reanchorTx.info,
-            proofFor(reanchorTx.txHash),
-            NO_MAIN_UTXO_PARAM,
-            reservationKey
-          )
-      ).to.be.revertedWith("Re-anchor amount below the reservation minimum")
-    })
-
-    it("re-anchors a reservation to another Live wallet", async () => {
-      const { anchorTx, reservationKey } = await makeAcceptedReservation()
-      await liveWallet(secondWalletPubKeyHash)
-
-      const reanchorFee = 500
-      const reanchorTx = buildTx(
-        [{ txHash: anchorTx.txHash, index: 0 }],
-        [
-          {
-            valueSat: anchorAmount.sub(reanchorFee),
-            script: p2wpkhScript(secondWalletPubKeyHash),
-          },
-        ]
-      )
-
       const tx = await bridge
         .connect(spvMaintainer)
         .submitReservationProof(
@@ -1594,22 +1569,14 @@ describe("Bridge - Reservation", () => {
           NO_MAIN_UTXO_PARAM,
           reservationKey
         )
-
       await expect(tx)
         .to.emit(bridge, "ReservationReanchored")
         .withArgs(
           reservationKey,
           secondWalletPubKeyHash,
           reanchorTx.txHash,
-          anchorAmount.sub(reanchorFee)
+          migrated
         )
-
-      const reservation = await bridge.reservations(reservationKey)
-      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
-      expect(reservation.anchorTxHash).to.equal(reanchorTx.txHash)
-      expect(reservation.anchorAmount).to.equal(anchorAmount.sub(reanchorFee))
-      // The gross claim is unchanged by in-kind re-anchor fees.
-      expect(reservation.mintedAmount).to.equal(anchorAmount)
     })
 
     it("dissolves an expired reservation into the wallet main UTXO", async () => {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -12,6 +12,7 @@ import type {
   BridgeGovernance,
   BridgeStub,
   IRelay,
+  IWalletRegistry,
   ReservationVault,
   TBTCVault,
   TBTC,
@@ -35,6 +36,8 @@ const RESERVATION_MIN_AMOUNT = 10000
 const RESERVATION_TX_MAX_FEE = 2000
 const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
 const MAX_RESERVATIONS_PER_WALLET = 10
+const RESERVATION_DISSOLUTION_TX_MAX_FEE = 1500
+const MAX_CUMULATIVE_REANCHOR_FEE = 100000
 
 const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
 
@@ -47,12 +50,15 @@ describe("Bridge - Reservation", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
+  let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub
   let tbtc: TBTC & Contract
   let tbtcVault: TBTCVault & Contract
   let bridgeGovernance: BridgeGovernance
   let reservationVault: ReservationVault
   let bridgeGovernanceSigner: SignerWithAddress
+  let redemptionTimeoutSlashingAmount: BigNumber
+  let redemptionTimeoutNotifierRewardMultiplier: number
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -64,11 +70,16 @@ describe("Bridge - Reservation", () => {
       treasury,
       bank,
       relay,
+      walletRegistry,
       bridge,
       bridgeGovernance,
       tbtc,
       tbtcVault,
     } = await waffle.loadFixture(bridgeFixture))
+    ;({
+      redemptionTimeoutSlashingAmount,
+      redemptionTimeoutNotifierRewardMultiplier,
+    } = await bridge.redemptionParameters())
 
     reservationVault = await helpers.contracts.getContract("ReservationVault")
 
@@ -106,10 +117,12 @@ describe("Bridge - Reservation", () => {
         reservationVault.address,
         RESERVATION_MIN_AMOUNT,
         RESERVATION_TX_MAX_FEE,
+        RESERVATION_DISSOLUTION_TX_MAX_FEE,
         RESERVATION_TERM,
         RESERVATION_GRACE,
         RESERVATION_MAX_TOTAL,
-        MAX_RESERVATIONS_PER_WALLET
+        MAX_RESERVATIONS_PER_WALLET,
+        MAX_CUMULATIVE_REANCHOR_FEE
       )
   }
 
@@ -134,6 +147,8 @@ describe("Bridge - Reservation", () => {
       redemptionTxMaxFee: 0,
       redeemer: ZERO_ADDRESS,
       redeemerOutputScriptHash: ZERO_BYTES32,
+      cumulativeReanchorFee: 0,
+      lastTimeoutWasWalletFault: false,
     }
   }
 
@@ -272,10 +287,12 @@ describe("Bridge - Reservation", () => {
               reservationVault.address,
               RESERVATION_MIN_AMOUNT,
               RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -289,10 +306,12 @@ describe("Bridge - Reservation", () => {
             reservationVault.address,
             RESERVATION_MIN_AMOUNT,
             RESERVATION_TX_MAX_FEE,
+            RESERVATION_DISSOLUTION_TX_MAX_FEE,
             RESERVATION_TERM,
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET
+            MAX_RESERVATIONS_PER_WALLET,
+            MAX_CUMULATIVE_REANCHOR_FEE
           )
 
         await expect(tx)
@@ -303,10 +322,12 @@ describe("Bridge - Reservation", () => {
           .withArgs(
             RESERVATION_MIN_AMOUNT,
             RESERVATION_TX_MAX_FEE,
+            RESERVATION_DISSOLUTION_TX_MAX_FEE,
             RESERVATION_TERM,
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET
+            MAX_RESERVATIONS_PER_WALLET,
+            MAX_CUMULATIVE_REANCHOR_FEE
           )
       })
 
@@ -318,14 +339,52 @@ describe("Bridge - Reservation", () => {
               reservationVault.address,
               RESERVATION_MIN_AMOUNT,
               0,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
             )
         ).to.be.revertedWith(
           "Reservation transaction max fee must be greater than zero"
         )
+      })
+
+      it("should revert when the minimum amount is not greater than the tx max fee", async () => {
+        await expect(
+          bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_TX_MAX_FEE, // equal, not greater
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_DISSOLUTION_TX_MAX_FEE,
+            RESERVATION_TERM,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            MAX_CUMULATIVE_REANCHOR_FEE
+          )
+        ).to.be.revertedWith(
+          "Reservation minimum amount must be greater than the reservation TX max fee"
+        )
+      })
+
+      it("should revert for a zero reservation term", async () => {
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
+              0,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
+            )
+        ).to.be.revertedWith("Reservation term must be greater than zero")
       })
 
       it("should revert when changing the vault with active reservations", async () => {
@@ -346,10 +405,12 @@ describe("Bridge - Reservation", () => {
               thirdParty.address,
               RESERVATION_MIN_AMOUNT,
               RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
             )
         ).to.be.revertedWith("Active reservations exist")
       })
@@ -414,10 +475,12 @@ describe("Bridge - Reservation", () => {
           tbtcVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
       expect(await bridge.isReservedDeposit(depositKey)).to.be.true
 
@@ -526,10 +589,12 @@ describe("Bridge - Reservation", () => {
           tbtcVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       // Classification is a reveal-time fact, not a live vault-address
@@ -625,6 +690,25 @@ describe("Bridge - Reservation", () => {
         await expect(tx)
           .to.emit(bridge, "ReservationExtended")
           .withArgs(reservationKey, after_.expiresAt)
+      })
+    })
+
+    context("when the reservation is not active", () => {
+      it("should revert", async () => {
+        const pendingKey = 778
+        await bridge.setReservation(pendingKey, {
+          ...(await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            BigNumber.from(100000000)
+          )),
+          state: 2, // RedemptionRequested
+        })
+
+        const vaultSigner = await impersonateContract(reservationVault.address)
+        await expect(
+          bridge.connect(vaultSigner).extendReservation(pendingKey)
+        ).to.be.revertedWith("Reservation is not active")
       })
     })
   })
@@ -733,9 +817,143 @@ describe("Bridge - Reservation", () => {
       await expect(timeoutTx)
         .to.emit(bridge, "ReservedRedemptionTimedOut")
         .withArgs(reservationKey, walletPubKeyHash)
+      await expect(timeoutTx)
+        .to.emit(bridge, "ReservedRedemptionTimeoutSlashingSkipped")
+        .withArgs(reservationKey, walletPubKeyHash)
+      expect(
+        (await bridge.reservations(reservationKey)).lastTimeoutWasWalletFault
+      ).to.be.false
+      expect(walletRegistry.seize).to.not.have.been.called
 
       expect(await bank.balanceOf(thirdParty.address)).to.equal(amountSat)
       expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+    })
+
+    it("slashes the wallet operators on timeout when the wallet is Live", async () => {
+      const liveReservationKey = 889
+      const liveWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
+      const walletMembersIDs = [1, 2, 3, 4, 5]
+
+      await bridge.setWallet(liveWalletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setActiveWallet(liveWalletPubKeyHash)
+      await bridge.setReservation(
+        liveReservationKey,
+        await activeReservation(
+          thirdParty.address,
+          liveWalletPubKeyHash,
+          amountSat
+        )
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          liveReservationKey,
+          thirdParty.address,
+          redeemerOutputScript
+        )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+
+      const wallet = await bridge.wallets(liveWalletPubKeyHash)
+      const tx = await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(liveReservationKey, walletMembersIDs)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionTimedOut")
+        .withArgs(liveReservationKey, liveWalletPubKeyHash)
+      expect(walletRegistry.seize).to.have.been.calledOnceWith(
+        redemptionTimeoutSlashingAmount,
+        redemptionTimeoutNotifierRewardMultiplier,
+        await thirdParty.getAddress(),
+        wallet.ecdsaWalletID,
+        walletMembersIDs
+      )
+
+      walletRegistry.seize.reset()
+    })
+
+    it("should revert when the redeemer output script points to the wallet public key hash", async () => {
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      const bridgeSigner = await impersonateContract(bridge.address)
+
+      const guardKey = 890
+      await bridge.setReservation(
+        guardKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+
+      // Wallet public key hash hidden under P2WPKH.
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            guardKey,
+            thirdParty.address,
+            `0x160014${walletPubKeyHash.substring(2)}`
+          )
+      ).to.be.revertedWith(
+        "Redeemer output script must not point to the wallet PKH"
+      )
+
+      // Wallet public key hash hidden under P2PKH.
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            guardKey,
+            thirdParty.address,
+            `0x1976a914${walletPubKeyHash.substring(2)}88ac`
+          )
+      ).to.be.revertedWith(
+        "Redeemer output script must not point to the wallet PKH"
+      )
+    })
+
+    it("should revert when the redeemer output script is not a standard type", async () => {
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      const bridgeSigner = await impersonateContract(bridge.address)
+
+      const guardKey = 891
+      await bridge.setReservation(
+        guardKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            guardKey,
+            thirdParty.address,
+            "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
+          )
+      ).to.be.revertedWith("Redeemer output script must be a standard type")
     })
   })
 
@@ -784,6 +1002,54 @@ describe("Bridge - Reservation", () => {
           grossTbtc.sub(expectedFee)
         )
         expect(await tbtc.balanceOf(treasury.address)).to.equal(expectedFee)
+      })
+
+      it("should revert when no depositors are specified", async () => {
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await expect(
+          bank
+            .connect(bridgeSigner)
+            .increaseBalanceAndCall(reservationVault.address, [], [])
+        ).to.be.revertedWith("No depositors specified")
+      })
+
+      it("should mint gross TBTC and split the initiation fee across multiple depositors", async () => {
+        const bridgeSigner = await impersonateContract(bridge.address)
+        const secondDepositor = governance.address
+        const firstAmount = amountSat
+        const secondAmount = amountSat.mul(3)
+
+        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+        const firstBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+        const secondBalanceBefore = await tbtc.balanceOf(secondDepositor)
+
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address, secondDepositor],
+            [firstAmount, secondAmount]
+          )
+
+        const firstFee = firstAmount.mul(SATOSHI_MULTIPLIER).mul(40).div(10000)
+        const secondFee = secondAmount
+          .mul(SATOSHI_MULTIPLIER)
+          .mul(40)
+          .div(10000)
+
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          firstBalanceBefore.add(
+            firstAmount.mul(SATOSHI_MULTIPLIER).sub(firstFee)
+          )
+        )
+        expect(await tbtc.balanceOf(secondDepositor)).to.equal(
+          secondBalanceBefore.add(
+            secondAmount.mul(SATOSHI_MULTIPLIER).sub(secondFee)
+          )
+        )
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore.add(firstFee).add(secondFee)
+        )
       })
     })
 
@@ -924,6 +1190,85 @@ describe("Bridge - Reservation", () => {
         await reservationVault.connect(deployer).updateFees(40, 20, 20)
       })
     })
+
+    describe("extendCustody", () => {
+      const reservationKey = 997
+      const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+
+      before(async () => {
+        await bridge.setReservation(
+          reservationKey,
+          await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            amountSat
+          )
+        )
+
+        // Fund the owner with TBTC for the extension fee via an
+        // acceptance-sized credit.
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address],
+            [amountSat]
+          )
+        await tbtc
+          .connect(thirdParty)
+          .approve(reservationVault.address, ethers.constants.MaxUint256)
+      })
+
+      it("should revert when the fee exceeds the caller's bound", async () => {
+        const fee = grossTbtc.mul(20).div(10000)
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .extendCustody(reservationKey, fee.sub(1))
+        ).to.be.revertedWith("Fee exceeds the caller's bound")
+      })
+
+      it("should transfer the extension fee to the treasury and advance expiresAt through the real vault path", async () => {
+        const fee = grossTbtc.mul(20).div(10000) // 20 bps extensionFeeBps
+        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+        const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+        const expiresAtBefore = (await bridge.reservations(reservationKey))
+          .expiresAt
+
+        const tx = await reservationVault
+          .connect(thirdParty)
+          .extendCustody(reservationKey, fee)
+
+        await expect(tx)
+          .to.emit(reservationVault, "CustodyExtended")
+          .withArgs(reservationKey, thirdParty.address, fee)
+
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore.add(fee)
+        )
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          ownerBalanceBefore.sub(fee)
+        )
+        expect((await bridge.reservations(reservationKey)).expiresAt).to.equal(
+          expiresAtBefore + RESERVATION_TERM
+        )
+      })
+    })
+
+    describe("updateFees", () => {
+      it("should revert when a fee parameter exceeds the maximum", async () => {
+        await expect(
+          reservationVault.connect(deployer).updateFees(501, 20, 20)
+        ).to.be.revertedWith("Fee exceeds the maximum")
+        await expect(
+          reservationVault.connect(deployer).updateFees(40, 501, 20)
+        ).to.be.revertedWith("Fee exceeds the maximum")
+        await expect(
+          reservationVault.connect(deployer).updateFees(40, 20, 501)
+        ).to.be.revertedWith("Fee exceeds the maximum")
+      })
+    })
   })
 
   describe("notifyReservedRedemptionVeto", () => {
@@ -1024,10 +1369,14 @@ describe("Bridge - Reservation", () => {
         state: walletState.Terminated,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
-      await bridge.setReservation(
-        reservationKey,
-        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
-      )
+      await bridge.setReservation(reservationKey, {
+        ...(await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          amountSat
+        )),
+        lastTimeoutWasWalletFault: true,
+      })
 
       // Simulate the state a redemption timeout leaves the owner in: the
       // gross amount refunded as Bank balance. The fee is paid in TBTC,
@@ -1067,6 +1416,34 @@ describe("Bridge - Reservation", () => {
         treasuryBalanceBefore
       )
     })
+
+    it("reverts when the previous request did not time out through wallet fault", async () => {
+      const otherReservationKey = 445
+      await bridge.setReservation(otherReservationKey, {
+        ...(await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          amountSat
+        )),
+        lastTimeoutWasWalletFault: false,
+      })
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(thirdParty.address, amountSat)
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, amountSat)
+
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservation(otherReservationKey, redeemerOutputScript)
+      ).to.be.revertedWith(
+        "Previous request did not time out through wallet fault"
+      )
+    })
   })
 
   describe("governance-delayed reservation parameters update", () => {
@@ -1085,10 +1462,12 @@ describe("Bridge - Reservation", () => {
           reservationVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       const beginReceipt = await beginTx.wait()
@@ -1102,10 +1481,12 @@ describe("Bridge - Reservation", () => {
           reservationVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE,
           beginBlock.timestamp
         )
 
@@ -1131,10 +1512,12 @@ describe("Bridge - Reservation", () => {
         .withArgs(
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
     })
   })
@@ -1224,6 +1607,14 @@ describe("Bridge - Reservation", () => {
     })
 
     it("vetoes a reserved redemption after three guardian objections", async () => {
+      const { redemptionRequestedAt } = await bridge.reservations(
+        reservationKey
+      )
+      const vetoKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint32"],
+        [reservationKey, redemptionRequestedAt]
+      )
+
       await redemptionWatchtower
         .connect(guardianSigners[0])
         .raiseReservedObjection(reservationKey)
@@ -1237,7 +1628,7 @@ describe("Bridge - Reservation", () => {
 
       await expect(tx)
         .to.emit(redemptionWatchtower, "VetoFinalized")
-        .withArgs(reservationKey)
+        .withArgs(vetoKey)
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionVetoed")
         .withArgs(reservationKey)
@@ -1249,7 +1640,7 @@ describe("Bridge - Reservation", () => {
       expect((await bridge.reservations(reservationKey)).state).to.equal(1)
 
       // Default penalty is 100%: the whole detained amount is burned.
-      const veto = await redemptionWatchtower.vetoProposals(reservationKey)
+      const veto = await redemptionWatchtower.vetoProposals(vetoKey)
       expect(veto.withdrawableAmount).to.equal(0)
       expect(await bank.balanceOf(redemptionWatchtower.address)).to.equal(0)
 
@@ -1265,6 +1656,151 @@ describe("Bridge - Reservation", () => {
             redeemerOutputScript
           )
       ).to.be.revertedWith("Redemption request rejected by the watchtower")
+    })
+
+    it("should revert when the reserved redemption does not exist", async () => {
+      const freshKey = 667
+      await bridge.setReservation(
+        freshKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      ).to.be.revertedWith("Reserved redemption does not exist")
+    })
+
+    it("should revert when a guardian already objected", async () => {
+      const freshKey = 668
+      // thirdParty was banned by the earlier veto test above; use a
+      // different, unbanned owner/redeemer for this reservation.
+      await bridge.setReservation(
+        freshKey,
+        await activeReservation(governance.address, walletPubKeyHash, amountSat)
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          freshKey,
+          governance.address,
+          redeemerOutputScript
+        )
+
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(freshKey)
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      ).to.be.revertedWith("Guardian already objected")
+    })
+
+    it("should emit VetoPeriodCheckOmitted for a redemption requested before the watchtower was enabled", async () => {
+      const freshKey = 669
+      const grandfatheredRequestedAt = 1 // long before watchtowerEnabledAt
+
+      await bridge.setReservation(freshKey, {
+        ...(await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          amountSat
+        )),
+        state: 2, // RedemptionRequested
+        redeemer: thirdParty.address,
+        redeemerOutputScriptHash: ethers.utils.keccak256(redeemerOutputScript),
+        redemptionRequestedAt: grandfatheredRequestedAt,
+        redemptionTxMaxFee: RESERVATION_TX_MAX_FEE,
+      })
+
+      const vetoKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint32"],
+        [freshKey, grandfatheredRequestedAt]
+      )
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      )
+        .to.emit(redemptionWatchtower, "VetoPeriodCheckOmitted")
+        .withArgs(vetoKey)
+    })
+
+    it("lets a new request generation start clean after an earlier generation is resolved", async () => {
+      const freshKey = 670
+      const owner = governance.address
+
+      await bridge.setReservation(
+        freshKey,
+        await activeReservation(owner, walletPubKeyHash, amountSat)
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(freshKey, owner, redeemerOutputScript)
+
+      // First generation: one guardian objects, below the 3-objection
+      // veto threshold, then the request times out without being
+      // vetoed.
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(freshKey)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(freshKey, [])
+
+      expect((await bridge.reservations(freshKey)).state).to.equal(1) // Active
+
+      // Second generation: re-request. The guardian who objected against
+      // generation 1 must be able to object again, and the new
+      // generation must start with zero objections -- a stale
+      // `objectionsCount` from the resolved generation 1 must not carry
+      // over and bias or block generation 2.
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(freshKey, owner, redeemerOutputScript)
+
+      const { redemptionRequestedAt } = await bridge.reservations(freshKey)
+      const secondGenVetoKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint32"],
+        [freshKey, redemptionRequestedAt]
+      )
+      expect(
+        (await redemptionWatchtower.vetoProposals(secondGenVetoKey))
+          .objectionsCount
+      ).to.equal(0)
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      )
+        .to.emit(redemptionWatchtower, "ObjectionRaised")
+        .withArgs(secondGenVetoKey, guardianSigners[0].address)
     })
   })
 
@@ -1466,6 +2002,51 @@ describe("Bridge - Reservation", () => {
           redemptionTxFee: 1500,
         })
       ).to.be.revertedWith("Reservation custodied by different wallet")
+    })
+
+    it("enforces the dissolution-specific fee cap, not the reservation tx max fee", async () => {
+      // Regression test: validateReservationDissolutionProposal must check
+      // proposal.dissolutionTxFee against reservationDissolutionTxMaxFee,
+      // not reservationTxMaxFee. Configure the two caps to differ so a fee
+      // that would pass the wrong cap is caught by the right one.
+      const reservationKey = 54321
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      await bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        500, // reservationDissolutionTxMaxFee, deliberately below RESERVATION_TX_MAX_FEE
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        MAX_CUMULATIVE_REANCHOR_FEE
+      )
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      // Within RESERVATION_TX_MAX_FEE (2000) but above the dissolution cap
+      // (500): must revert if the fee is checked against the right cap.
+      await expect(
+        validator.validateReservationDissolutionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          dissolutionTxFee: 1000,
+        })
+      ).to.be.revertedWith("Proposed transaction fee is too high")
+
+      // Exactly at the dissolution cap: must be accepted.
+      expect(
+        await validator.validateReservationDissolutionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          dissolutionTxFee: 500,
+        })
+      ).to.be.true
     })
   })
 
@@ -1686,10 +2267,12 @@ describe("Bridge - Reservation", () => {
           tbtcVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       const anchorTx = buildTx(
@@ -1710,10 +2293,166 @@ describe("Bridge - Reservation", () => {
       ).to.be.revertedWith("Deposit was not revealed as reserved")
     })
 
+    it("accepts a pre-swap reserved deposit after the vault changes, crediting the current vault", async () => {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+
+      // Revealed while `reservationVault` is still the reservation vault:
+      // classified as reserved at reveal time.
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+
+      const reservationKey = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.txHash, 0]
+      )
+      expect(await bridge.isReservedDeposit(reservationKey)).to.be.true
+
+      // Governance repurposes the reservation vault before the anchor is
+      // proven. The reveal-time classification survives unchanged.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          tbtcVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+      expect(await bridge.isReservedDeposit(reservationKey)).to.be.true
+
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+
+      const supplyBefore = await tbtc.totalSupply()
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          0
+        )
+
+      // Accepted despite the vault swap: the reservation record exists,
+      // which only the reservation path (not an ordinary sweep) creates.
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      // The credit routed through the *current* vault (`tbtcVault`, a
+      // 1:1 ordinary mint with no reservation-vault initiation fee
+      // split), not the vault configured at reveal time.
+      expect(await tbtc.totalSupply()).to.equal(
+        supplyBefore.add(anchorAmount.mul(SATOSHI_MULTIPLIER))
+      )
+      expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+        anchorAmount.mul(SATOSHI_MULTIPLIER)
+      )
+    })
+
     it("rejects an anchor paying an excessive miner fee", async () => {
       await expect(
         makeAcceptedReservation(depositAmount.sub(RESERVATION_TX_MAX_FEE + 1))
       ).to.be.revertedWith("Transaction fee is too high")
+    })
+
+    it("rejects an acceptance proof when reservations are disabled", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          ZERO_ADDRESS,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await expect(makeAcceptedReservation()).to.be.revertedWith(
+        "Reservations are disabled"
+      )
+    })
+
+    it("rejects an anchor below the reservation minimum amount", async () => {
+      await expect(
+        makeAcceptedReservation(BigNumber.from(RESERVATION_MIN_AMOUNT - 1))
+      ).to.be.revertedWith("Reservation amount too small")
+    })
+
+    it("rejects an acceptance that would exceed the total reserved amount cap", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          anchorAmount.sub(1),
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await expect(makeAcceptedReservation()).to.be.revertedWith(
+        "Total reserved amount cap exceeded"
+      )
+    })
+
+    it("rejects an acceptance that would exceed the per-wallet reservations cap", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          1,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await makeAcceptedReservation()
+      await expect(makeAcceptedReservation()).to.be.revertedWith(
+        "Wallet reservations cap exceeded"
+      )
     })
 
     it("completes an in-kind reserved redemption", async () => {
@@ -1768,6 +2507,280 @@ describe("Bridge - Reservation", () => {
       expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(grossTbtc))
     })
 
+    it("acknowledges a late redemption proof for a reservation that already timed out", async () => {
+      // The wallet may have already broadcast the redemption transaction
+      // before the redeemer noticed the timeout. Once
+      // `notifyReservedRedemptionTimeout` records the terminal settlement
+      // and refunds the redeemer, the SPV proof for that exact anchor
+      // spend must still be acknowledgeable -- and must not move any
+      // further balance or allow the outpoint to be reused.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+
+      const redeemerBalanceBeforeTimeout = await bank.balanceOf(
+        thirdParty.address
+      )
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [1, 2, 3, 4, 5])
+      walletRegistry.seize.reset()
+
+      // The gross amount was refunded as Bank balance on timeout.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        redeemerBalanceBeforeTimeout.add(anchorAmount)
+      )
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const bankBalanceBeforeProof = await bank.balanceOf(thirdParty.address)
+      const supplyBeforeProof = await tbtc.totalSupply()
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionSettled")
+        .withArgs(reservationKey, redemptionTx.txHash)
+
+      // No further balance movement: the redeemer was already made whole
+      // by the timeout refund above, and the reservation stays Active.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        bankBalanceBeforeProof
+      )
+      expect(await tbtc.totalSupply()).to.equal(supplyBeforeProof)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+
+      // The settlement record is consumed and the reservation is now
+      // Closed: a repeat submission of the same proof cannot reuse the
+      // anchor outpoint.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("No settled reserved redemption")
+    })
+
+    it("rejects a late redemption proof pointing at the wrong settled outpoint", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [1, 2, 3, 4, 5])
+      walletRegistry.seize.reset()
+
+      // A proof whose input spends a different outpoint than the one
+      // recorded in the settlement must not be acknowledged.
+      const wrongOutpointTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            wrongOutpointTx.info,
+            proofFor(wrongOutpointTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Wrong settled anchor outpoint")
+    })
+
+    it("rejects a late redemption proof once the reservation has been re-anchored since settlement", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+      await liveWallet(secondWalletPubKeyHash)
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [1, 2, 3, 4, 5])
+      walletRegistry.seize.reset()
+
+      // The reservation returns to Active on timeout and is legitimately
+      // re-anchored to a fresh outpoint before the settled anchor's late
+      // proof ever arrives.
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(anchorFee),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      // A late proof against the now-superseded settled anchor must not
+      // be able to force-close a reservation that has since moved on to
+      // a live, unsettled anchor.
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith(
+        "Reservation anchor no longer matches the settlement"
+      )
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+      expect((await bridge.reservations(reservationKey)).anchorTxHash).to.equal(
+        reanchorTx.txHash
+      )
+    })
+
+    it("acknowledges a late redemption proof for a reservation that was vetoed", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      // Treat `deployer` as the redemption watchtower, mirroring the
+      // dedicated `notifyReservedRedemptionVeto` unit tests.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(deployer.address)
+      await bridge
+        .connect(deployer)
+        .notifyReservedRedemptionVeto(reservationKey)
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const supplyBeforeProof = await tbtc.totalSupply()
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionSettled")
+        .withArgs(reservationKey, redemptionTx.txHash)
+
+      expect(await tbtc.totalSupply()).to.equal(supplyBeforeProof)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+    })
+
     it("keeps redemption provable when txMaxFee exceeds the anchor (underflow guard)", async () => {
       // Regression: redemptionTxMaxFee is a governable parameter, not a
       // tx-derived value, so a governance increase can push it above an
@@ -1785,10 +2798,12 @@ describe("Bridge - Reservation", () => {
           reservationVault.address,
           anchorAmount.add(2),
           anchorAmount.add(1),
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       const redeemerScript = `0x16${p2wpkhScript(
@@ -1908,6 +2923,223 @@ describe("Bridge - Reservation", () => {
         )
     })
 
+    it("rejects a re-anchor paying an excessive fee", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(RESERVATION_TX_MAX_FEE + 1),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Transaction fee is too high")
+    })
+
+    it("rejects a re-anchor landing at or below the dust floor", async () => {
+      // Lower the governance parameters so a single hop can carry an
+      // above-minimum anchor down to at-or-below the dust floor while
+      // staying within the per-transaction fee bound (minAmount must
+      // stay above txMaxFee by construction, so minAmount <= 2*txMaxFee
+      // is required to reach the floor in one hop). Build a small custom
+      // deposit/anchor pair instead of `makeAcceptedReservation`, whose
+      // fixed deposit size would blow the lowered fee bound.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          150,
+          100,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+      await bridge.setDepositDustThreshold(50)
+
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: 200, // 150 anchor + 50 acceptance-time fee
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: 150, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          0
+        )
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      await liveWallet(secondWalletPubKeyHash)
+
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [{ valueSat: 100, script: p2wpkhScript(secondWalletPubKeyHash) }]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Re-anchor amount below the dust floor")
+    })
+
+    it("rejects a re-anchor once the cumulative fee budget is exceeded", async () => {
+      // Lower the cumulative budget so two ordinary-fee re-anchor hops
+      // exceed it on the second hop.
+      await bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_DISSOLUTION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        anchorFee // budget == exactly one hop's fee
+      )
+
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      const firstHop = anchorAmount.sub(anchorFee)
+      const reanchorTx1 = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: firstHop,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      const tx1 = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx1.info,
+          proofFor(reanchorTx1.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+      await expect(tx1).to.emit(bridge, "ReservationReanchored")
+      expect(
+        (await bridge.reservations(reservationKey)).cumulativeReanchorFee
+      ).to.equal(anchorFee)
+
+      // Second hop: any positive fee now exceeds the exhausted budget.
+      const reanchorTx2 = buildTx(
+        [{ txHash: reanchorTx1.txHash, index: 0 }],
+        [
+          {
+            valueSat: firstHop.sub(1),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx2.info,
+            proofFor(reanchorTx2.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Cumulative re-anchor fee budget exceeded")
+    })
+
+    it("rejects a dissolution output that does not pay the custodying wallet", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            // Pays a different wallet than the custodying one.
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith(
+        "Dissolution output must pay to the custodying wallet"
+      )
+    })
+
     it("dissolves an expired reservation into the wallet main UTXO", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
 
@@ -1959,6 +3191,460 @@ describe("Bridge - Reservation", () => {
           [dissolutionTx.txHash, 0, anchorAmount.sub(dissolutionFee)]
         )
       )
+    })
+
+    it("dissolves a re-anchored reservation without burning unrelated Bank balance", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      // Re-anchor once, incurring a miner fee: `anchorAmount` shrinks
+      // below `mintedAmount`.
+      const reanchoredAmount = anchorAmount.sub(anchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: reanchoredAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      const reservationBefore = await bridge.reservations(reservationKey)
+      expect(reservationBefore.mintedAmount).to.equal(anchorAmount)
+      expect(reservationBefore.anchorAmount).to.equal(reanchoredAmount)
+
+      // A second, unrelated reservation's escrow, held by the Bridge as
+      // an ordinary Bank balance, must survive dissolution untouched --
+      // mirroring the balance shape the Bridge actually holds while a
+      // pooled or reserved redemption is in flight.
+      const unrelatedBalance = BigNumber.from(500000)
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(bridge.address, unrelatedBalance)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const dissolutionFee = 200
+      const dissolutionTx = buildTx(
+        [{ txHash: reanchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: reanchoredAmount.sub(dissolutionFee),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx).to.emit(bridge, "ReservationDissolved")
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+
+      // No Bank balance was burned: the unrelated escrow survives
+      // untouched.
+      expect(await bank.balanceOf(bridge.address)).to.equal(unrelatedBalance)
+
+      // The dissolution output carries forward exactly the shrunk
+      // `anchorAmount`, not the original gross `mintedAmount`.
+      const wallet = await bridge.wallets(secondWalletPubKeyHash)
+      expect(wallet.mainUtxoHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [dissolutionTx.txHash, 0, reanchoredAmount.sub(dissolutionFee)]
+        )
+      )
+    })
+
+    it("dissolves into an existing main UTXO and reports the fee-loss decomposition", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      // Re-anchor once so `anchorAmount` falls below `mintedAmount`: that
+      // gap is the in-kind loss the event has to report.
+      const reanchorFee = 800
+      const reanchoredAmount = anchorAmount.sub(reanchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: reanchoredAmount,
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      // Give the custodying wallet a main UTXO so the dissolution takes
+      // the dominant 2-in-1-out shape. Every other test in this suite
+      // dissolves 1-in-1-out, where the anchor value and the combined
+      // input total coincide and cannot be told apart.
+      const mainUtxoTxHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+      const mainUtxoValue = BigNumber.from(1000000)
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [mainUtxoTxHash, 0, mainUtxoValue]
+        ),
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const dissolutionFee = 600
+      const dissolutionTx = buildTx(
+        [
+          { txHash: reanchorTx.txHash, index: 0 },
+          { txHash: mainUtxoTxHash, index: 0 },
+        ],
+        [
+          {
+            valueSat: reanchoredAmount.add(mainUtxoValue).sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      const tx = await bridge.connect(spvMaintainer).submitReservationProof(
+        ProofType.Dissolution,
+        dissolutionTx.info,
+        proofFor(dissolutionTx.txHash),
+        {
+          txHash: mainUtxoTxHash,
+          txOutputIndex: 0,
+          txOutputValue: mainUtxoValue,
+        },
+        reservationKey
+      )
+
+      // The event must report the anchor's own value, not the combined
+      // input total: the unreconciled shortfall is
+      // `mintedAmount - anchorAmount + dissolutionFee`, here
+      // `reanchorFee + dissolutionFee`.
+      await expect(tx)
+        .to.emit(bridge, "ReservationDissolved")
+        .withArgs(
+          reservationKey,
+          walletPubKeyHash,
+          dissolutionTx.txHash,
+          anchorAmount,
+          reanchoredAmount,
+          dissolutionFee
+        )
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+
+      // The single output became the wallet's new main UTXO.
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.mainUtxoHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [
+            dissolutionTx.txHash,
+            0,
+            reanchoredAmount.add(mainUtxoValue).sub(dissolutionFee),
+          ]
+        )
+      )
+    })
+
+    it("leaves residual backing independent of claim size after maximal grinding", async () => {
+      // Characterization of the accepted underbacking risk (follow-up item 7
+      // in the reservation review notes). It pins the *shape* of the risk so
+      // any later change to the dust floor, the dissolution cap, the
+      // cumulative budget, or the `mintedAmount` accounting has to restate it
+      // rather than move it silently.
+      //
+      // The finding: the dust floor is absolute (`> reservationTxMaxFee`),
+      // so the satoshi left backing a fully-ground reservation is the
+      // constant `reservationTxMaxFee + 1 - reservationDissolutionTxMaxFee`
+      // no matter how large the claim was. Fractional underbacking therefore
+      // grows with position size, and peaks where the cumulative budget and
+      // the dust floor bind at the same time -- NOT on a minimum-sized
+      // reservation, which is the intuitive but wrong guess.
+      //
+      // The parameters below are scaled down from the suite fixture purely to
+      // keep the grind to a handful of hops: reaching the floor under the
+      // fixture's 2000/100000 pair would take 50 re-anchor proofs. The
+      // invariant is parameter-independent, so the scaled regime tests the
+      // same mechanism -- but note this test does NOT measure the fixture's
+      // own worst case, which is arithmetic from the invariant, not a
+      // measured result.
+      const txMaxFee = 100
+      const dissolutionCap = 60
+      const cumulativeCap = 400
+      const minAmount = 150
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          minAmount,
+          txMaxFee,
+          dissolutionCap,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          cumulativeCap
+        )
+      await bridge.setDepositDustThreshold(50)
+
+      const floor = txMaxFee + 1
+      // Residual backing is claim-independent, hence a single constant.
+      const residualBacking = floor - dissolutionCap
+
+      // Reveals and accepts a reservation of exactly `claim` satoshi, paying
+      // a 1-satoshi acceptance fee so the deposit stays within `txMaxFee`.
+      async function acceptClaim(claim: number) {
+        const fundingTx = buildTx(
+          [
+            {
+              txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+              index: 0,
+            },
+          ],
+          [
+            {
+              valueSat: claim + 1,
+              script: p2wshScript(
+                buildDepositScript(
+                  thirdParty.address,
+                  blindingFactor,
+                  walletPubKeyHash,
+                  refundPubKeyHash,
+                  refundLocktime
+                )
+              ),
+            },
+          ]
+        )
+        await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+          fundingOutputIndex: 0,
+          blindingFactor,
+          walletPubKeyHash,
+          refundPubKeyHash,
+          refundLocktime,
+          vault: reservationVault.address,
+        })
+        const anchorTx = buildTx(
+          [{ txHash: fundingTx.txHash, index: 0 }],
+          [{ valueSat: claim, script: p2wpkhScript(walletPubKeyHash) }]
+        )
+        const acceptTx = await bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            0
+          )
+        const receipt = await acceptTx.wait()
+        const accepted = receipt.events.find(
+          (e) => e.event === "ReservationAccepted"
+        )
+        return { anchorTx, reservationKey: accepted.args.reservationKey }
+      }
+
+      // Grinds the anchor down to the dust floor in maximum-fee hops.
+      async function grindToFloor(
+        startTx: { txHash: string },
+        startValue: number,
+        reservationKey: BigNumber
+      ) {
+        let prevTx = startTx
+        let value = startValue
+        while (value > floor) {
+          const next = Math.max(floor, value - txMaxFee)
+          const hop = buildTx(
+            [{ txHash: prevTx.txHash, index: 0 }],
+            [{ valueSat: next, script: p2wpkhScript(walletPubKeyHash) }]
+          )
+          // Sequential on purpose: each hop spends the previous hop's output,
+          // so the proofs cannot be submitted concurrently.
+          // eslint-disable-next-line no-await-in-loop
+          await bridge
+            .connect(spvMaintainer)
+            .submitReservationProof(
+              ProofType.Reanchor,
+              hop.info,
+              proofFor(hop.txHash),
+              NO_MAIN_UTXO_PARAM,
+              reservationKey
+            )
+          prevTx = hop
+          value = next
+        }
+        return prevTx
+      }
+
+      // Dissolves 1-in-1-out at the maximum permitted fee and returns the
+      // decomposition the event reports.
+      async function dissolveAtMaxFee(
+        anchorTxToSpend: { txHash: string },
+        reservationKey: BigNumber
+      ) {
+        const dissolutionTx = buildTx(
+          [{ txHash: anchorTxToSpend.txHash, index: 0 }],
+          [
+            {
+              valueSat: residualBacking,
+              script: p2wpkhScript(walletPubKeyHash),
+            },
+          ]
+        )
+        const tx = await bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+        const receipt = await tx.wait()
+        const dissolved = receipt.events.find(
+          (e) => e.event === "ReservationDissolved"
+        )
+        return dissolved.args
+      }
+
+      // Case A: a minimum-sized reservation. One hop reaches the floor, so
+      // the cumulative budget never binds.
+      const small = await acceptClaim(minAmount)
+      const smallFinal = await grindToFloor(
+        small.anchorTx,
+        minAmount,
+        small.reservationKey
+      )
+
+      // Case B: the peak-loss position -- sized so grinding to the floor
+      // consumes the cumulative budget EXACTLY. Any larger claim is better
+      // off proportionally, because the budget stops the grind early.
+      const peakClaim = cumulativeCap + floor
+      const peak = await acceptClaim(peakClaim)
+      const peakFinal = await grindToFloor(
+        peak.anchorTx,
+        peakClaim,
+        peak.reservationKey
+      )
+      expect(
+        (await bridge.reservations(peak.reservationKey)).cumulativeReanchorFee
+      ).to.equal(cumulativeCap)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const smallArgs = await dissolveAtMaxFee(smallFinal, small.reservationKey)
+
+      // The first dissolution's output became the wallet's new main UTXO,
+      // which would force the second into the 2-in-1-out shape. Clear it so
+      // both cases dissolve 1-in-1-out and only the claim size differs --
+      // the 2-in-1-out shape is covered by the decomposition test above.
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      const peakArgs = await dissolveAtMaxFee(peakFinal, peak.reservationKey)
+
+      // The claim differs by more than 3x; the backing left behind does not
+      // differ at all. That constant is the finding.
+      expect(smallArgs.mintedAmount).to.equal(minAmount)
+      expect(peakArgs.mintedAmount).to.equal(peakClaim)
+      expect(smallArgs.anchorAmount).to.equal(floor)
+      expect(peakArgs.anchorAmount).to.equal(floor)
+      expect(smallArgs.anchorAmount.sub(smallArgs.dissolutionFee)).to.equal(
+        residualBacking
+      )
+      expect(peakArgs.anchorAmount.sub(peakArgs.dissolutionFee)).to.equal(
+        residualBacking
+      )
+
+      // Fractional underbacking is therefore worse for the larger claim --
+      // the direction a reader would not predict, and the reason a bound
+      // relative to `reservationMinAmount` alone does not close this.
+      const smallLoss = minAmount - residualBacking
+      const peakLoss = peakClaim - residualBacking
+      expect(peakLoss / peakClaim).to.be.greaterThan(smallLoss / minAmount)
+    })
+
+    it("enforces the dissolution-specific fee cap on the proven transaction", async () => {
+      // Sanity: the two caps must differ or this test cannot discriminate
+      // which one the proof path checks against.
+      expect(RESERVATION_DISSOLUTION_TX_MAX_FEE).to.be.lessThan(
+        RESERVATION_TX_MAX_FEE
+      )
+
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      // Above `reservationDissolutionTxMaxFee` but still within the shared
+      // `reservationTxMaxFee`: this reverts only if the proven fee is
+      // checked against the dissolution-specific cap.
+      const dissolutionFee = RESERVATION_DISSOLUTION_TX_MAX_FEE + 1
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Transaction fee is too high")
     })
   })
 })

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -833,7 +833,7 @@ describe("Bridge - Reservation", () => {
     })
 
     it("stages the parameters and applies them after the governance delay", async () => {
-      await bridgeGovernance
+      const beginTx = await bridgeGovernance
         .connect(governance)
         .beginReservationParametersUpdate(
           reservationVault.address,
@@ -843,6 +843,24 @@ describe("Bridge - Reservation", () => {
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET
+        )
+
+      const beginReceipt = await beginTx.wait()
+      const beginBlock = await ethers.provider.getBlock(
+        beginReceipt.blockNumber
+      )
+
+      await expect(beginTx)
+        .to.emit(bridgeGovernance, "ReservationParametersUpdateStarted")
+        .withArgs(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          beginBlock.timestamp
         )
 
       await expect(

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -654,9 +654,8 @@ describe("Bridge - Reservation", () => {
         ).to.be.revertedWith("Caller is not the reservation owner")
       })
 
-      it("should surrender gross TBTC and register the redemption", async () => {
-        // Redemption is free by default; the exit leg is exit-neutral.
-        const fee = BigNumber.from(0)
+      it("should surrender gross TBTC, charge the redemption fee, and register the redemption", async () => {
+        const fee = grossTbtc.mul(20).div(10000)
         const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
 
         await tbtc
@@ -804,12 +803,11 @@ describe("Bridge - Reservation", () => {
       await restoreSnapshot()
     })
 
-    it("retries the redemption from Bank balance", async () => {
-      const fee = BigNumber.from(0)
+    it("retries the redemption from Bank balance without re-charging the fee", async () => {
       await bank
         .connect(thirdParty)
         .approveBalance(reservationVault.address, amountSat)
-      await tbtc.connect(thirdParty).approve(reservationVault.address, fee)
+      const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
 
       const tx = await reservationVault
         .connect(thirdParty)
@@ -818,6 +816,10 @@ describe("Bridge - Reservation", () => {
       await expect(tx).to.emit(bridge, "ReservedRedemptionRequested")
       expect((await bridge.reservations(reservationKey)).state).to.equal(2) // RedemptionRequested
       expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
+      // The redemption fee is not re-charged on retry.
+      expect(await tbtc.balanceOf(treasury.address)).to.equal(
+        treasuryBalanceBefore
+      )
     })
   })
 
@@ -1400,7 +1402,7 @@ describe("Bridge - Reservation", () => {
       // balance held by the Bridge.
       const supplyBefore = await tbtc.totalSupply()
 
-      const redemptionFee = BigNumber.from(0)
+      const redemptionFee = grossTbtc.mul(20).div(10000)
       await tbtc
         .connect(thirdParty)
         .approve(reservationVault.address, grossTbtc.add(redemptionFee))

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1439,6 +1439,137 @@ describe("Bridge - Reservation", () => {
       expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(grossTbtc))
     })
 
+    it("keeps redemption provable when txMaxFee exceeds the anchor (underflow guard)", async () => {
+      // Regression: redemptionTxMaxFee is a governable parameter, not a
+      // tx-derived value, so a governance increase can push it above an
+      // existing anchorAmount. The redemption range check must not underflow
+      // in that case. Fund the owner with two acceptances, then raise the
+      // fee/min parameters above the anchor and prove an in-kind redemption.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      // Raise the reservation tx max fee above the anchor amount (and the
+      // minimum above the fee, preserving the invariant).
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          anchorAmount.add(2),
+          anchorAmount.add(1),
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET
+        )
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript)
+
+      // Pay the full anchor value out (zero miner fee). The old lower bound
+      // `anchorAmount - redemptionTxMaxFee` would revert on underflow here.
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: redeemerScript.slice(4) }]
+      )
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, redemptionTx.txHash)
+    })
+
+    it("rejects a re-anchor that drops below the reservation minimum", async () => {
+      // Accept a reservation whose anchor sits at the reservation minimum,
+      // so a single fee-capped hop can push it below the floor.
+      const minAmount = BigNumber.from(RESERVATION_MIN_AMOUNT)
+      const depositAmt = minAmount.add(RESERVATION_TX_MAX_FEE)
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmt,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: minAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          0
+        )
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      await liveWallet(secondWalletPubKeyHash)
+
+      // Fee of 1 sat keeps the hop within the per-hop cap, but the resulting
+      // anchor (min - 1) sits below the reservation minimum.
+      const belowMin = minAmount.sub(1)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [{ valueSat: belowMin, script: p2wpkhScript(secondWalletPubKeyHash) }]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Re-anchor amount below the reservation minimum")
+    })
+
     it("re-anchors a reservation to another Live wallet", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
       await liveWallet(secondWalletPubKeyHash)

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1,0 +1,562 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import { ethers, helpers, waffle } from "hardhat"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber, Contract } from "ethers"
+import chai, { expect } from "chai"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+import type {
+  Bank,
+  BankStub,
+  Bridge,
+  BridgeStub,
+  IRelay,
+  ReservationVault,
+  TBTCVault,
+  TBTC,
+} from "../../typechain"
+import bridgeFixture from "../fixtures/bridge"
+import { walletState } from "../fixtures"
+import { DepositSweepTestData, SingleP2WSHDeposit } from "../data/deposit-sweep"
+
+chai.use(smock.matchers)
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime, increaseTime } = helpers.time
+const { impersonateAccount } = helpers.account
+
+const ZERO_ADDRESS = ethers.constants.AddressZero
+const ZERO_BYTES32 = ethers.constants.HashZero
+
+const RESERVATION_TERM = 31536000 // 365 days
+const RESERVATION_GRACE = 2592000 // 30 days
+const RESERVATION_MIN_AMOUNT = 10000
+const RESERVATION_TX_MAX_FEE = 2000
+const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
+const MAX_RESERVATIONS_PER_WALLET = 10
+
+const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
+
+describe("Bridge - Reservation", () => {
+  let governance: SignerWithAddress
+  let spvMaintainer: SignerWithAddress
+  let thirdParty: SignerWithAddress
+  let treasury: SignerWithAddress
+  let deployer: SignerWithAddress
+
+  let bank: Bank & BankStub
+  let relay: FakeContract<IRelay>
+  let bridge: Bridge & BridgeStub
+  let tbtc: TBTC & Contract
+  let tbtcVault: TBTCVault & Contract
+  let reservationVault: ReservationVault
+  let bridgeGovernanceSigner: SignerWithAddress
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      deployer,
+      governance,
+      spvMaintainer,
+      thirdParty,
+      treasury,
+      bank,
+      relay,
+      bridge,
+      tbtc,
+      tbtcVault,
+    } = await waffle.loadFixture(bridgeFixture))
+
+    reservationVault = await helpers.contracts.getContract("ReservationVault")
+
+    // The Bridge is governed by the BridgeGovernance contract in the
+    // fixture; impersonate it to exercise onlyGovernance functions
+    // directly. Production wiring through BridgeGovernance is a follow-up.
+    bridgeGovernanceSigner = await impersonateContract(
+      await bridge.governance()
+    )
+  })
+
+  // Impersonates a contract address, funding it via hardhat_setBalance
+  // (the impersonateAccount helper funds with a plain transfer, which
+  // reverts for contracts without a receive function).
+  async function impersonateContract(
+    address: string
+  ): Promise<SignerWithAddress> {
+    await ethers.provider.send("hardhat_impersonateAccount", [address])
+    await ethers.provider.send("hardhat_setBalance", [
+      address,
+      "0x8AC7230489E80000", // 10 ETH
+    ])
+    return ethers.getSigner(address)
+  }
+
+  // Marks the reservation vault as trusted and wires it together with the
+  // reservation parameters into the Bridge.
+  async function wireReservations() {
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .setVaultStatus(reservationVault.address, true)
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET
+      )
+  }
+
+  // Builds an active reservation record owned by `owner`, custodied by the
+  // wallet identified by `walletPubKeyHash`.
+  async function activeReservation(
+    owner: string,
+    walletPubKeyHash: string,
+    amountSat: BigNumber
+  ) {
+    return {
+      owner,
+      mintedAmount: amountSat,
+      acceptedAt: await lastBlockTime(),
+      walletPubKeyHash,
+      anchorAmount: amountSat,
+      expiresAt: (await lastBlockTime()) + RESERVATION_TERM,
+      anchorTxHash: ethers.utils.randomBytes(32),
+      anchorTxOutputIndex: 0,
+      state: 1, // Active
+      redemptionRequestedAt: 0,
+      redemptionTxMaxFee: 0,
+      redeemer: ZERO_ADDRESS,
+      redeemerOutputScriptHash: ZERO_BYTES32,
+    }
+  }
+
+  describe("updateReservationParameters", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when called by a third party", () => {
+      it("should revert", async () => {
+        await expect(
+          bridge
+            .connect(thirdParty)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET
+            )
+        ).to.be.revertedWith("Caller is not the governance")
+      })
+    })
+
+    context("when called by the governance", () => {
+      it("should set the parameters and the reservation vault", async () => {
+        const tx = await bridge
+          .connect(bridgeGovernanceSigner)
+          .updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_TERM,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET
+          )
+
+        await expect(tx)
+          .to.emit(bridge, "ReservationVaultUpdated")
+          .withArgs(reservationVault.address)
+        await expect(tx)
+          .to.emit(bridge, "ReservationParametersUpdated")
+          .withArgs(
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_TERM,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET
+          )
+      })
+
+      it("should revert for a zero transaction max fee", async () => {
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              0,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET
+            )
+        ).to.be.revertedWith(
+          "Reservation transaction max fee must be greater than zero"
+        )
+      })
+
+      it("should revert when changing the vault with active reservations", async () => {
+        const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+        await bridge.setReservation(
+          12345,
+          await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            BigNumber.from(100000000)
+          )
+        )
+
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              thirdParty.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET
+            )
+        ).to.be.revertedWith("Active reservations exist")
+      })
+    })
+  })
+
+  describe("deposit sweep guard", () => {
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should refuse to sweep deposits routed to the reservation vault", async () => {
+      const data: DepositSweepTestData = JSON.parse(
+        JSON.stringify(SingleP2WSHDeposit)
+      )
+      // Route the revealed deposit and the sweep to the reservation vault.
+      data.deposits[0].reveal.vault = reservationVault.address
+      data.vault = reservationVault.address
+
+      relay.getCurrentEpochDifficulty.returns(data.chainDifficulty)
+      relay.getPrevEpochDifficulty.returns(data.chainDifficulty)
+
+      await bridge.setDepositDustThreshold(10000)
+      await bridge.setDepositTxMaxFee(2000)
+      await bridge.setDepositRevealAheadPeriod(0)
+
+      const { fundingTx, depositor, reveal } = data.deposits[0]
+      await bridge.setWallet(reveal.walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      const depositorSigner = await impersonateAccount(depositor, {
+        from: governance,
+        value: 10,
+      })
+      await bridge.connect(depositorSigner).revealDeposit(fundingTx, reveal)
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitDepositSweepProof(
+            data.sweepTx,
+            data.sweepProof,
+            data.mainUtxo,
+            data.vault
+          )
+      ).to.be.revertedWith("Reserved deposits must not be swept")
+    })
+  })
+
+  describe("extendReservation", () => {
+    const reservationKey = 777
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          BigNumber.from(100000000)
+        )
+      )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    context("when called by a third party", () => {
+      it("should revert", async () => {
+        await expect(
+          bridge.connect(thirdParty).extendReservation(reservationKey)
+        ).to.be.revertedWith("Caller is not the reservation vault")
+      })
+    })
+
+    context("when called by the reservation vault", () => {
+      it("should extend the reservation term", async () => {
+        const before_ = await bridge.reservations(reservationKey)
+
+        const vaultSigner = await impersonateContract(reservationVault.address)
+        const tx = await bridge
+          .connect(vaultSigner)
+          .extendReservation(reservationKey)
+
+        const after_ = await bridge.reservations(reservationKey)
+        expect(after_.expiresAt).to.equal(before_.expiresAt + RESERVATION_TERM)
+        await expect(tx)
+          .to.emit(bridge, "ReservationExtended")
+          .withArgs(reservationKey, after_.expiresAt)
+      })
+    })
+  })
+
+  describe("requestReservedRedemption", () => {
+    const reservationKey = 888
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const amountSat = BigNumber.from(100000000) // 1 BTC
+    // A valid P2WPKH redeemer output script.
+    const redeemerOutputScript =
+      "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      // A Terminated wallet lets the timeout path skip slashing and state
+      // transitions, isolating the reservation bookkeeping under test.
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      // Give the reservation vault the gross Bank balance it must
+      // surrender with the request.
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should revert when called by a third party", async () => {
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservedRedemption(
+            reservationKey,
+            thirdParty.address,
+            redeemerOutputScript
+          )
+      ).to.be.revertedWith("Caller is not the reservation vault")
+    })
+
+    it("should register the redemption, take the balance, and refund on timeout", async () => {
+      const vaultSigner = await impersonateContract(reservationVault.address)
+
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+
+      const tx = await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          reservationKey,
+          thirdParty.address,
+          redeemerOutputScript
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionRequested")
+        .withArgs(
+          reservationKey,
+          thirdParty.address,
+          redeemerOutputScript,
+          amountSat,
+          RESERVATION_TX_MAX_FEE
+        )
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(2) // RedemptionRequested
+      expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
+
+      // Re-requesting while one is pending must fail.
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            reservationKey,
+            thirdParty.address,
+            redeemerOutputScript
+          )
+      ).to.be.revertedWith("Reservation is not active")
+
+      // Timeout: the redeemer gets the balance back and the reservation
+      // survives as Active.
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+
+      const timeoutTx = await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [])
+
+      await expect(timeoutTx)
+        .to.emit(bridge, "ReservedRedemptionTimedOut")
+        .withArgs(reservationKey, walletPubKeyHash)
+
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(amountSat)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+    })
+  })
+
+  describe("ReservationVault", () => {
+    const amountSat = BigNumber.from(100000000) // 1 BTC
+    const grossTbtc = amountSat.mul(SATOSHI_MULTIPLIER)
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      // In the base fixture the TBTC token is still owned by the
+      // VendingMachine; hand it to the TBTC vault so minting works.
+      const tbtcOwner = await impersonateContract(await tbtc.owner())
+      await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    describe("receiveBalanceIncrease", () => {
+      it("should revert when not called by the Bank", async () => {
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .receiveBalanceIncrease([thirdParty.address], [amountSat])
+        ).to.be.revertedWith("Caller is not the Bank")
+      })
+
+      it("should mint gross TBTC and split the initiation fee", async () => {
+        const bridgeSigner = await impersonateContract(bridge.address)
+
+        // Simulates the acceptance-proof credit performed by the Bridge.
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address],
+            [amountSat]
+          )
+
+        // 40 bps initiation fee.
+        const expectedFee = grossTbtc.mul(40).div(10000)
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          grossTbtc.sub(expectedFee)
+        )
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(expectedFee)
+      })
+    })
+
+    describe("redeemReservation", () => {
+      const reservationKey = 999
+      const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+      const redeemerOutputScript =
+        "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+
+      before(async () => {
+        await bridge.setReservation(
+          reservationKey,
+          await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            amountSat
+          )
+        )
+
+        // Fund the owner with enough TBTC for the gross surrender plus the
+        // redemption fee by processing another acceptance-sized credit.
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address],
+            [amountSat.mul(2)]
+          )
+      })
+
+      it("should revert when called by a non-owner", async () => {
+        await expect(
+          reservationVault
+            .connect(governance)
+            .redeemReservation(reservationKey, redeemerOutputScript)
+        ).to.be.revertedWith("Caller is not the reservation owner")
+      })
+
+      it("should surrender gross TBTC, charge the fee, and register the redemption", async () => {
+        const fee = grossTbtc.mul(20).div(10000)
+        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+
+        await tbtc
+          .connect(thirdParty)
+          .approve(reservationVault.address, grossTbtc.add(fee))
+
+        const tx = await reservationVault
+          .connect(thirdParty)
+          .redeemReservation(reservationKey, redeemerOutputScript)
+
+        await expect(tx)
+          .to.emit(reservationVault, "ReservedRedemptionInitiated")
+          .withArgs(reservationKey, thirdParty.address, grossTbtc, fee)
+        await expect(tx).to.emit(bridge, "ReservedRedemptionRequested")
+
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore.add(fee)
+        )
+        expect((await bridge.reservations(reservationKey)).state).to.equal(2)
+        expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
+      })
+    })
+  })
+})

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -767,9 +767,9 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             reservationKey,
             thirdParty.address,
-            redeemerOutputScript
-          ,
-            false)
+            redeemerOutputScript,
+            false
+          )
       ).to.be.revertedWith("Caller is not the reservation vault")
     })
 
@@ -783,9 +783,9 @@ describe("Bridge - Reservation", () => {
         .requestReservedRedemption(
           reservationKey,
           thirdParty.address,
-          redeemerOutputScript
-        ,
-          false)
+          redeemerOutputScript,
+          false
+        )
 
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionRequested")
@@ -807,9 +807,9 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             reservationKey,
             thirdParty.address,
-            redeemerOutputScript
-          ,
-            false)
+            redeemerOutputScript,
+            false
+          )
       ).to.be.revertedWith("Reservation is not active")
 
       // The wallet dies (Terminated) while the redemption is in flight --
@@ -891,9 +891,9 @@ describe("Bridge - Reservation", () => {
         .requestReservedRedemption(
           liveReservationKey,
           thirdParty.address,
-          redeemerOutputScript
-        ,
-          false)
+          redeemerOutputScript,
+          false
+        )
 
       const { redemptionTimeout } = await bridge.redemptionParameters()
       await increaseTime(redemptionTimeout + 1)
@@ -952,9 +952,9 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             guardKey,
             thirdParty.address,
-            `0x160014${walletPubKeyHash.substring(2)}`
-          ,
-            false)
+            `0x160014${walletPubKeyHash.substring(2)}`,
+            false
+          )
       ).to.be.revertedWith(
         "Redeemer output script must not point to the wallet PKH"
       )
@@ -966,9 +966,9 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             guardKey,
             thirdParty.address,
-            `0x1976a914${walletPubKeyHash.substring(2)}88ac`
-          ,
-            false)
+            `0x1976a914${walletPubKeyHash.substring(2)}88ac`,
+            false
+          )
       ).to.be.revertedWith(
         "Redeemer output script must not point to the wallet PKH"
       )
@@ -1007,9 +1007,9 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             guardKey,
             thirdParty.address,
-            "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
-          ,
-            false)
+            "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac",
+            false
+          )
       ).to.be.revertedWith("Redeemer output script must be a standard type")
     })
   })
@@ -1378,9 +1378,9 @@ describe("Bridge - Reservation", () => {
         .requestReservedRedemption(
           reservationKey,
           thirdParty.address,
-          redeemerOutputScript
-        ,
-          false)
+          redeemerOutputScript,
+          false
+        )
 
       // Wire the watchtower only after the request so the
       // isSafeRedemption gate does not call an EOA.
@@ -1668,9 +1668,9 @@ describe("Bridge - Reservation", () => {
         .requestReservedRedemption(
           reservationKey,
           thirdParty.address,
-          redeemerOutputScript
-        ,
-          false)
+          redeemerOutputScript,
+          false
+        )
     })
 
     after(async () => {
@@ -1728,10 +1728,12 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             reservationKey,
             thirdParty.address,
-            redeemerOutputScript
-          ,
-            false)
-      ).to.be.revertedWith("Unresolved settlement exists for the current anchor")
+            redeemerOutputScript,
+            false
+          )
+      ).to.be.revertedWith(
+        "Unresolved settlement exists for the current anchor"
+      )
     })
 
     it("should revert when the reserved redemption does not exist", async () => {
@@ -1768,9 +1770,9 @@ describe("Bridge - Reservation", () => {
         .requestReservedRedemption(
           freshKey,
           governance.address,
-          redeemerOutputScript
-        ,
-          false)
+          redeemerOutputScript,
+          false
+        )
 
       await redemptionWatchtower
         .connect(guardianSigners[0])
@@ -1872,7 +1874,11 @@ describe("Bridge - Reservation", () => {
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
       await bridge.setReservation(freshKey, {
-        ...(await activeReservation(owner, secondGenWalletPubKeyHash, amountSat)),
+        ...(await activeReservation(
+          owner,
+          secondGenWalletPubKeyHash,
+          amountSat
+        )),
       })
 
       await bank
@@ -2081,9 +2087,9 @@ describe("Bridge - Reservation", () => {
         .requestReservedRedemption(
           reservationKey,
           thirdParty.address,
-          "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
-        ,
-          false)
+          "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef",
+          false
+        )
 
       await increaseTime(601)
 

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -9,6 +9,7 @@ import type {
   Bank,
   BankStub,
   Bridge,
+  BridgeGovernance,
   BridgeStub,
   IRelay,
   ReservationVault,
@@ -49,6 +50,7 @@ describe("Bridge - Reservation", () => {
   let bridge: Bridge & BridgeStub
   let tbtc: TBTC & Contract
   let tbtcVault: TBTCVault & Contract
+  let bridgeGovernance: BridgeGovernance
   let reservationVault: ReservationVault
   let bridgeGovernanceSigner: SignerWithAddress
 
@@ -63,6 +65,7 @@ describe("Bridge - Reservation", () => {
       bank,
       relay,
       bridge,
+      bridgeGovernance,
       tbtc,
       tbtcVault,
     } = await waffle.loadFixture(bridgeFixture))
@@ -557,6 +560,645 @@ describe("Bridge - Reservation", () => {
         expect((await bridge.reservations(reservationKey)).state).to.equal(2)
         expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
       })
+    })
+  })
+
+  describe("notifyReservedRedemptionVeto", () => {
+    const reservationKey = 555
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const amountSat = BigNumber.from(100000000)
+    const redeemerOutputScript =
+      "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          reservationKey,
+          thirdParty.address,
+          redeemerOutputScript
+        )
+
+      // Wire the watchtower only after the request so the
+      // isSafeRedemption gate does not call an EOA.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(deployer.address)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should revert when called by a third party", async () => {
+      await expect(
+        bridge.connect(thirdParty).notifyReservedRedemptionVeto(reservationKey)
+      ).to.be.revertedWith("Caller is not the redemption watchtower")
+    })
+
+    it("should detain the balance and reactivate the reservation", async () => {
+      const tx = await bridge
+        .connect(deployer)
+        .notifyReservedRedemptionVeto(reservationKey)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionVetoed")
+        .withArgs(reservationKey)
+
+      expect(await bank.balanceOf(deployer.address)).to.equal(amountSat)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+    })
+  })
+
+  describe("ReservationVault.retryRedeemReservation", () => {
+    const reservationKey = 444
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const amountSat = BigNumber.from(100000000)
+    const grossTbtc = amountSat.mul(SATOSHI_MULTIPLIER)
+    const redeemerOutputScript =
+      "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      const tbtcOwner = await impersonateContract(await tbtc.owner())
+      await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      // Simulate the state a redemption timeout leaves the owner in: the
+      // gross amount refunded as Bank balance. The fee is paid in TBTC,
+      // funded here through an ordinary reservation credit.
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(thirdParty.address, amountSat)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalanceAndCall(
+          reservationVault.address,
+          [thirdParty.address],
+          [amountSat]
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("retries the redemption from Bank balance", async () => {
+      const fee = grossTbtc.mul(20).div(10000)
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, amountSat)
+      await tbtc.connect(thirdParty).approve(reservationVault.address, fee)
+
+      const tx = await reservationVault
+        .connect(thirdParty)
+        .retryRedeemReservation(reservationKey, redeemerOutputScript)
+
+      await expect(tx).to.emit(bridge, "ReservedRedemptionRequested")
+      expect((await bridge.reservations(reservationKey)).state).to.equal(2) // RedemptionRequested
+      expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
+    })
+  })
+
+  describe("governance-delayed reservation parameters update", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("stages the parameters and applies them after the governance delay", async () => {
+      await bridgeGovernance
+        .connect(governance)
+        .beginReservationParametersUpdate(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET
+        )
+
+      await expect(
+        bridgeGovernance
+          .connect(governance)
+          .finalizeReservationParametersUpdate()
+      ).to.be.revertedWith("Governance delay has not elapsed")
+
+      await increaseTime(
+        (await bridgeGovernance.governanceDelays(0)).toNumber()
+      )
+
+      const tx = await bridgeGovernance
+        .connect(governance)
+        .finalizeReservationParametersUpdate()
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationVaultUpdated")
+        .withArgs(reservationVault.address)
+      await expect(tx)
+        .to.emit(bridge, "ReservationParametersUpdated")
+        .withArgs(
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET
+        )
+    })
+  })
+
+  describe("reservation SPV proofs", () => {
+    // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
+    // SPV proof validation checks transaction structure, merkle inclusion,
+    // and header work against the relay difficulty -- it does not execute
+    // Bitcoin scripts. Fixtures below use regtest-style compact bits
+    // (0x207fffff), whose integer difficulty is 0, with the relay mocked to
+    // report difficulty 0, so headers are minable in a couple of tries.
+
+    const REGTEST_BITS_LE = "ffff7f20"
+    const REGTEST_TARGET = BigNumber.from("0x7fffff").mul(
+      BigNumber.from(2).pow(8 * (0x20 - 3))
+    )
+
+    const reverseHex = (hex: string): string =>
+      hex.replace(/^0x/, "").match(/../g)!.reverse().join("")
+
+    const hash256 = (hexData: string): string =>
+      ethers.utils.sha256(ethers.utils.sha256(hexData))
+
+    const toLE = (value: number | BigNumber, byteLength: number): string =>
+      reverseHex(
+        BigNumber.from(value)
+          .toHexString()
+          .slice(2)
+          .padStart(byteLength * 2, "0")
+      )
+
+    const compactSize = (n: number): string => {
+      if (n >= 0xfd) {
+        throw new Error("compactSize > 252 not supported in fixtures")
+      }
+      return n.toString(16).padStart(2, "0")
+    }
+
+    interface FixtureTxIn {
+      txHash: string
+      index: number
+    }
+
+    interface FixtureTxOut {
+      valueSat: BigNumber | number
+      script: string // raw script hex, no 0x, no length prefix
+    }
+
+    function buildTx(inputs: FixtureTxIn[], outputs: FixtureTxOut[]) {
+      const inputVector = `0x${compactSize(inputs.length)}${inputs
+        .map((i) => `${i.txHash.slice(2)}${toLE(i.index, 4)}00ffffffff`)
+        .join("")}`
+      const outputVector = `0x${compactSize(outputs.length)}${outputs
+        .map(
+          (o) =>
+            `${toLE(BigNumber.from(o.valueSat), 8)}${compactSize(
+              o.script.length / 2
+            )}${o.script}`
+        )
+        .join("")}`
+      const info = {
+        version: "0x01000000",
+        inputVector,
+        outputVector,
+        locktime: "0x00000000",
+      }
+      const txHash = hash256(
+        `0x01000000${inputVector.slice(2)}${outputVector.slice(2)}00000000`
+      )
+      return { info, txHash }
+    }
+
+    function mineHeader(merkleRoot: string): string {
+      const prevBlock = ethers.utils
+        .hexlify(ethers.utils.randomBytes(32))
+        .slice(2)
+      const base = `20000000${prevBlock}${merkleRoot.slice(
+        2
+      )}662a2c68${REGTEST_BITS_LE}`
+      for (let nonce = 0; ; nonce++) {
+        const header = `0x${base}${toLE(nonce, 4)}`
+        if (
+          BigNumber.from(`0x${reverseHex(hash256(header))}`).lte(REGTEST_TARGET)
+        ) {
+          return header
+        }
+      }
+    }
+
+    // Builds an SPV proof for a transaction assumed to share a two-leaf
+    // block with a synthetic coinbase.
+    function proofFor(txHash: string) {
+      const coinbasePreimage = ethers.utils.sha256(ethers.utils.randomBytes(32))
+      const coinbaseTxId = ethers.utils.sha256(coinbasePreimage)
+      const merkleRoot = hash256(`0x${coinbaseTxId.slice(2)}${txHash.slice(2)}`)
+      return {
+        merkleProof: coinbaseTxId,
+        txIndexInBlock: 1,
+        bitcoinHeaders: mineHeader(merkleRoot),
+        coinbasePreimage,
+        coinbaseProof: txHash,
+      }
+    }
+
+    const buildDepositScript = (
+      depositor: string,
+      blinding: string,
+      walletPkh: string,
+      refundPkh: string,
+      locktime: string
+    ): string =>
+      `14${depositor.slice(2)}7508${blinding.slice(2)}7576a914${walletPkh
+        .slice(2)
+        .toLowerCase()}8763ac6776a914${refundPkh.slice(2)}8804${locktime.slice(
+        2
+      )}b175ac68`
+
+    const p2wshScript = (script: string): string =>
+      `0020${ethers.utils.sha256(`0x${script}`).slice(2)}`
+
+    const p2wpkhScript = (pkh: string): string => `0014${pkh.slice(2)}`
+
+    // ---- Scenario constants ----
+
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
+    const blindingFactor = "0xf9f0c90d00039523"
+    const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
+    const refundLocktime = "0x60bcea61"
+    const NO_MAIN_UTXO_PARAM = {
+      txHash: ZERO_BYTES32,
+      txOutputIndex: 0,
+      txOutputValue: 0,
+    }
+
+    const depositAmount = BigNumber.from(3000000)
+    const anchorFee = 1500
+    const anchorAmount = depositAmount.sub(anchorFee)
+    const grossTbtc = anchorAmount.mul(SATOSHI_MULTIPLIER)
+
+    const ProofType = {
+      Acceptance: 0,
+      Redemption: 1,
+      Reanchor: 2,
+      Dissolution: 3,
+    }
+
+    async function liveWallet(pkh: string) {
+      await bridge.setWallet(pkh, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+    }
+
+    // Reveals a fresh reserved deposit and proves its anchor transaction.
+    async function makeAcceptedReservation(anchorValue?: BigNumber) {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorValue ?? anchorAmount,
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      const acceptTx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          0
+        )
+
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      return { fundingTx, anchorTx, acceptTx, reservationKey }
+    }
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      relay.getCurrentEpochDifficulty.returns(0)
+      relay.getPrevEpochDifficulty.returns(0)
+
+      await bridge.setDepositDustThreshold(10000)
+      await bridge.setDepositTxMaxFee(2000)
+      await bridge.setDepositRevealAheadPeriod(0)
+      await liveWallet(walletPubKeyHash)
+
+      const tbtcOwner = await impersonateContract(await tbtc.owner())
+      await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("accepts a proven anchor and credits the gross amount", async () => {
+      const { anchorTx, acceptTx, reservationKey } =
+        await makeAcceptedReservation()
+
+      await expect(acceptTx)
+        .to.emit(bridge, "ReservationAccepted")
+        .withArgs(
+          reservationKey,
+          walletPubKeyHash,
+          thirdParty.address,
+          anchorTx.txHash,
+          anchorAmount,
+          (
+            await bridge.reservations(reservationKey)
+          ).expiresAt
+        )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.owner).to.equal(thirdParty.address)
+      expect(reservation.mintedAmount).to.equal(anchorAmount)
+      expect(reservation.anchorAmount).to.equal(anchorAmount)
+      expect(reservation.anchorTxHash).to.equal(anchorTx.txHash)
+      expect(reservation.state).to.equal(1) // Active
+
+      // Gross mint minus the 40 bps initiation fee.
+      const fee = grossTbtc.mul(40).div(10000)
+      expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+        grossTbtc.sub(fee)
+      )
+
+      // The anchor consumed the deposit: no double acceptance.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            0
+          )
+      ).to.be.revertedWith("Deposit already swept")
+    })
+
+    it("rejects an anchor paying an excessive miner fee", async () => {
+      await expect(
+        makeAcceptedReservation(depositAmount.sub(RESERVATION_TX_MAX_FEE + 1))
+      ).to.be.revertedWith("Transaction fee is too high")
+    })
+
+    it("completes an in-kind reserved redemption", async () => {
+      // Two acceptances fund the owner with enough TBTC for the gross
+      // surrender plus the redemption fee on the first reservation.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+
+      // Captured before the vault unmints the gross surrender: the ERC-20
+      // burn happens at request time, while the SPV proof burns the Bank
+      // balance held by the Bridge.
+      const supplyBefore = await tbtc.totalSupply()
+
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript)
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4), // strip 0x16 length prefix
+          },
+        ]
+      )
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, redemptionTx.txHash)
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+      // The gross surrendered balance was burned.
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+      expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(grossTbtc))
+    })
+
+    it("re-anchors a reservation to another Live wallet", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      const reanchorFee = 500
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(reanchorFee),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationReanchored")
+        .withArgs(
+          reservationKey,
+          secondWalletPubKeyHash,
+          reanchorTx.txHash,
+          anchorAmount.sub(reanchorFee)
+        )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(reservation.anchorTxHash).to.equal(reanchorTx.txHash)
+      expect(reservation.anchorAmount).to.equal(anchorAmount.sub(reanchorFee))
+      // The gross claim is unchanged by in-kind re-anchor fees.
+      expect(reservation.mintedAmount).to.equal(anchorAmount)
+    })
+
+    it("dissolves an expired reservation into the wallet main UTXO", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      // Not dissolvable before term + grace.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Reservation term or grace period not elapsed")
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx).to.emit(bridge, "ReservationDissolved")
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+
+      // The dissolution output became the wallet's new main UTXO.
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.mainUtxoHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [dissolutionTx.txHash, 0, anchorAmount.sub(dissolutionFee)]
+        )
+      )
     })
   })
 })

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -1,0 +1,96 @@
+import { artifacts } from "hardhat"
+import { expect } from "chai"
+import { assertStorageUpgradeSafe } from "@openzeppelin/upgrades-core"
+
+import bridgeTIP109HotfixDeployment from "../../deployments/mainnet/BridgeTIP109HotfixImplementation.json"
+
+type StorageEntry = {
+  label: string
+  offset: number
+  slot: string
+  type: string
+}
+
+type StorageLayout = {
+  storage: StorageEntry[]
+  types: Record<
+    string,
+    {
+      label: string
+      encoding: string
+      numberOfBytes: string
+      members?: StorageEntry[]
+      key?: string
+      value?: string
+      base?: string
+    }
+  >
+}
+
+type UpgradeStorageLayout = Parameters<typeof assertStorageUpgradeSafe>[0]
+
+async function getBridgeStorageLayout(): Promise<StorageLayout> {
+  const sourceName = "contracts/bridge/Bridge.sol"
+  const contractName = "Bridge"
+  // Bridge is compiled in multiple optimizer jobs and its final artifact can
+  // point at a job without storageLayout output. BridgeState's artifact points
+  // at the validation-enabled job that also contains the compiled Bridge.
+  const buildInfo = await artifacts.getBuildInfo(
+    "contracts/bridge/BridgeState.sol:BridgeState"
+  )
+  if (!buildInfo) {
+    throw new Error(`No build info for ${sourceName}:${contractName}`)
+  }
+
+  const layout = (
+    buildInfo.output.contracts[sourceName][contractName] as {
+      storageLayout?: StorageLayout
+    }
+  ).storageLayout
+  if (!layout) {
+    throw new Error(`No storage layout for ${sourceName}:${contractName}`)
+  }
+
+  return layout
+}
+
+function bridgeStateLayout(layout: StorageLayout): StorageLayout {
+  const bridgeState = layout.storage.find((entry) => entry.label === "self")
+  if (!bridgeState) {
+    throw new Error("BridgeState.Storage entry not found")
+  }
+
+  const bridgeStateType = layout.types[bridgeState.type]
+  if (!bridgeStateType?.members) {
+    throw new Error("BridgeState.Storage members not found")
+  }
+
+  // Bridge stores its state in one library struct. Flatten that struct for
+  // OpenZeppelin 1.x so its normal gap-consumption algorithm validates the
+  // real member slots; that release rejects every nested-struct append before
+  // applying the nested struct's own __gap semantics.
+  return {
+    storage: bridgeStateType.members,
+    types: layout.types,
+  }
+}
+
+describe("Bridge storage layout", () => {
+  it("is upgrade-safe against the deployed TIP-109 Bridge layout", async () => {
+    const deployedLayout = bridgeStateLayout(
+      bridgeTIP109HotfixDeployment.storageLayout as unknown as StorageLayout
+    )
+    const updatedLayout = bridgeStateLayout(await getBridgeStorageLayout())
+
+    // The checked-in deployment artifact predates solc's enum-members output.
+    // Allow incomplete custom-type descriptions while still validating every
+    // concrete slot, packing decision, mapping, struct, and storage-gap change.
+    expect(() =>
+      assertStorageUpgradeSafe(
+        deployedLayout as unknown as UpgradeStorageLayout,
+        updatedLayout as unknown as UpgradeStorageLayout,
+        true
+      )
+    ).not.to.throw()
+  })
+})

--- a/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
+++ b/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
@@ -27,6 +27,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
   const MOVING_FUNDS_ADDRESS = "0x0000000000000000000000000000000000000006"
   const BRIDGE_IMPL_ADDRESS = "0x0000000000000000000000000000000000000007"
   const REBATE_IMPL_ADDRESS = "0x0000000000000000000000000000000000000008"
+  const RESERVATION_ADDRESS = "0x0000000000000000000000000000000000000009"
   const BRIDGE_PROXY_ADDRESS = "0x5e4861a80B55f035D899f66772117F00FA0E8e7B"
   const REBATE_STAKING_PROXY_ADDRESS =
     "0x0184739c02d51bFc1cc2E3a2bF6bbBe31e265a45"
@@ -45,6 +46,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
     Wallets: WALLETS_ADDRESS,
     Fraud: FRAUD_ADDRESS,
     MovingFunds: MOVING_FUNDS_ADDRESS,
+    Reservation: RESERVATION_ADDRESS,
     Bridge: BRIDGE_PROXY_ADDRESS,
     RebateStaking: REBATE_STAKING_PROXY_ADDRESS,
     BridgeGovernance: BRIDGE_GOV_ADDRESS,
@@ -229,6 +231,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           "Wallets",
           "Fraud",
           "MovingFunds",
+          "Reservation",
         ]
         const getNames = getCalls.map((c) => c.name)
 
@@ -257,7 +260,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(directBridgeCall).to.be.undefined
       })
 
-      it("should define all 6 required libraries for Bridge implementation deployment", async () => {
+      it("should define all 7 required libraries for Bridge implementation deployment", async () => {
         await func(mockHre)
 
         const bridgeCall = deployCalls.find(
@@ -275,9 +278,10 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           "Wallets",
           "Fraud",
           "MovingFunds",
+          "Reservation",
         ]
         const actualKeys = Object.keys(libraries)
-        expect(actualKeys).to.have.lengthOf(6)
+        expect(actualKeys).to.have.lengthOf(7)
 
         expectedLibKeys.forEach((key) => {
           expect(libraries).to.have.property(key)
@@ -291,6 +295,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(libraries.Wallets).to.equal(WALLETS_ADDRESS)
         expect(libraries.Fraud).to.equal(FRAUD_ADDRESS)
         expect(libraries.MovingFunds).to.equal(MOVING_FUNDS_ADDRESS)
+        expect(libraries.Reservation).to.equal(RESERVATION_ADDRESS)
       })
 
       it("should deploy RebateStaking implementation with distinct artifact name", async () => {
@@ -772,11 +777,11 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       })
     })
 
-    it("should have libraries with all 6 entries", () => {
+    it("should have libraries with all 7 entries", () => {
       expect(summary).to.not.be.null
       const libs = summary.libraries
 
-      expect(Object.keys(libs)).to.have.lengthOf(6)
+      expect(Object.keys(libs)).to.have.lengthOf(7)
 
       const requiredKeys = [
         "Deposit",
@@ -785,6 +790,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         "Wallets",
         "Fraud",
         "MovingFunds",
+        "Reservation",
       ]
 
       requiredKeys.forEach((key) => {

--- a/solidity/test/deploy/95_deploy_reservation_vault.test.ts
+++ b/solidity/test/deploy/95_deploy_reservation_vault.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from "chai"
+import func from "../../deploy/95_deploy_reservation_vault"
+
+describe("Deploy Script 95: ReservationVault", () => {
+  const deployer = "0x1234567890123456789012345678901234567890"
+  const bank = "0x0000000000000000000000000000000000000001"
+  const tbtcVault = "0x0000000000000000000000000000000000000002"
+  const bridge = "0x0000000000000000000000000000000000000003"
+  const reservationVault = "0x0000000000000000000000000000000000000004"
+
+  it("does not recursively execute the Bridge deployment", () => {
+    expect(func.dependencies).to.deep.equal(["Bank", "TBTCVault"])
+  })
+
+  it("reads the existing Bridge address for the vault constructor", async () => {
+    const getCalls: string[] = []
+    const deployCalls: Array<{ name: string; options: any }> = []
+    const addresses: Record<string, string> = {
+      Bank: bank,
+      TBTCVault: tbtcVault,
+      Bridge: bridge,
+    }
+
+    const mockHre: any = {
+      deployments: {
+        get: async (name: string) => {
+          getCalls.push(name)
+          return { address: addresses[name] }
+        },
+        deploy: async (name: string, options: any) => {
+          deployCalls.push({ name, options })
+          return { address: reservationVault }
+        },
+      },
+      getNamedAccounts: async () => ({ deployer }),
+      helpers: {
+        etherscan: {
+          verify: async () => undefined,
+        },
+      },
+      network: { tags: {} },
+    }
+
+    await func(mockHre)
+
+    expect(getCalls).to.deep.equal(["Bank", "TBTCVault", "Bridge"])
+    expect(deployCalls).to.have.lengthOf(1)
+    expect(deployCalls[0]).to.deep.equal({
+      name: "ReservationVault",
+      options: {
+        from: deployer,
+        args: [bank, tbtcVault, bridge],
+        log: true,
+        waitConfirmations: 1,
+      },
+    })
+  })
+})

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -135,6 +135,8 @@ export default async function bridgeFixture(): Promise<{
           Fraud: (await helpers.contracts.getContract("Fraud")).address,
           MovingFunds: (await helpers.contracts.getContract("MovingFunds"))
             .address,
+          Reservation: (await helpers.contracts.getContract("Reservation"))
+            .address,
         },
       },
       proxyOpts: {


### PR DESCRIPTION
## What this is

Draft implementation of **UTXO reservations**: a deposit lane where a depositor's coins are custodied by the threshold network **without ever commingling** with the pooled supply, and redemption returns exactly their coin lineage (unbroken 1-input-1-output spends from deposit to redemption). Motivations: bailment-style fact pattern for tax treatment of bridging, and provable client-level fund segregation for institutions — with the side benefit that reserved clients neither inherit nor contribute UTXO taint.

Wallet-side companion: threshold-network/keep-core#4238.

## Design

Commingling in tBTC happens at exactly one place: the deposit sweep merges deposit UTXOs into the wallet's main UTXO, and balances are credited only there. A reservation is a deposit that is never merged:

1. **Reveal**: a regular reveal routed to the new `ReservationVault` (`reveal.vault` doubles as the reservation flag).
2. **Anchor**: instead of sweeping, the wallet performs a 1-in-1-out spend of the deposit into a fresh wallet-controlled output with **no refund path**. Credit happens only on the anchor's SPV proof — the sweep's refund-disabling role without its consolidating role.
3. **Custody term**: a contract-layer fact only (no Bitcoin-side timelocks). Extension is a fee payment.
4. **In-kind redemption**: gross surrender, wallet spends exactly the anchor outpoint to the redeemer script, gross burn reconciles supply to backing to the satoshi.
5. **Re-anchor** (wallet migration) and **dissolution** (post term+grace; the stranding pressure valve).

**Claims are minted gross, never netted** — all protocol fees are explicit TBTC transfers collected by the vault (schedule: **40 bps initiation + 20 bps/yr extension + 20 bps redemption**, decomposing as endpoint parity with the pooled path — a 20 bps mint leg and the standard 20 bps redemption fee — plus a 20 bps/yr custody fee that is the actual premium being purchased, with the first year prepaid inside the initiation fee. An N-year holding pays 40 + 20N bps against the pooled 40 bps round trip: strictly premium at every horizon. The redemption fee is waived on retries after wallet-fault timeouts. The schedule is intended to be stable across the FROST transition: the minimum reservation size, not the fee legs, is the governance dial that keeps carry covering per-position lifecycle costs).

## Safety wiring

- Acceptance marks the deposit `sweptAt`; consumed anchors are recorded in `spentMainUTXOs` — fraud-defeat coverage with **zero Fraud.sol changes**.
- Sweep proofs targeting the reservation vault revert (Bridge) and sweep proposals containing reserved deposits are rejected (WalletProposalValidator).
- Wallets cannot finalize closing while custodying reservations.
- **Watchtower integration is complete on both sides**: requests pass `isSafeRedemption`, and guardians can veto pending reserved redemptions via `RedemptionWatchtower.raiseReservedObjection` (same three-objection flow, freeze, penalty burn, and redeemer ban; reuses the existing veto storage keyed by reservation key — no layout changes, upgrade-safe). Reserved vetoes deliberately share the pooled veto parameters and semantics (penalty divisor, freeze period, ban); parity is intended, not inherited by accident. Timeouts reuse `notifyWalletRedemptionTimeout` slashing.
- **WalletProposalValidator** validates all four lifecycle proposals (anchor eligibility/fees/refund margin, reserved redemption age/timeout margins/watchtower delay, re-anchor targets, dissolution term+grace).
- **BridgeGovernance** stages all reservation parameters behind the standard governance delay (`beginReservationParametersUpdate` / `finalizeReservationParametersUpdate`).
- Premature dissolution signing is economically deterred (undefeatable fraud-challenge target until grace passes).
- Launch throttles: min size, total cap, per-wallet cap — defaulting to disabled until governance wires them.

## Testing

26 tests in the reservation suite; full repo suite green (3000+). Includes **Bitcoin SPV fixtures for all four proof validators** (structurally-valid transactions + regtest-difficulty headers crafted in TypeScript; SPV checks structure/merkle/PoW, not scripts), the watchtower veto e2e (three guardian objections through the Bridge hook, penalty burn, ban blocking re-requests), validator coverage, vault fee math, retry path, and the governance-delayed parameter flow.

## Decision point 1: EIP-170 strategy

Main's Bridge compiles to **24.093 KB at runs=1000 — 483 bytes under the 24.576 limit**. No usable reservation API fits in that. This PR consolidates all four lifecycle proofs behind one `submitReservationProof` entry point, trims the API to essentials, and gives Bridge.sol a **runs=100 optimizer override** (a contract-specific override — the same technique BridgeGovernance uses, though it runs at 200, not the same number), landing at **24.175 KB** with the full surface including the veto hook and parameters getter.

- *Cost of runs=100*: marginally higher runtime gas on all Bridge functions (typically low single-digit percent on hot paths — worth quantifying with a gas-report diff before mainnet).
- *Alternative*: a router-style refactor moving entry points out of the Bridge — durable headroom, but it would stand up a second router architecture parallel to the one the P2TR activation track is already building.

**Recommendation**: ship the override short-term; converge on the activation track's router architecture as the durable fix rather than inventing a parallel one. The override is one line, reversible, and precedented; the router is the right end-state but should happen once, in one shape.

## Decision point 2: re-anchor miner-fee policy

Re-anchor (wallet migration) miner fees ride in-kind: they reduce the on-chain `anchorAmount` while the gross claim (`mintedAmount`) is unchanged, so accumulated fees are settled by the owner at redemption (gross burn vs. reduced payout). Migrations happen on the *network's* schedule, so this charges clients for events they don't control — but the protocol invariant stays maximally clean ("claims burn gross; miner fees are the only in-kind deduction"), and the amounts are negligible: a re-anchor costs roughly 500–2,000 sats, i.e. sub-0.01 bp on a 10 BTC reservation, versus 20 bps/yr custody.

- *Alternative*: vault-side compensation (transfer the fee delta to the owner at redemption from custody-fee revenue) — requires the vault to retain a fee buffer and adds a transfer path + audit surface for immaterial fairness gain.

**Recommendation**: keep owner-borne in the protocol; disclose in the custody agreement that all Bitcoin miner fees — including network-scheduled re-anchors — ride in-kind, and handle any client-specific rebates commercially. The design principle that rotation must not be disincentivized is preserved where it matters: operator economics are untouched.

## ⚠️ Comprehensive review outcome — NOT audit-ready as-is

A full design+implementation review (Codex gpt-5.6-sol, max effort) found **1 Critical, 8 High, 9 Medium, 1 Low**. The SPV proof paths, replay guards, and storage layout are sound; the findings are about the **settlement state machine and economic model**. Root cause: the reservation lifecycle is single-phase (`request → prove`) over long-lived per-position UTXOs, but tBTC settlement needs a **two-phase authorize-then-prove** model with request nonces and terminal settlement records (as the main redemption path has via `timedOutRedemptions`). The headline bug (**C-01**) is a claim double-spend: a timeout/veto racing a confirmed reserved-redemption tx refunds the claim after the BTC was already paid.

**Critical:** C-01 claim double-spend (timeout/veto races a confirmed redemption tx -> BTC paid + claim refunded).
**High:** H-01 re-anchor/dissolution lack on-chain authorization + proof-type ambiguity; H-02 capacity/lifecycle checked at proof time not reserved before signing (confirmed spends become unprovable); H-03 watchtower delay enforced only by the advisory validator, not the Bridge proof path; H-04 dissolution permanently underbacks by cumulative in-kind fees (treasury transfers do not burn liability); H-05 requests against Closing wallets permanently lock owner+wallet and post-grace requests defeat the stranding bound; H-06 forced termination with live anchors enables unchallengeable unbacked mint; H-07 concurrent no-main-UTXO dissolutions race; H-08 **FIXED** (re-anchor-floor regression).
**Medium (9):** retry fee-bypass, per-generation veto keying, vault-swap sweep leak, anchor-not-bound-to-named-wallet, cap semantics, term/fee bounds, instant vault fee changes + un-transferred ownership, release completeness. **Low (1):** stale close data.

The Critical/High settlement-race items are a deliberate follow-up redesign (two-phase authorize-then-prove with request nonces + terminal settlement records), **not ad-hoc patches**. Full triaged detail with file:line and fixes is maintained in the local design docs.

## External review notes (Codex gpt-5.6-sol, max effort)

An independent read of the proof validators surfaced two correctness bugs, now **fixed** in this branch with regression tests:

- **Redemption underflow**: the redemption range check subtracted the governable `redemptionTxMaxFee` from `anchorAmount`, reverting on underflow when a governance fee increase pushes the bound above an existing anchor — which would strand that reservation. Reformulated underflow-safe.
- **Missing re-anchor floor**: re-anchors bounded only the per-hop fee; repeated network-scheduled hops could grind the anchor toward the fee bound. Now floored at `reservationMinAmount`.

Open items it raised, carried as review/governance decisions (not blockers):

- **Dissolution deficit is exact-plus-fee**: on dissolution the pooled shortfall is `mintedAmount − anchorAmount + dissolutionTxFee`, and `reservationTotalAmount` tracks current anchor assets rather than gross minted liability, so the total-reserved cap does not bound cumulative backing leakage across many dissolved positions. Immaterial at the sat-scale magnitudes and the launch cap, but worth an explicit acknowledgement (or a small burn-the-shortfall step) before the cap is widened.
- **Fees are not grandfathered**: `ReservationVault.updateFees` applies immediately to live positions (each leg ≤ 500 bp). If the custody agreement promises schedule stability, this needs a timelock/snapshot or an explicit governance-change clause.
- **EIP-170 margin convention**: the 24.175 KB artifact leaves ~401 bytes; the activation branch uses a 512-byte minimum production margin, so this should be an explicit exception or recover ~111 bytes, and the "one-line reversible" property only holds *before* reservations hold live state — after activation, changing the layout needs a state migration. Codex's strongest addition: **sequence the merge so reservations are never activated on the temporary layout** — deploy disabled (as the deploy script already does), rebase onto the router architecture, then enable the vault via governance. That removes the live-state-migration risk entirely.

## Remaining follow-ups (all blocked on sequencing, not design)

1. **SDK** (typescript/): typechain is generated from the **published** `@keep-network/tbtc-v2` npm artifacts, so reservation methods cannot typecheck until this PR merges and publishes. The work itself is mechanical (vault routing in `DepositsService` + a thin reservations service).
2. **keep-core executor wiring + tbtcpg generation + Ethereum bindings**: same artifact-publication dependency; the foundations (action types, proposals, chain interface, transaction assembly) are in threshold-network/keep-core#4238.
3. **Protobuf definitions** for the coordination proposal types (TODO-marked in #4238).
4. **System-tests**: regtest e2e with real wallet signing (contract-side validation is covered by the crafted SPV fixtures here).





