### PR TITLE
feat(bridge): two-phase authorize-then-prove reservation settlement

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -446,33 +446,36 @@ but they will not get reimbursed for doing so. To not mix the concept of
 reimbursement with the logic of the `Bridge` contract, we placed the
 reimbursement logic in a special contract called `MaintainerProxy`. Only
 DAO-authorized maintainers can call `Bridge` via `MaintainerProxy` and get
-reimbursed for the call but it does not block anyone from calling `Bridge`
-directly. The only difference is that those calling `Bridge` directly will not
-get reimbursed. This should be enough to prevent malicious actors from
-front-running honest maintainers. Maintainers are getting authorized by a DAO
-with a call to `MaintainerProxy.authorize` and can be deauthorized by a DAO with
-a call to `MaintainerProxy.unauthorize`.
+reimbursed. Permissionless `Bridge` endpoints remain callable directly without
+reimbursement. SPV-proof endpoints additionally require the caller to be
+authorized in `Bridge`, so governance authorizes the proxy address itself;
+direct proof submitters need separate Bridge authorization. This should be
+enough to prevent malicious actors from front-running honest maintainers.
+Maintainers are authorized and deauthorized by a DAO using the wallet- or
+SPV-specific authorization functions exposed by `MaintainerProxy`.
 
-`Bridge.submitDepositSweepProof` and `Bridge.submitRedemptionProof` are
-functions that must be called often and they execute quite an expensive SPV
-proof. These functions need to be protected with `onlyMaintainer` notifier in
-`MaintainerProxy`.
+`Bridge.submitDepositSweepProof`, `Bridge.submitRedemptionProof`, and
+`Bridge.submitReservationProof` are functions that must be called often and
+they execute quite an expensive SPV proof. These functions need to be protected
+with `onlySpvMaintainer` in the maintainer proxy (the reservation endpoint is
+available in `MaintainerProxyV2`).
 
 `Bridge.submitMovingFundsProof` and `Bridge.submitMovedFundsSweepProof` are
 functions that are called less often but they also execute an expensive SPV
 proof. The input parameters to them are pretty much the same as for
 `Bridge.submitDepositSweepProof` and `Bridge.submitRedemptionProof` so we assume
 calling them is also the maintainer's responsibility and we protect them in
-`MaintainerProxy` with `onlyMaintainer` modifier.
+`MaintainerProxy` with the `onlySpvMaintainer` modifier.
 
 It is important to note that the off-chain client software should not rely
 entirely on maintainers to call these functions. If proofs are not submitted on
 time, the wallet can be accused of fraud, or it can get slashed because of
 exceeding redemption timeout, moving funds timeout, or sweeping moved funds
 timeout. The wallet should expect the maintainer bots to do their work but it
-should also monitor if that actually happens. If not, the wallet should submit
-the proof itself - directly to the `Bridge` - to avoid slashing. Such a call
-would not be reimbursed but it should also never be needed.
+should also monitor if that actually happens. If not, it should ensure that an
+authorized maintainer submits the proof. A wallet-controlled account can submit
+directly only if governance separately authorized it in `Bridge`; that call is
+not reimbursed.
 
 Functions like `Bridge.requestNewWallet`, `Bridge.notifyMovingFundsBelowDust`,
 `Bridge.notifyWalletCloseable`, or `Bridge.notifyWalletClosingPeriodElapsed`

--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -230,6 +230,12 @@ transaction the honest wallet signs is the dissolution itself.
 
 === Acceptance as a two-phase action
 
+NOTE: The pending-reserved-deposit counter and its permissionless
+stale-marking function described below are not yet implemented as of the
+settlement PR in this stack; the vault-migration guard currently checks
+only `reservationTotalAmount == 0`. Tracked as deferred follow-up scope
+(M-04/M-05).
+
 Acceptance follows the same model with reveal-time integration:
 
 * At *reveal*, a deposit routed to the reservation vault records its
@@ -279,9 +285,13 @@ Reserved redemption requests are accepted only while
 Live or MovingFunds, and the owner passes the reservation-scoped watchtower
 safety check). After grace, only dissolution may be requested — so an owner
 cannot cycle request/timeout to hold a wallet hostage past the custody
-term: *term + grace + one action timeout* is a hard stranding bound. One
-carve-out: a timeout-minted retry entitlement may be used after grace until
-a dissolution is requested; requesting dissolution voids outstanding
+term: *term + grace + one action timeout* is a hard stranding bound absent
+the retry carve-out below. One carve-out: a timeout-minted retry
+entitlement may be used after grace until a dissolution is requested, and
+because the entitlement itself is minted by a fee-paid redemption
+timeout, a request placed just before grace expiry can yield a bound of
+*term + grace + 2 x redemptionTimeout* (each of the two timeouts slashes
+the custodying wallet); requesting dissolution voids outstanding
 entitlements (the claim simply remains pooled TBTC).
 
 === Watchtower integration (per-generation)
@@ -298,6 +308,14 @@ check.
 == Backing integrity
 
 === The rule
+
+NOTE: The vault fee-financing mechanism described below (unminting TBTC
+and burning the corresponding Bank balance to finance the re-anchor and
+dissolution miner fee, plus the in-kind fee-debt fallback) is not yet
+implemented as of the settlement PR in this stack. Merging that PR alone
+is safe because it leaves `reservationVault` inert; this mechanism is
+required before vault activation. Tracked as deferred follow-up scope
+(H-04/M-06).
 
 *The claim always equals the current anchor.* `mintedAmount` (the gross
 claim surrendered at redemption) tracks `anchorAmount` exactly, at every
@@ -349,6 +367,14 @@ checked and reserved at request/authorization time, never at proof time.
   pooled claim — the backing shortfall is socialized exactly like a
   terminated wallet's main UTXO today. A governance-insurance hook is
   stubbed for a future compensation module.
+  +
+  NOTE: This permissionless general-termination marking is not yet
+  implemented as of the settlement PR in this stack. Today `Stranded` is
+  reachable only as a side effect of a late acceptance, re-anchor or
+  dissolution proof settling against an already-terminated wallet; a
+  reservation `Active` (or mid-action) when its wallet terminates outside
+  those paths has no code path to reach `Stranded`. Tracked as deferred
+  follow-up scope (H-06).
 
 == Economic policy (governed defaults)
 
@@ -371,8 +397,9 @@ decisions* surfaced for sign-off:
 == Storage layout policy
 
 `BridgeState.Storage` is append-only: every new field decrements `__gap`
-(43 at the start of this track) by exactly the slots added; mappings append
-freely; nothing is ever reordered. The same discipline applies to the
+(41 at the start of this track, decremented to 39 by this PR's two new
+mappings) by exactly the slots added; mappings append freely; nothing is
+ever reordered. The same discipline applies to the
 `RedemptionWatchtower` (upgradeable) — its reservation-generation keying
 reuses the existing veto mappings under generation-scoped keys, adding no
 new storage prefix requirements.

--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -239,9 +239,11 @@ Acceptance follows the same model with reveal-time integration:
 * `requestReservationAcceptance` (permissionless) authorizes the anchor:
   checks deposit routing, designated-wallet liveness, minimum amount and
   post-fee floor, reserves capacity against the designated wallet,
-  snapshots the fee bound, and sets the authorization's validity window
-  ending safely before the deposit refund locktime (the wallet must never
-  sign an anchor that can race the depositor's refund).
+  snapshots the fee bound, and rejects the request unless at least one
+  integer timestamp remains after the deposit-age gate and before both the
+  action-timeout and deposit-refund safety margins. The authorization ends
+  before the exact refund locktime (the wallet must never sign an anchor
+  that can race the depositor's refund).
 * The acceptance proof requires the authorization record and requires the
   anchor output to pay the *designated* wallet.
 * If the wallet never anchors, the authorization times out (capacity

--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -382,3 +382,10 @@ deployed inert (`reservationVault == 0` in Bridge parameters), the router
 ships with the Bridge implementation upgrade, and governance enables the
 vault last. No live reservation state ever exists on the pre-router
 layout, so there is no live-state migration.
+
+The production `MaintainerProxy` is immutable and does not expose the routed
+reservation-proof selector. Before activation, deploy `MaintainerProxyV2`,
+migrate the SPV-maintainer allowlist, transfer its ownership to governance,
+and have governance authorize the new proxy in both the Bridge and
+`ReimbursementPool`. The existing proxy remains the route for legacy and
+wallet-maintainer calls.

--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -1,0 +1,384 @@
+:toc: macro
+
+= RFC 13: UTXO reservation settlement architecture
+
+:icons: font
+:numbered:
+toc::[]
+
+== Background
+
+The UTXO reservation feature (PR #1088) lets a depositor reserve their
+deposited UTXO: the coins are custodied by a tBTC wallet without ever being
+commingled with the pooled supply and are returned in-kind — with an unbroken
+1-input-1-output lineage — upon redemption. The initial implementation
+shipped a *single-phase* lifecycle: every Bitcoin action (anchor acceptance,
+reserved redemption, re-anchor, dissolution) was requested and then proven,
+with all validity checks performed at proof time against live state.
+
+An external review of that implementation surfaced a class of settlement
+races sharing one root cause: *a long-lived, per-position Bitcoin UTXO
+lifecycle needs a two-phase, nonce-bound state machine with terminal
+settlement records* — the same shape the pooled redemption path already has
+(`pendingRedemptions` / `timedOutRedemptions`), generalized to every
+reservation action. Without it:
+
+* a timeout or veto can race a confirmed Bitcoin redemption, refunding the
+  claim on Ethereum after the BTC has irrevocably left custody, while the
+  late proof reverts and leaves the honest wallet exposed to an
+  undefeatable fraud challenge (claim double-spend);
+* re-anchor and dissolution transactions exist on Bitcoin with no on-chain
+  authorization naming their generation, action type, source/target wallet
+  and fee bound — and a same-wallet re-anchor is byte-identical to a
+  dissolution, with the interpretation chosen by the proof submitter;
+* capacity and lifecycle checks performed only at proof time can make an
+  already-confirmed Bitcoin spend unprovable;
+* the watchtower veto delay is enforced only by the advisory proposal
+  validator, not by the Bridge proof path.
+
+This RFC specifies the target architecture: the *reservation router* (how
+the surface fits the Bridge under EIP-170) and the *two-phase
+authorize-then-prove settlement machine* (how every reservation action is
+requested, authorized, proven and settled), together with the corrected
+backing/fee model and the wallet lifecycle integration.
+
+== Reservation router
+
+=== Problem
+
+The mainnet Bridge implementation sits within ~400 bytes of the EIP-170
+deployed-code limit even with the optimizer turned down. The reservation
+surface — and any serious rework of it — does not fit.
+
+=== Considered shapes
+
+*External router with privileged callbacks* (the shape used by the P2TR
+activation track for fraud signature verification): works for stateless
+verification, but reservations mutate core Bridge state (`deposits`,
+`registeredWallets`, `spentMainUTXOs`) and exercise Bank authority reserved
+for the Bridge address (`increaseBalanceAndCall`, `transferBalanceFrom`,
+`decreaseBalance`). An external contract would need a wide set of new
+privileged Bridge mutators — more new Bridge bytecode than the refactor
+removes, plus a brand-new trusted-party surface.
+
+*Delegatecall extension (chosen)*: the Bridge keeps a single storage slot
+with the address of a `ReservationRouter` contract and routes every call
+with an unmatched function selector to it via `delegatecall` from its
+fallback. Router code executes at the Bridge address, on Bridge storage,
+with Bridge Bank authority. The ABI observable at the Bridge address is
+unchanged; off-chain clients are unaffected.
+
+=== Invariants
+
+1. *Storage parity.* The router inherits the same storage-bearing bases as
+   the Bridge in the same order and declares exactly one storage variable,
+   the shared `BridgeState.Storage self`. All new reservation state is
+   appended to `BridgeState.Storage` with a matching `__gap` reduction. A
+   storage-layout parity test compares the canonicalized solc layouts of
+   `Bridge`, `BridgeStub` (prefix) and `ReservationRouter`.
+2. *No selector shadowing.* A selector declared by the Bridge never reaches
+   the router. A test asserts selector disjointness (the `Governable`
+   members inherited by both are identical by construction and exempt).
+3. *No standalone authority.* Direct calls to the router execute on its own
+   empty storage: no governance, no SPV maintainer, no vault, no Bank
+   authority — every state-changing entry point reverts.
+4. *Upgrade model.* `Bridge.setReservationRouter` is one-time and
+   governance-gated; replacing router code afterwards requires a Bridge
+   implementation upgrade. Pointing a delegatecall target at new code *is*
+   an implementation change, so it deliberately carries implementation-
+   upgrade ceremony, not parameter-governance ceremony.
+
+The Bridge remains at reduced optimizer `runs` (measured ~0 runtime-gas
+cost: it is a dispatch shell over external libraries that keep `runs=1000`),
+with a ~2.1 kB margin; the router has its own EIP-170 budget for the
+settlement machine below.
+
+== Two-phase settlement machine
+
+=== Model
+
+Every Bitcoin action of a reservation's life is one of four *action types*:
+
+[cols="1,2,2"]
+|===
+|Action |Bitcoin transaction |Ethereum effect at settlement
+
+|Acceptance
+|1-in (revealed reserved deposit) → 1-out (wallet P2(W)PKH anchor)
+|Position created; gross anchor value credited via vault (mint)
+
+|Redemption
+|1-in (anchor) → 1-out (redeemer script)
+|Claim burned; position closed
+
+|Re-anchor
+|1-in (anchor) → 1-out (target wallet P2(W)PKH)
+|Anchor moved to target wallet; claim reduced by the financed miner fee
+
+|Dissolution
+|1-in (anchor) [+ 2nd in: wallet main UTXO] → 1-out (wallet P2(W)PKH)
+|Anchor merged into pooled main UTXO; position closed; miner fee financed
+|===
+
+Each action goes through the same *two-phase* lifecycle:
+
+----
+                    request (checks + capacity reserved + snapshot + nonce)
+                       │
+                       ▼
+                 ┌───────────┐   watchtower delay elapses (redemptions)
+                 │ Requested │ ──────────────────────────────┐
+                 └───────────┘                               ▼
+                       │ veto (redemptions only,       [authorized —
+                       │ within delay window)           wallet may sign]
+                       ▼                                     │
+                 ┌───────────┐                     proof     │   timeout
+                 │  Vetoed   │ (terminal;        ┌───────────┴──────────┐
+                 └───────────┘  proof rejected   ▼                      ▼
+                                forever)   ┌──────────┐          ┌───────────┐
+                                           │ Settled  │          │ TimedOut  │
+                                           └──────────┘          └───────────┘
+                                                                       │
+                                                     late proof settles the
+                                                     generation: anchor marked
+                                                     spent, lineage closed,
+                                                     no second refund
+----
+
+*Request.* A reservation action is created by an explicit request that:
+
+* increments the position's monotonic *request nonce* — all subsequent
+  state, proofs and settlement for this action are keyed by
+  `(reservationKey, nonce)`; a stale generation can never be confused with
+  a newer one;
+* performs *all* capacity and lifecycle checks and *reserves* what it
+  checks (global reserved total, per-wallet count/amount, target wallet
+  liveness, post-fee dust floor, the per-wallet main-UTXO action lock) —
+  a wallet that signs an authorized action must never find the action
+  unprovable because state moved after signing;
+* *snapshots* every proof- and settlement-critical parameter (tx max fee,
+  redeemer script hash, target wallet, expected main-UTXO hash, fee-paid
+  flag) — later governance changes never affect an in-flight generation.
+
+*Authorization.* For reserved redemptions, the request is
+authorized-for-signing only after the applicable watchtower delay elapses
+without a veto. The *Bridge proof path itself* enforces this: a proof for a
+redemption generation is rejected until
+`requestedAt + watchtowerDelay(generation) <= now` and the generation is not
+vetoed. A Byzantine wallet that broadcasts early gains nothing: its spend
+cannot finalize before the guardians' window closes, and if the generation
+is vetoed the spend is unprovable forever — leaving the signature exposed
+to the fraud machinery, which is the intended punishment for signing an
+unauthorized action. Re-anchor and dissolution requests are authorized
+immediately at request time (their authorization conditions are the request
+preconditions; no watchtower window applies).
+
+*Settlement.* Exactly one of:
+
+* *Proof* (`Settled`): the SPV proof names `(reservationKey, nonce)`; the
+  transaction must match the generation's snapshot (inputs = the recorded
+  anchor [+ recorded main UTXO], output script/target = the recorded
+  commitment, miner fee within the snapshot bound). Consumed outpoints are
+  recorded in `spentMainUTXOs` so the honest signature defeats any fraud
+  challenge.
+* *Timeout* (`TimedOut`, terminal record): permissionless notification
+  after the generation's timeout. Releases reserved capacity and the
+  main-UTXO lock, refunds the escrowed claim (redemptions), slashes the
+  wallet like a pooled redemption timeout (redemptions), mints the
+  single-use fee-free *retry entitlement* if the generation had paid the
+  redemption fee, and returns the position to `Active`. The terminal
+  record persists.
+* *Veto* (`Vetoed`, terminal record): the watchtower detains the escrowed
+  claim (penalty/freeze/ban per pooled-parity policy). The position
+  returns to `Active` (the anchor was not spent; the in-kind claim
+  survives, though a banned owner cannot re-request).
+
+*Late proofs.* A proof arriving after a timeout settles against the
+`TimedOut` record of its generation — mirroring
+`timedOutRedemptions` on the pooled path:
+
+* the transaction is validated against the *record's* snapshot, never live
+  parameters;
+* consumed outpoints are marked in `spentMainUTXOs` (the honest-but-late
+  signature defeats fraud challenges) and the anchor lineage is closed;
+* *no second refund and no burn*: the timeout already refunded the claim
+  and slashed the wallet. As on the pooled path, the residual double-pay
+  (refunded claim + delivered BTC) is a wallet-fault cost deterred by
+  slashing, not an owner entitlement;
+* if the position has a *newer pending generation whose snapshot also
+  matches the transaction*, the proof must settle against the pending
+  generation (normal settlement, escrow burned) — the late-settlement path
+  refuses it. This makes the choice of generation deterministic and always
+  picks the economically correct settlement;
+* if a newer pending generation exists but does *not* match the
+  transaction (different redeemer script), late settlement additionally
+  unwinds the pending generation: its escrow is refunded, because its
+  anchor no longer exists.
+* a proof against a `Vetoed` generation is rejected forever: only a wallet
+  that signed before authorization can be in this position.
+
+*Late dissolution proofs and main-UTXO drift.* A dissolution authorized
+when the wallet had no main UTXO can race a deposit sweep that lands first
+and registers a new main UTXO. The confirmed dissolution (1-input, per its
+snapshot) is then proven against its record; since its output can no longer
+become the wallet's main UTXO, it is registered as a *moved-funds sweep
+request* — the existing machinery for wallet-held UTXOs pending
+consolidation — keeping backing tracked and the lineage closed. When the
+snapshot recorded a specific main UTXO, drift is impossible: that UTXO can
+only be consumed by proving a transaction that spends it, and the only such
+transaction the honest wallet signs is the dissolution itself.
+
+=== Acceptance as a two-phase action
+
+Acceptance follows the same model with reveal-time integration:
+
+* At *reveal*, a deposit routed to the reservation vault records its
+  designated wallet (the `walletPubKeyHash` proven by the reveal's script
+  commitment) and increments the pending-reserved-deposit counter (used by
+  the vault-migration guard).
+* `requestReservationAcceptance` (permissionless) authorizes the anchor:
+  checks deposit routing, designated-wallet liveness, minimum amount and
+  post-fee floor, reserves capacity against the designated wallet,
+  snapshots the fee bound, and sets the authorization's validity window
+  ending safely before the deposit refund locktime (the wallet must never
+  sign an anchor that can race the depositor's refund).
+* The acceptance proof requires the authorization record and requires the
+  anchor output to pay the *designated* wallet.
+* If the wallet never anchors, the authorization times out (capacity
+  released; re-requestable while the locktime margin allows). After the
+  refund locktime, a stale reserved deposit with no live authorization can
+  be permissionlessly marked stale, decrementing the pending counter.
+
+=== Explicit re-anchor and dissolution authorization
+
+*Re-anchor* (`requestReservationReanchor(key, targetWallet)`): allowed only
+in a migration or approved-rotation context — the source wallet is in
+`MovingFunds` state, or the caller is governance (rotation of a Live
+wallet). Target must be Live, different from the source, and have capacity
+(reserved at request). The proof requires the single output to pay the
+*recorded* target. Same-wallet re-anchors no longer exist, which — together
+with the action-typed generation records — removes the re-anchor/dissolution
+byte-ambiguity: a proof settles only against the single outstanding
+generation of its recorded action type, and repeated Byzantine self-re-
+anchoring is impossible because each hop needs a fresh authorization
+context.
+
+*Dissolution* (`requestReservationDissolution(key)`): permissionless once
+`now > expiresAt + gracePeriod` (the system's cleanup right), wallet in
+Live or MovingFunds state. Acquires the *per-wallet main-UTXO action lock*:
+at most one dissolution per wallet may be in flight, which (with the
+snapshot of the expected main-UTXO hash) removes the concurrent-dissolution
+race entirely. Snapshots the fee bound and expected main UTXO.
+
+=== Precedence and the stranding bound
+
+Reserved redemption requests are accepted only while
+`now <= expiresAt + gracePeriod` (and the position is Active, the wallet is
+Live or MovingFunds, and the owner passes the reservation-scoped watchtower
+safety check). After grace, only dissolution may be requested — so an owner
+cannot cycle request/timeout to hold a wallet hostage past the custody
+term: *term + grace + one action timeout* is a hard stranding bound. One
+carve-out: a timeout-minted retry entitlement may be used after grace until
+a dissolution is requested; requesting dissolution voids outstanding
+entitlements (the claim simply remains pooled TBTC).
+
+=== Watchtower integration (per-generation)
+
+Veto and objection state is keyed by `keccak256(reservationKey, nonce)`:
+objections never accumulate across generations, and a once-vetoed
+reservation (owner later unbanned) starts every new generation with a clean
+objection count. The watchtower exposes the applicable delay per generation
+(2h/8h/24h ladder shared with the pooled path); the Bridge proof path
+consults it (H-03), and the request path uses a reservation-scoped safety
+check (owner/redeemer ban state) rather than the pooled redemption-key
+check.
+
+== Backing integrity
+
+=== The rule
+
+*The claim always equals the current anchor.* `mintedAmount` (the gross
+claim surrendered at redemption) tracks `anchorAmount` exactly, at every
+instant, for every position:
+
+* *Acceptance*: mint = anchor output value (the acceptance miner fee is
+  borne by the depositor, exactly like a pooled sweep fee share).
+* *Redemption*: owner surrenders the claim (= anchor), receives
+  anchor − miner fee on Bitcoin; the fee is the owner's exit cost; supply
+  and backing reconcile exactly with no compensation needed.
+* *Re-anchor*: the anchor shrinks by the miner fee; the vault *finances*
+  the fee from its custody-fee revenue — it unmints TBTC equal to the fee
+  and burns the corresponding Bank balance — so supply shrinks in lockstep
+  with backing and the claim is written down to the new anchor value.
+  Rotation costs are thereby borne by the custody fee that was priced for
+  them, not by the owner and not by the peg.
+* *Dissolution*: the pool absorbs anchor − miner fee while the owner's
+  claim (= anchor) remains outstanding as ordinary TBTC; the vault finances
+  the dissolution miner fee the same way. Reconciliation is atomic with
+  the proof.
+
+If the vault's fee revenue cannot cover an in-kind fee, settlement still
+proceeds (a confirmed Bitcoin spend must never fail to settle); the
+uncovered remainder is recorded as a public *in-kind fee debt* with a
+governance top-up path, and the global-accounting invariant test asserts
+debt is zero across normal lifecycles.
+
+=== Caps on liability
+
+Because claim ≡ anchor, one number — the sum of anchors — is both the
+asset- and liability-side total. Caps: global reserved total (absolute),
+reserved fraction of total Bank-tracked backing (relative), per-wallet
+count *and* per-wallet satoshi amount, and per-position maximum. All are
+checked and reserved at request/authorization time, never at proof time.
+
+== Wallet lifecycle integration
+
+* A wallet holding reservation anchors (or pending reservation actions)
+  cannot *begin* closing: moving-funds completion requires the reservation
+  count to be zero — anchors are funds, and "funds moved" is false while
+  they remain. (The existing finalize-closing guard stays as defense in
+  depth.)
+* Reserved redemption requests require the wallet to be Live or
+  MovingFunds; every settlement path (timeout, veto, proof) works in any
+  wallet state.
+* A *terminated* wallet's reservations can be permissionlessly marked
+  `Stranded` (per position): pending escrow unwinds to its redeemer,
+  counters release, and the owner's minted TBTC simply remains a fungible
+  pooled claim — the backing shortfall is socialized exactly like a
+  terminated wallet's main UTXO today. A governance-insurance hook is
+  stubbed for a future compensation module.
+
+== Economic policy (governed defaults)
+
+Mechanics implemented now; *parameter values are explicit governance
+decisions* surfaced for sign-off:
+
+* term bounds: minimum 3 months, maximum 2 years *(default, flagged)*;
+* extension fee prorated to the extension length (20 bps/yr base);
+* renewal horizon cap: `expiresAt <= now + 2 × term` *(default, flagged)*
+  — prepaid extensions cannot push expiry out indefinitely;
+* grace-period penalty: none *(default 0, flagged — decision pending)*;
+* pricing of the embedded senior-liquidity option: financial-modeling task,
+  out of scope for the contracts, tracked as an open economics item;
+* `ReservationVault` ownership transferred to governance/timelock at
+  deploy; `updateFees` behind the protocol governance delay; per-position
+  fee terms snapshotted at acceptance; user-supplied fee-slippage bound on
+  mint/redeem paths. Fee schedule stays 40 bps initiation / 20 bps/yr
+  extension / 20 bps redemption.
+
+== Storage layout policy
+
+`BridgeState.Storage` is append-only: every new field decrements `__gap`
+(43 at the start of this track) by exactly the slots added; mappings append
+freely; nothing is ever reordered. The same discipline applies to the
+`RedemptionWatchtower` (upgradeable) — its reservation-generation keying
+reuses the existing veto mappings under generation-scoped keys, adding no
+new storage prefix requirements.
+
+== Deployment sequencing
+
+Reservations activate only on the router architecture: the vault is
+deployed inert (`reservationVault == 0` in Bridge parameters), the router
+ships with the Bridge implementation upgrade, and governance enables the
+vault last. No live reservation state ever exists on the pre-router
+layout, so there is no live-state migration.

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -27,7 +27,6 @@ import "./BridgeState.sol";
 import "./Deposit.sol";
 import "./DepositSweep.sol";
 import "./Redemption.sol";
-import "./Reservation.sol";
 import "./BitcoinTx.sol";
 import "./EcdsaLib.sol";
 import "./Wallets.sol";
@@ -68,7 +67,6 @@ contract Bridge is
     using Deposit for BridgeState.Storage;
     using DepositSweep for BridgeState.Storage;
     using Redemption for BridgeState.Storage;
-    using Reservation for BridgeState.Storage;
     using MovingFunds for BridgeState.Storage;
     using Wallets for BridgeState.Storage;
     using Fraud for BridgeState.Storage;
@@ -107,64 +105,6 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash,
         bytes redeemerOutputScript
     );
-
-    event ReservationAccepted(
-        uint256 indexed reservationKey,
-        bytes20 indexed walletPubKeyHash,
-        address indexed owner,
-        bytes32 anchorTxHash,
-        uint64 anchorAmount,
-        uint32 expiresAt
-    );
-
-    event ReservationExtended(
-        uint256 indexed reservationKey,
-        uint32 newExpiresAt
-    );
-
-    event ReservedRedemptionRequested(
-        uint256 indexed reservationKey,
-        address indexed redeemer,
-        bytes redeemerOutputScript,
-        uint64 mintedAmount,
-        uint64 txMaxFee
-    );
-
-    event ReservedRedemptionCompleted(
-        uint256 indexed reservationKey,
-        bytes32 redemptionTxHash
-    );
-
-    event ReservedRedemptionTimedOut(
-        uint256 indexed reservationKey,
-        bytes20 indexed walletPubKeyHash
-    );
-
-    event ReservedRedemptionVetoed(uint256 indexed reservationKey);
-
-    event ReservationReanchored(
-        uint256 indexed reservationKey,
-        bytes20 indexed newWalletPubKeyHash,
-        bytes32 newAnchorTxHash,
-        uint64 newAnchorAmount
-    );
-
-    event ReservationDissolved(
-        uint256 indexed reservationKey,
-        bytes20 indexed walletPubKeyHash,
-        bytes32 dissolutionTxHash
-    );
-
-    event ReservationParametersUpdated(
-        uint64 reservationMinAmount,
-        uint64 reservationTxMaxFee,
-        uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
-        uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
-    );
-
-    event ReservationVaultUpdated(address reservationVault);
 
     event WalletMovingFunds(
         bytes32 indexed ecdsaWalletID,
@@ -824,99 +764,6 @@ contract Bridge is
             walletMembersIDs,
             redeemerOutputScript
         );
-    }
-
-    /// @notice Single entry point for all reservation lifecycle SPV proofs:
-    ///         anchor acceptance, in-kind reserved redemption, re-anchoring
-    ///         and dissolution. Consolidated into one external function to
-    ///         preserve the Bridge's EIP-170 deployment size margin. See
-    ///         `Reservation.submitReservationProof` and the individual
-    ///         handlers in the `Reservation` library for detailed
-    ///         requirements.
-    /// @param proofType The type of the submitted proof, see
-    ///        `Reservation.ProofType`.
-    /// @param txInfo Bitcoin transaction data.
-    /// @param proof Bitcoin proof data.
-    /// @param mainUtxo Data of the wallet's main UTXO; only used for
-    ///        `Dissolution` proofs and ignored otherwise.
-    /// @param reservationKey The key of the target reservation; ignored for
-    ///        `Acceptance` proofs where the key is derived from the spent
-    ///        deposit outpoint.
-    function submitReservationProof(
-        uint8 proofType,
-        BitcoinTx.Info calldata txInfo,
-        BitcoinTx.Proof calldata proof,
-        BitcoinTx.UTXO calldata mainUtxo,
-        uint256 reservationKey
-    ) external onlySpvMaintainer {
-        self.submitReservationProof(
-            proofType,
-            txInfo,
-            proof,
-            mainUtxo,
-            reservationKey
-        );
-    }
-
-    /// @notice Extends the custody term of a reservation by the current
-    ///         reservation term length. Can only be called by the
-    ///         reservation vault, which collects the custody fee for the
-    ///         extension. See `Reservation.extendReservation`.
-    /// @param reservationKey The key of the reservation to extend.
-    function extendReservation(uint256 reservationKey) external {
-        // The caller is checked in the library function.
-        self.extendReservation(reservationKey);
-    }
-
-    /// @notice Requests an in-kind redemption of a reservation: the wallet
-    ///         is expected to spend exactly the reservation's current anchor
-    ///         outpoint to the redeemer output script in a 1-input-1-output
-    ///         transaction. Can only be called by the reservation vault,
-    ///         which must have approved the Bridge in the Bank for the gross
-    ///         minted amount. See `Reservation.requestReservedRedemption`.
-    /// @param reservationKey The key of the reservation to redeem.
-    /// @param redeemer The address able to claim the surrendered balance
-    ///        back if the redemption times out.
-    /// @param redeemerOutputScript The redeemer's length-prefixed output
-    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
-    function requestReservedRedemption(
-        uint256 reservationKey,
-        address redeemer,
-        bytes calldata redeemerOutputScript
-    ) external {
-        // The caller is checked in the library function.
-        self.requestReservedRedemption(
-            reservationKey,
-            redeemer,
-            redeemerOutputScript
-        );
-    }
-
-    /// @notice Notifies that a pending reserved redemption has timed out.
-    ///         Returns the surrendered balance to the redeemer, slashes the
-    ///         wallet operators like a regular redemption timeout, and
-    ///         returns the reservation to the Active state. See
-    ///         `Reservation.notifyReservedRedemptionTimeout`.
-    /// @param reservationKey The key of the reservation with the timed out
-    ///        redemption.
-    /// @param walletMembersIDs Identifiers of the wallet signing group
-    ///        members.
-    function notifyReservedRedemptionTimeout(
-        uint256 reservationKey,
-        uint32[] calldata walletMembersIDs
-    ) external {
-        self.notifyReservedRedemptionTimeout(reservationKey, walletMembersIDs);
-    }
-
-    /// @notice Notifies that a pending reserved redemption was vetoed in the
-    ///         redemption watchtower. Detains the surrendered balance to the
-    ///         watchtower and returns the reservation to the Active state.
-    ///         See `Reservation.notifyReservedRedemptionVeto`.
-    /// @param reservationKey The key of the reservation with the vetoed
-    ///        redemption.
-    function notifyReservedRedemptionVeto(uint256 reservationKey) external {
-        // The caller is checked in the library function.
-        self.notifyReservedRedemptionVeto(reservationKey);
     }
 
     /// @notice Submits the moving funds target wallets commitment.
@@ -2234,84 +2081,74 @@ contract Bridge is
         self.notifyRedemptionVeto(walletPubKeyHash, redeemerOutputScript);
     }
 
-    /// @notice Updates parameters of reservations, including the
-    ///         reservation vault address. Deposits revealed with the
-    ///         reservation vault address are treated as UTXO reservations.
-    /// @param reservationVault Address of the reservation vault. Can only be
-    ///        changed while there are no active reservations.
-    /// @param reservationMinAmount New value of the reservation minimum
-    ///        amount in satoshis. It is the minimal anchor output amount
-    ///        accepted for a reservation.
-    /// @param reservationTxMaxFee New value of the reservation transaction
-    ///        max fee in satoshis. It is the maximum amount of BTC
-    ///        transaction fee that can be incurred by a single reservation
-    ///        lifecycle transaction.
-    /// @param reservationTermSeconds New value of the reservation custody
-    ///        term length in seconds.
-    /// @param reservationGracePeriod New value of the reservation grace
-    ///        period in seconds.
-    /// @param reservationMaxTotalAmount New cap on the total amount in
-    ///        satoshi locked under active reservations.
-    /// @param maxReservationsPerWallet New cap on the number of active
-    ///        reservations a single wallet can custody.
+    /// @notice Sets the reservation router: the contract holding the
+    ///         Bridge's UTXO-reservation external surface, reached through
+    ///         the fallback function below via `delegatecall`. See
+    ///         `ReservationRouter` for the architecture and its security
+    ///         invariants.
+    /// @param _reservationRouter Address of the reservation router.
     /// @dev Requirements:
     ///      - The caller must be the governance,
-    ///      - See `Reservation.updateReservationParameters` for parameter
-    ///        requirements.
-    function updateReservationParameters(
-        address reservationVault,
-        uint64 reservationMinAmount,
-        uint64 reservationTxMaxFee,
-        uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
-        uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
-    ) external onlyGovernance {
-        self.updateReservationParameters(
-            reservationVault,
-            reservationMinAmount,
-            reservationTxMaxFee,
-            reservationTermSeconds,
-            reservationGracePeriod,
-            reservationMaxTotalAmount,
-            maxReservationsPerWallet
-        );
+    ///      - The reservation router must not be already set,
+    ///      - The reservation router address must not be 0x0.
+    ///
+    ///      This function supports a one-time initialization of the router.
+    ///      Since the router executes via `delegatecall` on the Bridge
+    ///      storage, pointing it at new code is equivalent to a Bridge
+    ///      implementation change — replacing the router therefore
+    ///      deliberately requires a Bridge implementation upgrade (the
+    ///      proxy-admin ceremony), not a governance parameter update.
+    function setReservationRouter(address _reservationRouter)
+        external
+        onlyGovernance
+    {
+        self.setReservationRouter(_reservationRouter);
     }
 
-    /// @notice Collection of all reservations indexed by the deposit key of
-    ///         the underlying reserved deposit, i.e.
-    ///         `keccak256(fundingTxHash | fundingOutputIndex)`.
-    /// @param reservationKey The key of the reservation.
-    function reservations(uint256 reservationKey)
-        external
-        view
-        returns (Reservation.ReservationRequest memory)
-    {
-        return self.reservations[reservationKey];
-    }
+    /// @notice Routes calls with unmatched function selectors to the
+    ///         reservation router via `delegatecall`, executing them on the
+    ///         Bridge storage at the Bridge address. This is how the
+    ///         UTXO-reservation surface (see `ReservationRouter`) is exposed
+    ///         without growing the Bridge implementation past the EIP-170
+    ///         size limit.
+    /// @dev The router address can only be set once, by the governance, via
+    ///      `setReservationRouter`; replacing it requires a Bridge
+    ///      implementation upgrade. Calls made before the router is set
+    ///      revert. The function is deliberately not payable — the Bridge
+    ///      never accepts ETH.
+    // The fallback is intentionally a delegatecall dispatcher (the whole
+    // point of the router architecture) and intentionally not payable.
+    /* solhint-disable payable-fallback, no-complex-fallback */
+    fallback() external {
+        address reservationRouter = self.reservationRouter;
+        require(reservationRouter != address(0), "Unknown function");
 
-    /// @notice Returns the current values of Bridge reservation parameters.
-    function reservationParameters()
-        external
-        view
-        returns (
-            address reservationVault,
-            uint64 reservationMinAmount,
-            uint64 reservationTxMaxFee,
-            uint32 reservationTermSeconds,
-            uint32 reservationGracePeriod,
-            uint64 reservationMaxTotalAmount,
-            uint64 reservationTotalAmount,
-            uint32 maxReservationsPerWallet
-        )
-    {
-        reservationVault = self.reservationVault;
-        reservationMinAmount = self.reservationMinAmount;
-        reservationTxMaxFee = self.reservationTxMaxFee;
-        reservationTermSeconds = self.reservationTermSeconds;
-        reservationGracePeriod = self.reservationGracePeriod;
-        reservationMaxTotalAmount = self.reservationMaxTotalAmount;
-        reservationTotalAmount = self.reservationTotalAmount;
-        maxReservationsPerWallet = self.maxReservationsPerWallet;
+        // slither-disable-next-line assembly
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            // The router address is written exactly once by the governance
+            // via `setReservationRouter` and afterwards changeable only
+            // through a Bridge implementation upgrade, so this delegatecall
+            // target is as trusted as the Bridge implementation itself.
+            // slither-disable-next-line controlled-delegatecall
+            let result := delegatecall(
+                gas(),
+                reservationRouter,
+                0,
+                calldatasize(),
+                0,
+                0
+            )
+            returndatacopy(0, 0, returndatasize())
+            switch result
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
     }
+    /* solhint-enable payable-fallback, no-complex-fallback */
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -2090,7 +2090,8 @@ contract Bridge is
     /// @dev Requirements:
     ///      - The caller must be the governance,
     ///      - The reservation router must not be already set,
-    ///      - The reservation router address must not be 0x0.
+    ///      - The reservation router address must not be 0x0,
+    ///      - The reservation router address must contain deployed code.
     ///
     ///      This function supports a one-time initialization of the router.
     ///      Since the router executes via `delegatecall` on the Bridge

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -979,7 +979,9 @@ contract Bridge is
     ///      - `mainUtxo` components must point to the recent main UTXO
     ///        of the sweeping wallet, as currently known on the Ethereum chain.
     ///        If there is no main UTXO, this parameter is ignored,
-    ///      - The sweeping wallet must be in the Live or MovingFunds state,
+    ///      - The sweeping wallet must be in the Live, MovingFunds, or Closing
+    ///        state. A Closing wallet is returned to MovingFunds without being
+    ///        counted as Live again,
     ///      - The total Bitcoin transaction fee must be lesser or equal
     ///        to `movedFundsSweepTxMaxTotalFee` governable parameter.
     function submitMovedFundsSweepProof(

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1823,7 +1823,8 @@ contract BridgeGovernance is Ownable {
         uint32 _newReservationTermSeconds,
         uint32 _newReservationGracePeriod,
         uint64 _newReservationMaxTotalAmount,
-        uint32 _newMaxReservationsPerWallet
+        uint32 _newMaxReservationsPerWallet,
+        uint32 _newReservationActionTimeout
     ) external onlyOwner {
         reservationData.beginReservationParametersUpdate(
             _newReservationVault,
@@ -1832,7 +1833,8 @@ contract BridgeGovernance is Ownable {
             _newReservationTermSeconds,
             _newReservationGracePeriod,
             _newReservationMaxTotalAmount,
-            _newMaxReservationsPerWallet
+            _newMaxReservationsPerWallet,
+            _newReservationActionTimeout
         );
     }
 
@@ -1850,7 +1852,8 @@ contract BridgeGovernance is Ownable {
             staged.newReservationTermSeconds,
             staged.newReservationGracePeriod,
             staged.newReservationMaxTotalAmount,
-            staged.newMaxReservationsPerWallet
+            staged.newMaxReservationsPerWallet,
+            staged.newReservationActionTimeout
         );
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -291,6 +291,22 @@ contract BridgeGovernance is Ownable {
     event TreasuryUpdateStarted(address newTreasury, uint256 timestamp);
     event TreasuryUpdated(address treasury);
 
+    // Emitted by the linked BridgeGovernanceParameters library through
+    // delegatecall, hence its address is this BridgeGovernance contract.
+    // Redeclare the exact signature so governance tooling can decode it
+    // from the BridgeGovernance ABI.
+    event ReservationParametersUpdateStarted(
+        address newReservationVault,
+        uint64 newReservationMinAmount,
+        uint64 newReservationTxMaxFee,
+        uint32 newReservationTermSeconds,
+        uint32 newReservationGracePeriod,
+        uint64 newReservationMaxTotalAmount,
+        uint32 newMaxReservationsPerWallet,
+        uint32 newReservationActionTimeout,
+        uint256 timestamp
+    );
+
     constructor(Bridge _bridge, uint256 _governanceDelay) {
         bridge = _bridge;
         governanceDelays[0] = _governanceDelay;

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -19,6 +19,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "./BridgeGovernanceParameters.sol";
 
 import "./Bridge.sol";
+import "./IReservationBridge.sol";
 
 /// @title Bridge Governance
 /// @notice Owns the `Bridge` contract and is responsible for updating
@@ -1842,7 +1843,7 @@ contract BridgeGovernance is Ownable {
         BridgeGovernanceParameters.ReservationData
             memory staged = reservationData;
         reservationData.finalizeReservationParametersUpdate(governanceDelay());
-        bridge.updateReservationParameters(
+        IReservationBridge(address(bridge)).updateReservationParameters(
             staged.newReservationVault,
             staged.newReservationMinAmount,
             staged.newReservationTxMaxFee,

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -1580,6 +1580,7 @@ library BridgeGovernanceParameters {
         uint32 newReservationGracePeriod;
         uint64 newReservationMaxTotalAmount;
         uint32 newMaxReservationsPerWallet;
+        uint32 newReservationActionTimeout;
         uint256 reservationParametersChangeInitiated;
     }
 
@@ -1591,6 +1592,7 @@ library BridgeGovernanceParameters {
         uint32 newReservationGracePeriod,
         uint64 newReservationMaxTotalAmount,
         uint32 newMaxReservationsPerWallet,
+        uint32 newReservationActionTimeout,
         uint256 timestamp
     );
 
@@ -1605,7 +1607,8 @@ library BridgeGovernanceParameters {
         uint32 _newReservationTermSeconds,
         uint32 _newReservationGracePeriod,
         uint64 _newReservationMaxTotalAmount,
-        uint32 _newMaxReservationsPerWallet
+        uint32 _newMaxReservationsPerWallet,
+        uint32 _newReservationActionTimeout
     ) external {
         /* solhint-disable not-rely-on-time */
         self.newReservationVault = _newReservationVault;
@@ -1615,6 +1618,7 @@ library BridgeGovernanceParameters {
         self.newReservationGracePeriod = _newReservationGracePeriod;
         self.newReservationMaxTotalAmount = _newReservationMaxTotalAmount;
         self.newMaxReservationsPerWallet = _newMaxReservationsPerWallet;
+        self.newReservationActionTimeout = _newReservationActionTimeout;
         self.reservationParametersChangeInitiated = block.timestamp;
         emit ReservationParametersUpdateStarted(
             _newReservationVault,
@@ -1624,6 +1628,7 @@ library BridgeGovernanceParameters {
             _newReservationGracePeriod,
             _newReservationMaxTotalAmount,
             _newMaxReservationsPerWallet,
+            _newReservationActionTimeout,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -30,14 +30,19 @@ import "../bank/Bank.sol";
 
 library BridgeState {
     /// @notice Reveal-time facts for a deposit routed to the reservation
-    ///         vault. Both fields fit in one storage word.
+    ///         vault. All fields fit in one storage word.
     struct PendingReservedDeposit {
         // Wallet committed by the deposit script and therefore the only
         // wallet that can be authorized to anchor the deposit.
         bytes20 walletPubKeyHash;
-        // Exact Bitcoin refund locktime validated at reveal time. Zero is a
-        // sentinel used when the reveal-ahead validation was disabled.
+        // Exact Bitcoin refund locktime decoded at reveal time. Reserved
+        // deposits retain it even when reveal-ahead validation is disabled,
+        // because acceptance must enforce the validator's refund margin.
         uint32 refundDeadline;
+        // True if the global reveal-ahead policy validated the deadline.
+        // Later stale cleanup uses this bit to preserve the disabled policy's
+        // historical behavior; acceptance always uses the exact deadline.
+        bool refundDeadlineValidated;
     }
 
     struct Storage {

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -924,7 +924,8 @@ library BridgeState {
     /// @param _reservationRouter Address of the reservation router.
     /// @dev Requirements:
     ///      - Reservation router address must not be already set,
-    ///      - Reservation router address must not be 0x0.
+    ///      - Reservation router address must not be 0x0,
+    ///      - Reservation router address must contain deployed code.
     ///
     ///      This function is designed to support a one-time initialization
     ///      of the reservation router. The router is a `delegatecall`
@@ -943,6 +944,10 @@ library BridgeState {
         require(
             _reservationRouter != address(0),
             "Reservation router address must not be 0x0"
+        );
+        require(
+            _reservationRouter.code.length > 0,
+            "Reservation router must be a contract"
         );
 
         self.reservationRouter = _reservationRouter;

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -31,7 +31,7 @@ import "../bank/Bank.sol";
 library BridgeState {
     /// @notice Reveal-time facts for a deposit routed to the reservation
     ///         vault. Both fields fit in one storage word.
-    struct ReservedDepositInfo {
+    struct PendingReservedDeposit {
         // Wallet committed by the deposit script and therefore the only
         // wallet that can be authorized to anchor the deposit.
         bytes20 walletPubKeyHash;
@@ -408,7 +408,7 @@ library BridgeState {
         // Reveal-time facts for deposits routed to the reservation vault.
         // The exact refund deadline is immutable even when governance later
         // changes `depositRevealAheadPeriod`.
-        mapping(uint256 => ReservedDepositInfo) reservedDeposits;
+        mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -29,6 +29,17 @@ import "./MovingFunds.sol";
 import "../bank/Bank.sol";
 
 library BridgeState {
+    /// @notice Reveal-time facts for a deposit routed to the reservation
+    ///         vault. Both fields fit in one storage word.
+    struct ReservedDepositInfo {
+        // Wallet committed by the deposit script and therefore the only
+        // wallet that can be authorized to anchor the deposit.
+        bytes20 walletPubKeyHash;
+        // Exact Bitcoin refund locktime validated at reveal time. Zero is a
+        // sentinel used when the reveal-ahead validation was disabled.
+        uint32 refundDeadline;
+    }
+
     struct Storage {
         // Address of the Bank the Bridge belongs to.
         Bank bank;
@@ -394,6 +405,10 @@ library BridgeState {
         // dissolutions of a no-main-UTXO wallet could all confirm on
         // Bitcoin with only the first being provable.
         mapping(bytes20 => uint256) walletPendingDissolution;
+        // Reveal-time facts for deposits routed to the reservation vault.
+        // The exact refund deadline is immutable even when governance later
+        // changes `depositRevealAheadPeriod`.
+        mapping(uint256 => ReservedDepositInfo) reservedDeposits;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -44,8 +44,10 @@ library BridgeState {
         // because acceptance must enforce the validator's refund margin.
         uint32 refundDeadline;
         // True if the global reveal-ahead policy validated the deadline.
-        // Later stale cleanup uses this bit to preserve the disabled policy's
-        // historical behavior; acceptance always uses the exact deadline.
+        // Reserved for the planned stale-deposit marking path (RFC 13),
+        // which will use this bit to preserve the disabled policy's
+        // historical behavior; currently stored but not consulted by the
+        // acceptance path, which always uses the exact deadline.
         bool refundDeadlineValidated;
     }
 

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -366,6 +366,14 @@ library BridgeState {
         // The number of active reservations custodied by the given wallet,
         // identified by its 20-byte wallet public key hash.
         mapping(bytes20 => uint32) walletReservationsCount;
+        // Address of the reservation router: the delegatecall extension of
+        // the Bridge holding the UTXO-reservation external surface. The
+        // Bridge's fallback function routes calls with unmatched selectors
+        // to this address. Set exactly once via governance; changing it
+        // afterwards requires a Bridge implementation upgrade, as pointing
+        // the fallback delegatecall at new code is equivalent to a Bridge
+        // implementation change.
+        address reservationRouter;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -373,7 +381,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[43] __gap;
+        uint256[42] __gap;
     }
 
     event DepositParametersUpdated(
@@ -427,6 +435,8 @@ library BridgeState {
     event TreasuryUpdated(address treasury);
 
     event RedemptionWatchtowerSet(address redemptionWatchtower);
+
+    event ReservationRouterSet(address reservationRouter);
 
     // Event emitted when the rebate staking address is initialized. Declared
     // in this library as the event is emitted from within `BridgeState` and
@@ -908,6 +918,35 @@ library BridgeState {
 
         self.redemptionWatchtower = _redemptionWatchtower;
         emit RedemptionWatchtowerSet(_redemptionWatchtower);
+    }
+
+    /// @notice Sets the reservation router address.
+    /// @param _reservationRouter Address of the reservation router.
+    /// @dev Requirements:
+    ///      - Reservation router address must not be already set,
+    ///      - Reservation router address must not be 0x0.
+    ///
+    ///      This function is designed to support a one-time initialization
+    ///      of the reservation router. The router is a `delegatecall`
+    ///      extension of the Bridge, so changing it after it is set is
+    ///      equivalent to changing the Bridge implementation and requires
+    ///      a dedicated upgrade path.
+    function setReservationRouter(
+        Storage storage self,
+        address _reservationRouter
+    ) internal {
+        require(
+            self.reservationRouter == address(0),
+            "Reservation router already set"
+        );
+
+        require(
+            _reservationRouter != address(0),
+            "Reservation router address must not be 0x0"
+        );
+
+        self.reservationRouter = _reservationRouter;
+        emit ReservationRouterSet(_reservationRouter);
     }
 
     /// @notice Sets the rebate staking address.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -374,6 +374,26 @@ library BridgeState {
         // the fallback delegatecall at new code is equivalent to a Bridge
         // implementation change.
         address reservationRouter;
+        // Time in seconds after which a requested reservation action
+        // (acceptance anchor, re-anchor, dissolution) can be reported
+        // timed out. Reserved redemptions use `redemptionTimeout` instead.
+        // Snapshotted into each action record at request time.
+        uint32 reservationActionTimeout;
+        // Collection of all reservation action generation records indexed
+        // by `keccak256(reservationKey | requestNonce)`. Each record
+        // snapshots every proof- and settlement-critical parameter of one
+        // requested action generation. Terminal records (TimedOut, Vetoed,
+        // Superseded, Settled) are never deleted: timed-out generations
+        // must keep accepting late proofs of their confirmed Bitcoin
+        // transactions.
+        mapping(uint256 => Reservation.ReservationAction) reservationActions;
+        // Per-wallet main-UTXO action lock: maps the 20-byte wallet public
+        // key hash to the reservation key of the wallet's in-flight
+        // dissolution, or zero when none is pending. At most one
+        // dissolution per wallet may be in flight — concurrent
+        // dissolutions of a no-main-UTXO wallet could all confirm on
+        // Bitcoin with only the first being provable.
+        mapping(bytes20 => uint256) walletPendingDissolution;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -381,7 +401,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[42] __gap;
+        uint256[39] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -207,8 +207,12 @@ library Deposit {
             "Vault is not trusted"
         );
 
+        uint32 refundDeadline;
         if (self.depositRevealAheadPeriod > 0) {
-            validateDepositRefundLocktime(self, reveal.refundLocktime);
+            refundDeadline = validateDepositRefundLocktime(
+                self,
+                reveal.refundLocktime
+            );
         }
 
         bytes memory expectedScript;
@@ -317,13 +321,12 @@ library Deposit {
             )
             .hash256View();
 
-        DepositRequest storage deposit = self.deposits[
-            uint256(
-                keccak256(
-                    abi.encodePacked(fundingTxHash, reveal.fundingOutputIndex)
-                )
+        uint256 depositKey = uint256(
+            keccak256(
+                abi.encodePacked(fundingTxHash, reveal.fundingOutputIndex)
             )
-        ];
+        );
+        DepositRequest storage deposit = self.deposits[depositKey];
         require(deposit.revealedAt == 0, "Deposit already revealed");
 
         uint64 fundingOutputAmount = fundingOutput.extractValue();
@@ -350,6 +353,15 @@ library Deposit {
                     deposit.treasuryFee,
                     RebateStaking.TreasuryFeeType.Deposit
                 );
+        }
+
+        if (
+            reveal.vault != address(0) && reveal.vault == self.reservationVault
+        ) {
+            self.reservedDeposits[depositKey] = BridgeState.ReservedDepositInfo(
+                reveal.walletPubKeyHash,
+                refundDeadline
+            );
         }
 
         _emitDepositRevealedEvent(fundingTxHash, fundingOutputAmount, reveal);
@@ -426,10 +438,10 @@ library Deposit {
     function validateDepositRefundLocktime(
         BridgeState.Storage storage self,
         bytes4 refundLocktime
-    ) internal view {
+    ) internal view returns (uint32 depositRefundableTimestamp) {
         // Convert the refund locktime byte array to a LE integer. This is
         // the moment in time when the deposit become refundable.
-        uint32 depositRefundableTimestamp = BTCUtils.reverseUint32(
+        depositRefundableTimestamp = BTCUtils.reverseUint32(
             uint32(refundLocktime)
         );
         // According to https://developer.bitcoin.org/devguide/transactions.html#locktime-and-sequence-number
@@ -450,5 +462,7 @@ library Deposit {
                 depositRefundableTimestamp,
             "Deposit refund locktime is too close"
         );
+
+        return depositRefundableTimestamp;
     }
 }

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -443,6 +443,10 @@ library Deposit {
     ///         earlier than the moment when the deposit refund locktime is
     ///         reached, i.e. the deposit become refundable. Reverts otherwise.
     /// @param refundLocktime The deposit refund locktime as 4-byte LE.
+    /// @return depositRefundableTimestamp The decoded refund locktime as a
+    ///         Unix timestamp (the moment the deposit becomes refundable),
+    ///         reused by the reserved-deposit acceptance flow as the
+    ///         authorization upper bound.
     /// @dev Requirements:
     ///      - `refundLocktime` as integer must be >= 500M
     ///      - `refundLocktime` must denote a timestamp that is at least

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -207,11 +207,23 @@ library Deposit {
             "Vault is not trusted"
         );
 
+        bool isReservedDeposit = reveal.vault != address(0) &&
+            reveal.vault == self.reservationVault;
         uint32 refundDeadline = 0;
+        bool refundDeadlineValidated = false;
         if (self.depositRevealAheadPeriod > 0) {
             refundDeadline = validateDepositRefundLocktime(
                 self,
                 reveal.refundLocktime
+            );
+            refundDeadlineValidated = true;
+        } else if (isReservedDeposit) {
+            // Ordinary deposits preserve the historical disabled-validation
+            // path. Reserved deposits still need the exact script deadline
+            // so a permissionless acceptance request cannot reserve capacity
+            // for an action the wallet validator can never sign.
+            refundDeadline = BTCUtils.reverseUint32(
+                uint32(reveal.refundLocktime)
             );
         }
 
@@ -355,13 +367,12 @@ library Deposit {
                 );
         }
 
-        if (
-            reveal.vault != address(0) && reveal.vault == self.reservationVault
-        ) {
+        if (isReservedDeposit) {
             self.pendingReservedDeposit[depositKey] = BridgeState
                 .PendingReservedDeposit(
                     reveal.walletPubKeyHash,
-                    refundDeadline
+                    refundDeadline,
+                    refundDeadlineValidated
                 );
         }
 

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -207,7 +207,7 @@ library Deposit {
             "Vault is not trusted"
         );
 
-        uint32 refundDeadline;
+        uint32 refundDeadline = 0;
         if (self.depositRevealAheadPeriod > 0) {
             refundDeadline = validateDepositRefundLocktime(
                 self,

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -358,10 +358,11 @@ library Deposit {
         if (
             reveal.vault != address(0) && reveal.vault == self.reservationVault
         ) {
-            self.reservedDeposits[depositKey] = BridgeState.ReservedDepositInfo(
-                reveal.walletPubKeyHash,
-                refundDeadline
-            );
+            self.pendingReservedDeposit[depositKey] = BridgeState
+                .PendingReservedDeposit(
+                    reveal.walletPubKeyHash,
+                    refundDeadline
+                );
         }
 
         _emitDepositRevealedEvent(fundingTxHash, fundingOutputAmount, reveal);

--- a/solidity/contracts/bridge/DepositSweep.sol
+++ b/solidity/contracts/bridge/DepositSweep.sol
@@ -242,6 +242,7 @@ library DepositSweep {
         wallet.mainUtxoHash = keccak256(
             abi.encodePacked(sweepTxHash, uint32(0), sweepTxOutputValue)
         );
+        Wallets.rearmMovingFundsTimeout(self, walletPubKeyHash);
 
         // slither-disable-next-line reentrancy-events
         emit DepositsSwept(walletPubKeyHash, sweepTxHash);

--- a/solidity/contracts/bridge/IReservationBridge.sol
+++ b/solidity/contracts/bridge/IReservationBridge.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "./Reservation.sol";
+
+/// @notice Interface of the UTXO-reservation surface observable at the
+///         Bridge address. The functions listed here are implemented by the
+///         `ReservationRouter` and reached through the Bridge's fallback via
+///         `delegatecall`, so callers use this interface against the Bridge
+///         address itself — the Bridge contract type does not declare them.
+interface IReservationBridge {
+    /// @notice See `ReservationRouter.requestReservedRedemption`.
+    function requestReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript
+    ) external;
+
+    /// @notice See `ReservationRouter.extendReservation`.
+    function extendReservation(uint256 reservationKey) external;
+
+    /// @notice See `ReservationRouter.notifyReservedRedemptionVeto`.
+    function notifyReservedRedemptionVeto(uint256 reservationKey) external;
+
+    /// @notice See `ReservationRouter.updateReservationParameters`.
+    function updateReservationParameters(
+        address reservationVault,
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    ) external;
+
+    /// @notice Bridge treasury address. Declared by the Bridge contract
+    ///         itself (not the router); included here so reservation
+    ///         consumers can use a single interface against the Bridge
+    ///         address.
+    function treasury() external view returns (address);
+
+    /// @notice See `ReservationRouter.reservations`.
+    function reservations(uint256 reservationKey)
+        external
+        view
+        returns (Reservation.ReservationRequest memory);
+
+    /// @notice See `ReservationRouter.reservationParameters`.
+    function reservationParameters()
+        external
+        view
+        returns (
+            address reservationVault,
+            uint64 reservationMinAmount,
+            uint64 reservationTxMaxFee,
+            uint32 reservationTermSeconds,
+            uint32 reservationGracePeriod,
+            uint64 reservationMaxTotalAmount,
+            uint64 reservationTotalAmount,
+            uint32 maxReservationsPerWallet
+        );
+}

--- a/solidity/contracts/bridge/IReservationBridge.sol
+++ b/solidity/contracts/bridge/IReservationBridge.sol
@@ -23,18 +23,44 @@ import "./Reservation.sol";
 ///         `delegatecall`, so callers use this interface against the Bridge
 ///         address itself — the Bridge contract type does not declare them.
 interface IReservationBridge {
+    /// @notice See `ReservationRouter.requestReservationAcceptance`.
+    function requestReservationAcceptance(
+        uint256 reservationKey,
+        bytes20 walletPubKeyHash
+    ) external;
+
     /// @notice See `ReservationRouter.requestReservedRedemption`.
     function requestReservedRedemption(
         uint256 reservationKey,
         address redeemer,
-        bytes calldata redeemerOutputScript
+        bytes calldata redeemerOutputScript,
+        bool feePaid,
+        bool useRetryCredit
+    ) external;
+
+    /// @notice See `ReservationRouter.requestReservationReanchor`.
+    function requestReservationReanchor(
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash
+    ) external;
+
+    /// @notice See `ReservationRouter.requestReservationDissolution`.
+    function requestReservationDissolution(uint256 reservationKey) external;
+
+    /// @notice See `ReservationRouter.notifyReservationActionTimeout`.
+    function notifyReservationActionTimeout(
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
     ) external;
 
     /// @notice See `ReservationRouter.extendReservation`.
     function extendReservation(uint256 reservationKey) external;
 
     /// @notice See `ReservationRouter.notifyReservedRedemptionVeto`.
-    function notifyReservedRedemptionVeto(uint256 reservationKey) external;
+    function notifyReservedRedemptionVeto(
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external;
 
     /// @notice See `ReservationRouter.updateReservationParameters`.
     function updateReservationParameters(
@@ -44,7 +70,8 @@ interface IReservationBridge {
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint32 reservationActionTimeout
     ) external;
 
     /// @notice Bridge treasury address. Declared by the Bridge contract
@@ -59,6 +86,12 @@ interface IReservationBridge {
         view
         returns (Reservation.ReservationRequest memory);
 
+    /// @notice See `ReservationRouter.reservationActions`.
+    function reservationActions(uint256 reservationKey, uint64 requestNonce)
+        external
+        view
+        returns (Reservation.ReservationAction memory);
+
     /// @notice See `ReservationRouter.reservationParameters`.
     function reservationParameters()
         external
@@ -71,6 +104,7 @@ interface IReservationBridge {
             uint32 reservationGracePeriod,
             uint64 reservationMaxTotalAmount,
             uint64 reservationTotalAmount,
-            uint32 maxReservationsPerWallet
+            uint32 maxReservationsPerWallet,
+            uint32 reservationActionTimeout
         );
 }

--- a/solidity/contracts/bridge/IReservationBridge.sol
+++ b/solidity/contracts/bridge/IReservationBridge.sol
@@ -47,6 +47,16 @@ interface IReservationBridge {
     /// @notice See `ReservationRouter.requestReservationDissolution`.
     function requestReservationDissolution(uint256 reservationKey) external;
 
+    /// @notice See `ReservationRouter.submitReservationProof`.
+    function submitReservationProof(
+        uint8 proofType,
+        BitcoinTx.Info calldata txInfo,
+        BitcoinTx.Proof calldata proof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external;
+
     /// @notice See `ReservationRouter.notifyReservationActionTimeout`.
     function notifyReservationActionTimeout(
         uint256 reservationKey,

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -136,6 +136,8 @@ library MovingFunds {
     ///        wallets that the source wallet commits to move the funds to.
     /// @dev Requirements:
     ///      - The source wallet must be in the MovingFunds state,
+    ///      - The source wallet's current moving-funds generation must not be
+    ///        already completed,
     ///      - The source wallet must not have pending redemption requests,
     ///      - The source wallet must not have pending moved funds sweep requests,
     ///      - The source wallet must not have submitted its commitment already,
@@ -176,6 +178,11 @@ library MovingFunds {
         require(
             wallet.state == Wallets.WalletState.MovingFunds,
             "Source wallet must be in MovingFunds state"
+        );
+
+        require(
+            wallet.movingFundsRequestedAt != 0,
+            "Moving funds process already completed"
         );
 
         require(
@@ -267,6 +274,8 @@ library MovingFunds {
     /// @param walletPubKeyHash 20-byte public key hash of the moving funds wallet
     /// @dev Requirements:
     ///      - The wallet must be in the MovingFunds state,
+    ///      - The wallet's current moving-funds generation must not be already
+    ///        completed,
     ///      - The target wallets commitment must not be already submitted for
     ///        the given moving funds wallet,
     ///      - Live wallets count must be zero,
@@ -282,6 +291,11 @@ library MovingFunds {
         require(
             wallet.state == Wallets.WalletState.MovingFunds,
             "Wallet must be in MovingFunds state"
+        );
+
+        require(
+            wallet.movingFundsRequestedAt != 0,
+            "Moving funds process already completed"
         );
 
         // If the moving funds wallet already submitted their target wallets
@@ -497,10 +511,10 @@ library MovingFunds {
             // by the target wallet. The target wallet must sweep the
             // received funds with their own main UTXO in order to update
             // their BTC balance. Worth noting there is no need to check
-            // if the sweep request already exists in the system because
-            // the moving funds wallet is moved to the Closing state after
-            // submitting the moving funds proof so there is no possibility
-            // to submit the proof again and register the sweep request twice.
+            // if the sweep request already exists in the system because the
+            // successfully proven source main UTXO is deleted. Even when
+            // other tracked obligations retain MovingFunds, the same proof
+            // therefore cannot register the request twice.
             self.movedFundsSweepRequests[
                 uint256(
                     keccak256(
@@ -569,11 +583,19 @@ library MovingFunds {
         bytes20 walletPubKeyHash,
         uint32[] calldata walletMembersIDs
     ) external {
-        // Wallet state is validated in `notifyWalletMovingFundsTimeout`.
+        Wallets.Wallet storage wallet = self.registeredWallets[
+            walletPubKeyHash
+        ];
+        require(
+            wallet.state == Wallets.WalletState.MovingFunds,
+            "Wallet must be in MovingFunds state"
+        );
 
-        uint32 movingFundsRequestedAt = self
-            .registeredWallets[walletPubKeyHash]
-            .movingFundsRequestedAt;
+        uint32 movingFundsRequestedAt = wallet.movingFundsRequestedAt;
+        require(
+            movingFundsRequestedAt != 0,
+            "Moving funds process already completed"
+        );
 
         require(
             /* solhint-disable-next-line not-rely-on-time */
@@ -661,7 +683,9 @@ library MovingFunds {
     ///      - `mainUtxo` components must point to the recent main UTXO
     ///        of the sweeping wallet, as currently known on the Ethereum chain.
     ///        If there is no main UTXO, this parameter is ignored,
-    ///      - The sweeping wallet must be in the Live or MovingFunds state,
+    ///      - The sweeping wallet must be in the Live, MovingFunds, or Closing
+    ///        state. A Closing wallet is returned to MovingFunds without being
+    ///        counted as Live again,
     ///      - The total Bitcoin transaction fee must be lesser or equal
     ///        to `movedFundsSweepTxMaxTotalFee` governable parameter.
     function submitMovedFundsSweepProof(
@@ -708,6 +732,7 @@ library MovingFunds {
         wallet.mainUtxoHash = keccak256(
             abi.encodePacked(sweepTxHash, uint32(0), sweepTxOutputValue)
         );
+        Wallets.rearmMovingFundsTimeout(self, walletPubKeyHash);
 
         // slither-disable-next-line reentrancy-events
         emit MovedFundsSwept(walletPubKeyHash, sweepTxHash);
@@ -768,7 +793,9 @@ library MovingFunds {
     ///         the chain state. If the validation went well, this is the
     ///         plain-text main UTXO corresponding to the `wallet.mainUtxoHash`.
     /// @dev Requirements:
-    ///     - Sweeping wallet must be either in Live or MovingFunds state,
+    ///     - Sweeping wallet must be in Live, MovingFunds, or Closing state.
+    ///       A Closing wallet is reactivated with a fresh moving-funds
+    ///       deadline; its Live-wallet count is not changed,
     ///     - If the main UTXO of the sweeping wallet exists in the storage,
     ///       the passed `mainUTXO` parameter must be equal to the stored one.
     function resolveMovedFundsSweepingWallet(
@@ -777,7 +804,6 @@ library MovingFunds {
         BitcoinTx.UTXO calldata mainUtxo
     )
         internal
-        view
         returns (
             Wallets.Wallet storage wallet,
             BitcoinTx.UTXO memory resolvedMainUtxo
@@ -788,9 +814,19 @@ library MovingFunds {
         Wallets.WalletState walletState = wallet.state;
         require(
             walletState == Wallets.WalletState.Live ||
-                walletState == Wallets.WalletState.MovingFunds,
-            "Wallet must be in Live or MovingFunds state"
+                walletState == Wallets.WalletState.MovingFunds ||
+                walletState == Wallets.WalletState.Closing,
+            "Wallet must be in Live or MovingFunds or Closing state"
         );
+
+        if (walletState == Wallets.WalletState.Closing) {
+            wallet.state = Wallets.WalletState.MovingFunds;
+            delete wallet.movingFundsRequestedAt;
+            delete wallet.closingStartedAt;
+            // Closing wallets from earlier generations may retain a stale
+            // commitment. It must not constrain the freshly rearmed process.
+            delete wallet.movingFundsTargetWalletsCommitmentHash;
+        }
 
         // Check if the main UTXO for given wallet exists. If so, validate
         // passed main UTXO data against the stored hash and use them for
@@ -1017,8 +1053,8 @@ library MovingFunds {
     /// @dev Requirements:
     ///      - The moved funds sweep request must be in the Pending state,
     ///      - The moved funds sweep timeout must be actually exceeded,
-    ///      - The wallet must be either in the Live or MovingFunds or
-    ///        Terminated state,,
+    ///      - The wallet must be in the Live, MovingFunds, Closing, Closed,
+    ///        or Terminated state,
     ///      - The expression `keccak256(abi.encode(walletMembersIDs))` must
     ///        be exactly the same as the hash stored under `membersIdsHash`
     ///        for the given `walletID`. Those IDs are not directly stored

--- a/solidity/contracts/bridge/MovingFunds.sol
+++ b/solidity/contracts/bridge/MovingFunds.sol
@@ -595,6 +595,8 @@ library MovingFunds {
     ///        on the Ethereum chain.
     /// @dev Requirements:
     ///      - The wallet must be in the MovingFunds state,
+    ///      - The wallet must not custody reservation anchors or have pending
+    ///        moved-funds sweep requests,
     ///      - The `mainUtxo` components must point to the recent main UTXO
     ///        of the given wallet, as currently known on the Ethereum chain.
     ///        If the wallet has no main UTXO, this parameter can be empty as it

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -64,9 +64,10 @@ interface IRedemptionWatchtower {
         returns (uint32);
 
     /// @notice Returns the applicable veto delay for the given pending
-    ///         reserved redemption generation. Zero when the watchtower is
-    ///         not enabled (no guardians can object) or was permanently
-    ///         disabled.
+    ///         reserved redemption generation, selected from the immutable
+    ///         schedule captured when the generation was requested. A
+    ///         permanently disabled watchtower overrides the snapshot with
+    ///         zero.
     /// @param reservationKey The key of the reservation.
     /// @param requestNonce The redemption generation.
     /// @return Reserved redemption veto delay.
@@ -74,6 +75,23 @@ interface IRedemptionWatchtower {
         uint256 reservationKey,
         uint64 requestNonce
     ) external view returns (uint32);
+
+    /// @notice Returns the current three-level veto delay schedule to
+    ///         snapshot for a newly requested reserved redemption. All
+    ///         values are zero when the watchtower is not enabled, has been
+    ///         disabled, or the amount is waived.
+    /// @param requestedAmount Reserved redemption amount in satoshis.
+    /// @return defaultDelay Delay before any guardian objection.
+    /// @return levelOneDelay Delay after one guardian objection.
+    /// @return levelTwoDelay Delay after two guardian objections.
+    function getReservedRedemptionDelaySchedule(uint64 requestedAmount)
+        external
+        view
+        returns (
+            uint32 defaultDelay,
+            uint32 levelOneDelay,
+            uint32 levelTwoDelay
+        );
 
     /// @notice Determines whether a reserved redemption request is
     ///         considered safe: neither the reservation owner nor the

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -63,14 +63,31 @@ interface IRedemptionWatchtower {
         view
         returns (uint32);
 
-    /// @notice Returns the applicable veto delay for a pending reserved
-    ///         redemption identified by the given reservation key.
+    /// @notice Returns the applicable veto delay for the given pending
+    ///         reserved redemption generation. Zero when the watchtower is
+    ///         not enabled (no guardians can object) or was permanently
+    ///         disabled.
     /// @param reservationKey The key of the reservation.
+    /// @param requestNonce The redemption generation.
     /// @return Reserved redemption veto delay.
-    function getReservedRedemptionDelay(uint256 reservationKey)
+    function getReservedRedemptionDelay(
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external view returns (uint32);
+
+    /// @notice Determines whether a reserved redemption request is
+    ///         considered safe: neither the reservation owner nor the
+    ///         redeemer may be banned. Objection state is per generation,
+    ///         so — unlike the pooled `isSafeRedemption` — no historical
+    ///         objection count is consulted: a fresh generation always
+    ///         starts with a clean count.
+    /// @param owner The reservation owner.
+    /// @param redeemer The address requesting the redemption.
+    /// @return True if the reserved redemption request is safe.
+    function isSafeReservedRedemption(address owner, address redeemer)
         external
         view
-        returns (uint32);
+        returns (bool);
 }
 
 /// @notice Aggregates functions common to the redemption transaction proof

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -19,6 +19,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 import "./Bridge.sol";
 import "./Redemption.sol";
+import "./IReservationBridge.sol";
 import "./Reservation.sol";
 
 /// @title Redemption watchtower
@@ -440,9 +441,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         );
         require(!objections[objectionKey], "Guardian already objected");
 
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
-            reservationKey
-        );
+        Reservation.ReservationRequest memory reservation = IReservationBridge(
+            address(bridge)
+        ).reservations(reservationKey);
 
         require(
             reservation.state ==
@@ -488,7 +489,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             // Notify the Bridge about the veto. As result of this call,
             // this contract receives the surrendered gross amount
             // (as Bank's balance) from the Bridge.
-            bridge.notifyReservedRedemptionVeto(reservationKey);
+            IReservationBridge(address(bridge)).notifyReservedRedemptionVeto(
+                reservationKey
+            );
             // Burn the penalty fee but leave the claimable amount for the
             // redeemer to withdraw after the freeze period.
             bank.decreaseBalance(penaltyFee);
@@ -505,9 +508,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         view
         returns (uint32)
     {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
-            reservationKey
-        );
+        Reservation.ReservationRequest memory reservation = IReservationBridge(
+            address(bridge)
+        ).reservations(reservationKey);
 
         require(
             reservation.state ==

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -138,14 +138,21 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
     event GuardianRemoved(address indexed guardian);
 
+    // `vetoKey` is either the pooled redemption key
+    // (`keccak256(keccak256(redeemerOutputScript), walletPubKeyHash)`) or
+    // the reserved veto key (`reservedVetoKey(reservationKey,
+    // requestNonce)`), depending on which path raised the objection.
+    // Collision between the two key spaces is cryptographically
+    // infeasible (different preimage lengths); indexers distinguish them
+    // by cross-referencing whichever Bridge event accompanies them.
     event ObjectionRaised(
-        uint256 indexed redemptionKey,
+        uint256 indexed vetoKey,
         address indexed guardian
     );
 
-    event VetoPeriodCheckOmitted(uint256 indexed redemptionKey);
+    event VetoPeriodCheckOmitted(uint256 indexed vetoKey);
 
-    event VetoFinalized(uint256 indexed redemptionKey);
+    event VetoFinalized(uint256 indexed vetoKey);
 
     event WatchtowerParametersUpdated(
         uint32 watchtowerLifetime,
@@ -444,6 +451,13 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     ///      - The generation must be within the veto delay snapshotted for
     ///        its current objection level; a permanently disabled watchtower
     ///        makes the effective delay zero.
+    ///      Deliberate divergence from the pooled path: a generation
+    ///      requested before the watchtower was ever enabled snapshots an
+    ///      all-zero delay schedule and can therefore never be objected to
+    ///      (there is no `VetoPeriodCheckOmitted` escape hatch here).
+    ///      Harmless under the deployment sequencing this stack assumes
+    ///      (the watchtower is enabled before any reserved redemption is
+    ///      requested).
     function raiseReservedObjection(uint256 reservationKey, uint64 requestNonce)
         external
         onlyGuardian

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -145,10 +145,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     // Collision between the two key spaces is cryptographically
     // infeasible (different preimage lengths); indexers distinguish them
     // by cross-referencing whichever Bridge event accompanies them.
-    event ObjectionRaised(
-        uint256 indexed vetoKey,
-        address indexed guardian
-    );
+    event ObjectionRaised(uint256 indexed vetoKey, address indexed guardian);
 
     event VetoPeriodCheckOmitted(uint256 indexed vetoKey);
 

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -441,8 +441,9 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     ///      - The generation must not have been vetoed already,
     ///      - The guardian must not have already objected to it,
     ///      - The generation must be the reservation's pending redemption,
-    ///      - The generation must be within its veto delay period, unless
-    ///        it was requested before the watchtower was enabled.
+    ///      - The generation must be within the veto delay snapshotted for
+    ///        its current objection level; a permanently disabled watchtower
+    ///        makes the effective delay zero.
     function raiseReservedObjection(uint256 reservationKey, uint64 requestNonce)
         external
         onlyGuardian
@@ -470,17 +471,13 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             "Reserved redemption does not exist"
         );
 
-        if (action.requestedAt >= watchtowerEnabledAt) {
-            require(
-                /* solhint-disable-next-line not-rely-on-time */
-                block.timestamp <
-                    action.requestedAt +
-                        _redemptionDelay(veto.objectionsCount, action.amount),
-                "Redemption veto delay period expired"
-            );
-        } else {
-            emit VetoPeriodCheckOmitted(vetoKey);
-        }
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <
+                uint256(action.requestedAt) +
+                    _reservedRedemptionDelay(action, veto.objectionsCount),
+            "Redemption veto delay period expired"
+        );
 
         objections[objectionKey] = true;
         veto.redeemer = action.redeemer;
@@ -522,13 +519,15 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     /// @param reservationKey The key of the reservation.
     /// @param requestNonce The redemption generation.
     /// @return Reserved redemption veto delay.
-    /// @dev The delay is zero when the watchtower has not been enabled
-    ///      (no guardians exist, so a delay would protect nothing) or has
-    ///      been permanently disabled.
+    /// @dev The returned level is selected from the immutable schedule the
+    ///      Bridge captured when the generation was requested. A permanently
+    ///      disabled watchtower overrides every captured schedule with zero.
     function getReservedRedemptionDelay(
         uint256 reservationKey,
         uint64 requestNonce
     ) external view returns (uint32) {
+        // Preserve the pre-enable API behavior: no guardians exist, so no
+        // reservation lookup is needed to establish that the delay is zero.
         // slither-disable-next-line incorrect-equality
         if (watchtowerEnabledAt == 0) {
             return 0;
@@ -544,11 +543,73 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         );
 
         return
-            _redemptionDelay(
+            _reservedRedemptionDelay(
+                action,
                 vetoProposals[reservedVetoKey(reservationKey, requestNonce)]
-                    .objectionsCount,
-                action.amount
+                    .objectionsCount
             );
+    }
+
+    /// @notice Returns the current three-level veto delay schedule to
+    ///         snapshot for a newly requested reserved redemption.
+    /// @param requestedAmount Reserved redemption amount in satoshis.
+    /// @return reservedDefaultDelay Delay before any guardian objection.
+    /// @return reservedLevelOneDelay Delay after one guardian objection.
+    /// @return reservedLevelTwoDelay Delay after two guardian objections.
+    /// @dev Returns an all-zero schedule when no guardian veto policy applies
+    ///      at request time: the watchtower is not enabled, has been disabled,
+    ///      or the requested amount is below the waiver limit.
+    function getReservedRedemptionDelaySchedule(uint64 requestedAmount)
+        external
+        view
+        returns (
+            uint32 reservedDefaultDelay,
+            uint32 reservedLevelOneDelay,
+            uint32 reservedLevelTwoDelay
+        )
+    {
+        if (
+            // slither-disable-next-line incorrect-equality
+            watchtowerEnabledAt == 0 ||
+            watchtowerDisabledAt != 0 ||
+            requestedAmount < waivedAmountLimit
+        ) {
+            return (0, 0, 0);
+        }
+
+        return (defaultDelay, levelOneDelay, levelTwoDelay);
+    }
+
+    /// @notice Selects a reserved redemption generation's snapshotted veto
+    ///         delay for the given number of objections.
+    /// @dev A permanently disabled watchtower makes the effective delay zero
+    ///      for every generation, including those requested before shutdown.
+    function _reservedRedemptionDelay(
+        Reservation.ReservationAction memory action,
+        uint8 objectionsCount
+    ) internal view returns (uint32) {
+        if (watchtowerDisabledAt != 0) {
+            return 0;
+        }
+
+        if (
+            // slither-disable-next-line incorrect-equality
+            objectionsCount == 0
+        ) {
+            return action.watchtowerDefaultDelay;
+        } else if (
+            // slither-disable-next-line incorrect-equality
+            objectionsCount == 1
+        ) {
+            return action.watchtowerLevelOneDelay;
+        } else if (
+            // slither-disable-next-line incorrect-equality
+            objectionsCount == 2
+        ) {
+            return action.watchtowerLevelTwoDelay;
+        } else {
+            revert("No delay for given objections count");
+        }
     }
 
     /// @notice Determines whether a reserved redemption request is

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -404,32 +404,51 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         }
     }
 
+    /// @notice Computes the veto-state key of a reserved redemption
+    ///         generation. Veto and objection state is keyed per
+    ///         generation, so objections never accumulate across
+    ///         generations and a once-vetoed reservation starts every new
+    ///         generation with a clean objection count.
+    /// @param reservationKey The key of the reservation.
+    /// @param requestNonce The redemption generation.
+    function reservedVetoKey(uint256 reservationKey, uint64 requestNonce)
+        public
+        pure
+        returns (uint256)
+    {
+        return
+            uint256(keccak256(abi.encodePacked(reservationKey, requestNonce)));
+    }
+
     /// @notice Raises an objection to a pending reserved redemption
-    ///         identified by its reservation key. Works the same way as
-    ///         `raiseObjection` does for regular redemption requests: each
-    ///         pending reserved redemption has a delay period during which
-    ///         the wallet is not allowed to process it and the guardians can
-    ///         raise objections to; the third objection vetoes it. A veto
-    ///         detains the surrendered gross amount from the Bridge, freezes
-    ///         it for the freeze period, burns the penalty fee, and bans the
-    ///         redeemer. The reservation itself returns to the Active state
-    ///         on the Bridge -- the anchor outpoint was not spent, so the
-    ///         in-kind claim survives (though a banned owner cannot
-    ///         re-request until unbanned).
+    ///         generation. Works the same way as `raiseObjection` does for
+    ///         regular redemption requests: each pending reserved
+    ///         redemption has a delay period during which the wallet is not
+    ///         allowed to process it and the guardians can raise objections
+    ///         to; the third objection vetoes it. A veto detains the
+    ///         escrowed gross amount from the Bridge, freezes it for the
+    ///         freeze period, burns the penalty fee, and bans the redeemer.
+    ///         The reservation itself returns to the Active state on the
+    ///         Bridge -- the anchor outpoint was not spent, so the in-kind
+    ///         claim survives (though a banned owner cannot re-request
+    ///         until unbanned). The vetoed generation never accepts an SPV
+    ///         proof.
     /// @param reservationKey The key of the reservation with the pending
     ///        reserved redemption.
+    /// @param requestNonce The pending redemption generation.
     /// @dev Requirements:
     ///      - The caller must be a redemption guardian,
-    ///      - The reserved redemption must not have been vetoed already,
+    ///      - The generation must not have been vetoed already,
     ///      - The guardian must not have already objected to it,
-    ///      - The reserved redemption must be pending,
-    ///      - The reserved redemption must be within its veto delay period,
-    ///        unless it was requested before the watchtower was enabled.
-    function raiseReservedObjection(uint256 reservationKey)
+    ///      - The generation must be the reservation's pending redemption,
+    ///      - The generation must be within its veto delay period, unless
+    ///        it was requested before the watchtower was enabled.
+    function raiseReservedObjection(uint256 reservationKey, uint64 requestNonce)
         external
         onlyGuardian
     {
-        VetoProposal storage veto = vetoProposals[reservationKey];
+        uint256 vetoKey = reservedVetoKey(reservationKey, requestNonce);
+        VetoProposal storage veto = vetoProposals[vetoKey];
 
         require(
             veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
@@ -437,60 +456,58 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         );
 
         uint256 objectionKey = uint256(
-            keccak256(abi.encodePacked(reservationKey, msg.sender))
+            keccak256(abi.encodePacked(vetoKey, msg.sender))
         );
         require(!objections[objectionKey], "Guardian already objected");
 
-        Reservation.ReservationRequest memory reservation = IReservationBridge(
+        Reservation.ReservationAction memory action = IReservationBridge(
             address(bridge)
-        ).reservations(reservationKey);
+        ).reservationActions(reservationKey, requestNonce);
 
         require(
-            reservation.state ==
-                Reservation.ReservationState.RedemptionRequested,
+            action.actionType == Reservation.ActionType.Redemption &&
+                action.state == Reservation.ActionState.Pending,
             "Reserved redemption does not exist"
         );
 
-        if (reservation.redemptionRequestedAt >= watchtowerEnabledAt) {
+        if (action.requestedAt >= watchtowerEnabledAt) {
             require(
                 /* solhint-disable-next-line not-rely-on-time */
                 block.timestamp <
-                    reservation.redemptionRequestedAt +
-                        _redemptionDelay(
-                            veto.objectionsCount,
-                            reservation.mintedAmount
-                        ),
+                    action.requestedAt +
+                        _redemptionDelay(veto.objectionsCount, action.amount),
                 "Redemption veto delay period expired"
             );
         } else {
-            emit VetoPeriodCheckOmitted(reservationKey);
+            emit VetoPeriodCheckOmitted(vetoKey);
         }
 
         objections[objectionKey] = true;
-        veto.redeemer = reservation.redeemer;
+        veto.redeemer = action.redeemer;
         veto.objectionsCount++;
 
-        emit ObjectionRaised(reservationKey, msg.sender);
+        emit ObjectionRaised(vetoKey, msg.sender);
 
         if (veto.objectionsCount == REQUIRED_OBJECTIONS_COUNT) {
             uint64 penaltyFee = vetoPenaltyFeeDivisor > 0
-                ? reservation.mintedAmount / vetoPenaltyFeeDivisor
+                ? action.amount / vetoPenaltyFeeDivisor
                 : 0;
 
-            veto.withdrawableAmount = reservation.mintedAmount - penaltyFee;
+            veto.withdrawableAmount = action.amount - penaltyFee;
             /* solhint-disable-next-line not-rely-on-time */
             veto.finalizedAt = uint32(block.timestamp);
-            isBanned[reservation.redeemer] = true;
+            isBanned[action.redeemer] = true;
 
-            emit Banned(reservation.redeemer);
+            emit Banned(action.redeemer);
 
-            emit VetoFinalized(reservationKey);
+            emit VetoFinalized(vetoKey);
 
             // Notify the Bridge about the veto. As result of this call,
-            // this contract receives the surrendered gross amount
+            // this contract receives the escrowed gross amount
             // (as Bank's balance) from the Bridge.
             IReservationBridge(address(bridge)).notifyReservedRedemptionVeto(
-                reservationKey
+                reservationKey,
+                requestNonce
             );
             // Burn the penalty fee but leave the claimable amount for the
             // redeemer to withdraw after the freeze period.
@@ -498,31 +515,55 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         }
     }
 
-    /// @notice Returns the applicable veto delay for a pending reserved
-    ///         redemption identified by the given reservation key.
+    /// @notice Returns the applicable veto delay for the given pending
+    ///         reserved redemption generation. This is the delay the
+    ///         Bridge proof path enforces before a redemption generation
+    ///         can settle: wallets must not sign before it elapses.
     /// @param reservationKey The key of the reservation.
+    /// @param requestNonce The redemption generation.
     /// @return Reserved redemption veto delay.
-    /// @dev If the watchtower has been disabled, the delay is always zero.
-    function getReservedRedemptionDelay(uint256 reservationKey)
-        external
-        view
-        returns (uint32)
-    {
-        Reservation.ReservationRequest memory reservation = IReservationBridge(
+    /// @dev The delay is zero when the watchtower has not been enabled
+    ///      (no guardians exist, so a delay would protect nothing) or has
+    ///      been permanently disabled.
+    function getReservedRedemptionDelay(
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external view returns (uint32) {
+        if (watchtowerEnabledAt == 0) {
+            return 0;
+        }
+
+        Reservation.ReservationAction memory action = IReservationBridge(
             address(bridge)
-        ).reservations(reservationKey);
+        ).reservationActions(reservationKey, requestNonce);
 
         require(
-            reservation.state ==
-                Reservation.ReservationState.RedemptionRequested,
+            action.actionType == Reservation.ActionType.Redemption,
             "Reserved redemption does not exist"
         );
 
         return
             _redemptionDelay(
-                vetoProposals[reservationKey].objectionsCount,
-                reservation.mintedAmount
+                vetoProposals[reservedVetoKey(reservationKey, requestNonce)]
+                    .objectionsCount,
+                action.amount
             );
+    }
+
+    /// @notice Determines whether a reserved redemption request is
+    ///         considered safe: neither the reservation owner nor the
+    ///         redeemer may be banned. Objection state is per generation,
+    ///         so no historical objection count is consulted — a fresh
+    ///         generation always starts with a clean count.
+    /// @param owner The reservation owner.
+    /// @param redeemer The address requesting the redemption.
+    /// @return True if the reserved redemption request is safe.
+    function isSafeReservedRedemption(address owner, address redeemer)
+        external
+        view
+        returns (bool)
+    {
+        return !isBanned[owner] && !isBanned[redeemer];
     }
 
     /// @notice Returns the redemption delay for a given number of objections

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -529,6 +529,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         uint256 reservationKey,
         uint64 requestNonce
     ) external view returns (uint32) {
+        // slither-disable-next-line incorrect-equality
         if (watchtowerEnabledAt == 0) {
             return 0;
         }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -482,7 +482,7 @@ library Reservation {
         // deadline is retained even when reveal-ahead validation is disabled
         // because the wallet validator always enforces its refund margin.
         require(
-            timeoutAt <= reservedDeposit.refundDeadline,
+            timeoutAt < reservedDeposit.refundDeadline,
             "Authorization window would overlap the deposit refund window"
         );
         require(
@@ -1143,6 +1143,10 @@ library Reservation {
             require(
                 self.reservationTotalAmount == 0,
                 "Active reservations exist"
+            );
+            require(
+                self.reservationRouter != address(0),
+                "Router not set"
             );
             self.reservationVault = reservationVault;
             emit ReservationVaultUpdated(reservationVault);

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -212,14 +212,16 @@ library Reservation {
         // gross claim for redemptions, the capacity-reserved deposit value
         // for acceptances, the anchor value at request time otherwise.
         uint64 amount;
-        // keccak256 hash of the length-prefixed redeemer output script a
-        // redemption generation must pay to. Zero for other action types.
-        bytes32 redeemerOutputScriptHash;
-        // Wallet main UTXO hash expected by a dissolution generation
-        // (`registeredWallets[wallet].mainUtxoHash` at request time).
-        // Zero for other action types, and for dissolutions of wallets
-        // with no main UTXO.
-        bytes32 expectedMainUtxoHash;
+        // Action-specific authorization data: the keccak256 hash of the
+        // length-prefixed redeemer output script for redemptions, or the
+        // wallet main UTXO hash snapshotted for dissolutions. Zero for
+        // acceptances and re-anchors, and for dissolutions of wallets with
+        // no main UTXO.
+        bytes32 actionDataHash;
+        // Hash of the reservation anchor outpoint this generation was
+        // authorized to spend. Zero only for acceptance generations, which
+        // spend the revealed deposit rather than an existing anchor.
+        bytes32 sourceAnchorUtxoHash;
         // True when this redemption generation consumed the reservation's
         // single-use retry entitlement. Needed to return the entitlement if
         // a late re-anchor makes the generation impossible to settle.
@@ -346,6 +348,23 @@ library Reservation {
         uint64 requestNonce
     ) internal view returns (ReservationAction storage) {
         return self.reservationActions[actionKey(reservationKey, requestNonce)];
+    }
+
+    /// @notice Returns the canonical hash of a reservation anchor outpoint.
+    ///         Action generations snapshot this value so a late proof can
+    ///         only consume the exact anchor that generation authorized.
+    function anchorUtxoHash(ReservationRequest storage reservation)
+        internal
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encodePacked(
+                    reservation.anchorTxHash,
+                    reservation.anchorTxOutputIndex
+                )
+            );
     }
 
     /// @notice Requests the acceptance of a revealed reserved deposit: the
@@ -608,7 +627,8 @@ library Reservation {
         action.usedRetryCredit = useRetryCredit;
         action.redeemer = redeemer;
         action.amount = reservation.mintedAmount;
-        action.redeemerOutputScriptHash = keccak256(redeemerOutputScriptMem);
+        action.actionDataHash = keccak256(redeemerOutputScriptMem);
+        action.sourceAnchorUtxoHash = anchorUtxoHash(reservation);
 
         if (self.redemptionWatchtower != address(0)) {
             (
@@ -735,6 +755,7 @@ library Reservation {
         action.txMaxFee = self.reservationTxMaxFee;
         action.targetWalletPubKeyHash = targetWalletPubKeyHash;
         action.amount = reservation.anchorAmount;
+        action.sourceAnchorUtxoHash = anchorUtxoHash(reservation);
 
         emit ReservationReanchorRequested(
             reservationKey,
@@ -820,14 +841,15 @@ library Reservation {
         action.txMaxFee = self.reservationTxMaxFee;
         action.targetWalletPubKeyHash = walletPubKeyHash;
         action.amount = reservation.anchorAmount;
-        action.expectedMainUtxoHash = wallet.mainUtxoHash;
+        action.actionDataHash = wallet.mainUtxoHash;
+        action.sourceAnchorUtxoHash = anchorUtxoHash(reservation);
 
         emit ReservationDissolutionRequested(
             reservationKey,
             requestNonce,
             walletPubKeyHash,
             action.txMaxFee,
-            action.expectedMainUtxoHash
+            action.actionDataHash
         );
     }
 

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -880,6 +880,10 @@ library Reservation {
             reservation.state = ReservationState.Active;
             delete self.walletPendingDissolution[reservation.walletPubKeyHash];
 
+            bool walletWasMovingFunds = self
+                .registeredWallets[reservation.walletPubKeyHash]
+                .state == Wallets.WalletState.MovingFunds;
+
             // A wallet failing its dissolution duty is slashed like a
             // wallet failing a redemption: dissolution is the mechanism
             // that makes term + grace a hard stranding bound.
@@ -887,6 +891,14 @@ library Reservation {
                 reservation.walletPubKeyHash,
                 walletMembersIDs
             );
+
+            // A Live wallet enters MovingFunds on its first failure and keeps
+            // the ordinary moving-funds deadline. A wallet already in
+            // MovingFunds has now also refused the terminal cleanup of its
+            // residual anchor, so terminate it at the dissolution bound.
+            if (walletWasMovingFunds) {
+                self.terminateWallet(reservation.walletPubKeyHash);
+            }
         }
 
         // slither-disable-next-line reentrancy-events

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -22,77 +22,115 @@ import "./BitcoinTx.sol";
 import "./BridgeState.sol";
 import "./Deposit.sol";
 import "./Redemption.sol";
+import "./ReservationProofs.sol";
 import "./Wallets.sol";
 
 import "../bank/Bank.sol";
 
-/// @title Bridge UTXO reservations
-/// @notice The library handles the logic for reserving deposited UTXOs so
-///         that a depositor's coins are custodied without ever being
-///         commingled with the pooled supply and are returned in-kind --
-///         with an unbroken 1-input-1-output lineage -- upon redemption.
-/// @dev A reserved deposit is a regular revealed deposit routed to the
-///      designated reservation vault (`reveal.vault == reservationVault`).
-///      Instead of being swept into the wallet's main UTXO, a reserved
-///      deposit is *anchored*: the wallet performs a 1-input-1-output spend
-///      of the deposit into a fresh wallet-controlled P2(W)PKH output that
-///      carries no refund path. The Bank balance is credited only when the
-///      SPV proof of that anchor transaction is submitted. The anchor thus
-///      mirrors the sweep's refund-disabling role while dropping its
-///      consolidating role -- balances are never credited against an output
-///      the depositor could still claw back, and the coins never merge with
-///      the pooled supply.
+/// @title Bridge UTXO reservations — control plane
+/// @notice The library handles the request/authorization side of UTXO
+///         reservations: deposits custodied without ever being commingled
+///         with the pooled supply and returned in-kind — with an unbroken
+///         1-input-1-output lineage — upon redemption. The SPV settlement
+///         side lives in the `ReservationProofs` companion library.
+/// @dev Every Bitcoin action of a reservation's life — the acceptance
+///      anchor, an in-kind redemption, a re-anchor to another wallet, and
+///      the post-term dissolution — follows a *two-phase,
+///      authorize-then-prove* model (see RFC 13):
 ///
-///      The registry tracks the reservation's current anchor outpoint
-///      through optional re-anchoring hops (wallet migration) until the
-///      reservation is closed by an in-kind redemption, or -- once the
-///      custody term and grace period elapse -- dissolved into the wallet's
-///      main UTXO, at which point the owner's balance simply remains an
-///      ordinary pooled claim.
+///      1. An explicit *request* increments the position's monotonic
+///         request nonce, performs every capacity and lifecycle check and
+///         *reserves* what it checks, and *snapshots* every proof- and
+///         settlement-critical parameter into a per-generation
+///         `ReservationAction` record keyed by `(reservationKey, nonce)`.
+///         A wallet signs only requested (and, for redemptions,
+///         watchtower-authorized) generations, and nothing that changes
+///         after the request can make the signed transaction unprovable.
+///
+///      2. The SPV *proof* settles the generation against the record's
+///         snapshots — never against live parameters. A generation that
+///         times out leaves a terminal record that still accepts a late
+///         proof (closing the anchor lineage without a second refund); a
+///         generation vetoed by the redemption watchtower never accepts a
+///         proof, leaving an early-signing wallet exposed to the fraud
+///         machinery — the intended consequence of signing an unauthorized
+///         action.
 ///
 ///      Claim accounting: the amount credited (`mintedAmount`) is the gross
-///      anchor output value; the per-deposit treasury fee computed at reveal
-///      time is deliberately not netted. All protocol fees are charged by
-///      the reservation vault as explicit transfers. Bitcoin miner fees are
-///      the only in-kind deductions: the anchor and any re-anchor fees
-///      reduce the on-chain `anchorAmount`, while the reserved redemption
-///      always burns the full `mintedAmount`, so supply and backing
-///      reconcile exactly when the reservation closes via redemption.
-///
-///      Fraud-defense integration: accepting a reservation marks the
-///      underlying deposit as swept (making the deposit outpoint recognized
-///      by `Fraud.defeatFraudChallenge`), and every proven consumption of an
-///      anchor outpoint (redemption, re-anchor, dissolution) records it in
-///      `spentMainUTXOs` -- the existing registry of honestly-spent,
-///      wallet-controlled outpoints the fraud defeat path consults.
+///      anchor output value. All protocol fees are charged by the
+///      reservation vault as explicit transfers; Bitcoin miner fees are the
+///      only in-kind deductions.
 library Reservation {
     using BridgeState for BridgeState.Storage;
     using Wallets for BridgeState.Storage;
-    using BitcoinTx for BridgeState.Storage;
 
     using BTCUtils for bytes;
     using BytesLib for bytes;
 
-    /// @notice Represents the state of a reservation.
+    /// @notice Represents the state of a reservation position.
     enum ReservationState {
-        /// @dev The reservation is unknown to the Bridge.
+        /// @dev The reservation is unknown to the Bridge. Acceptance
+        ///      requests are made against positions in this state.
         Unknown,
         /// @dev The reservation was accepted (anchor proven, balance
-        ///      credited) and its anchor outpoint is under wallet custody.
+        ///      credited) and its anchor outpoint is under wallet custody,
+        ///      with no action in flight.
         Active,
-        /// @dev The owner requested an in-kind redemption of the reserved
-        ///      outpoint and surrendered the gross balance. The wallet is
-        ///      expected to spend the anchor to the redeemer script.
-        RedemptionRequested,
-        /// @dev The reservation was closed, either by a proven in-kind
-        ///      redemption or by dissolution into the wallet's main UTXO.
-        Closed
+        /// @dev An action (redemption, re-anchor or dissolution) has been
+        ///      requested for the position and is not yet settled. The
+        ///      pending action record is
+        ///      `reservationActions[actionKey(reservationKey, requestNonce)]`.
+        ActionPending,
+        /// @dev The reservation was closed: redeemed in-kind, dissolved
+        ///      into the wallet's main UTXO, or settled late after a
+        ///      timeout.
+        Closed,
+        /// @dev The custodying wallet was terminated while the anchor was
+        ///      outstanding. The owner's minted balance remains an ordinary
+        ///      pooled claim; the anchor is no longer tracked.
+        Stranded
     }
 
-    /// @notice Represents a UTXO reservation.
+    /// @notice Type of a reservation action generation.
+    enum ActionType {
+        None,
+        Acceptance,
+        Redemption,
+        Reanchor,
+        Dissolution
+    }
+
+    /// @notice Settlement state of a reservation action generation.
+    enum ActionState {
+        /// @dev No action was ever requested under this key.
+        Unknown,
+        /// @dev The action is requested and awaiting its SPV proof. For
+        ///      redemptions, the wallet may only sign once the watchtower
+        ///      delay has elapsed without a veto; the proof path enforces
+        ///      this.
+        Pending,
+        /// @dev The action was proven and settled.
+        Settled,
+        /// @dev The action timed out. Terminal for the generation, but a
+        ///      late proof of the (already confirmed) Bitcoin transaction
+        ///      is still accepted against this record: it closes the anchor
+        ///      lineage and marks the consumed outpoints as honestly spent,
+        ///      without repeating the refund performed at timeout.
+        TimedOut,
+        /// @dev The action was vetoed by the redemption watchtower.
+        ///      Terminal; a proof against this generation is rejected
+        ///      forever.
+        Vetoed,
+        /// @dev The action's anchor was consumed by a late settlement of an
+        ///      older timed-out generation. Terminal; the escrowed claim
+        ///      was refunded during the late settlement.
+        Superseded
+    }
+
+    /// @notice Represents a UTXO reservation position.
     struct ReservationRequest {
-        // The reservation owner holding the in-kind redemption right. Set to
-        // the deposit's depositor at acceptance time.
+        // The reservation owner holding the in-kind redemption right. Set
+        // to the deposit's depositor at acceptance time.
         address owner;
         // Gross amount in satoshi credited to the owner via the reservation
         // vault at acceptance time. This is the amount that must be
@@ -109,9 +147,7 @@ library Reservation {
         // re-anchor hop.
         uint64 anchorAmount;
         // UNIX timestamp the custody term expires at. Purely a contract
-        // layer fact -- the anchor output carries no timelock. After
-        // `expiresAt + reservationGracePeriod` the wallet may dissolve the
-        // reservation into its main UTXO.
+        // layer fact -- the anchor output carries no timelock.
         // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 expiresAt;
         // Hash of the Bitcoin transaction holding the current anchor output.
@@ -119,28 +155,84 @@ library Reservation {
         // Output index of the current anchor output. Always 0 given anchor
         // transactions have a single output; kept for auditability.
         uint32 anchorTxOutputIndex;
-        // Current state of the reservation.
+        // Current state of the reservation position.
         ReservationState state;
-        // UNIX timestamp the pending reserved redemption was requested at.
-        // Zero when no redemption is pending.
-        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
-        uint32 redemptionRequestedAt;
-        // Transaction maximum BTC fee in satoshi snapshotted at redemption
-        // request time.
-        uint64 redemptionTxMaxFee;
-        // The address able to claim the surrendered balance back should the
-        // pending reserved redemption time out.
-        address redeemer;
-        // keccak256 hash of the length-prefixed redeemer output script the
-        // pending reserved redemption must pay to.
-        bytes32 redeemerOutputScriptHash;
+        // Monotonic generation counter. Incremented by every action
+        // request (including acceptance requests); all action state is
+        // keyed by `(reservationKey, requestNonce)` so a stale generation
+        // can never be confused with a newer one.
+        uint64 requestNonce;
+        // True when the owner holds a single-use, fee-free redemption
+        // retry entitlement, minted when a fee-paid redemption request
+        // times out through the wallet's fault. Consumed by the next
+        // retry request; voided by a dissolution request.
+        bool retryCredit;
+        // Custody term length in seconds, snapshotted at acceptance.
+        // Extensions extend by this value; later governance changes apply
+        // to new reservations only.
+        uint32 termSeconds;
+        // Grace period in seconds, snapshotted at acceptance. After
+        // `expiresAt + gracePeriod` the reservation becomes dissolvable
+        // and can no longer be redeemed in-kind.
+        uint32 gracePeriod;
         // This struct doesn't contain `__gap` property as the structure is
         // stored in a mapping, mappings store values in different slots and
         // they are not contiguous with other values.
     }
 
+    /// @notice Represents one requested generation of a reservation action.
+    ///         All fields the proof and settlement paths consult are
+    ///         snapshotted here at request time; live parameters are never
+    ///         read at settlement.
+    struct ReservationAction {
+        // 20-byte public key hash of the wallet the action's single
+        // wallet-controlled output must pay to: the designated custodian
+        // for acceptances, the migration target for re-anchors, the
+        // custodying wallet itself for dissolutions. Zero for redemptions.
+        bytes20 targetWalletPubKeyHash;
+        // UNIX timestamp the action was requested at.
+        uint32 requestedAt;
+        // UNIX timestamp after which the action can be reported timed out.
+        uint32 timeoutAt;
+        // Snapshotted maximum Bitcoin miner fee for the action transaction.
+        uint64 txMaxFee;
+        // Action type of this generation.
+        ActionType actionType;
+        // Settlement state of this generation.
+        ActionState state;
+        // True when the generation was created through a fee-paying vault
+        // entry point; a fee-paid redemption generation that times out
+        // mints the retry entitlement.
+        bool feePaid;
+        // The address able to claim the escrowed balance back should a
+        // redemption generation time out. Zero for other action types.
+        address redeemer;
+        // Amount in satoshi associated with the generation: the escrowed
+        // gross claim for redemptions, the capacity-reserved deposit value
+        // for acceptances, the anchor value at request time otherwise.
+        uint64 amount;
+        // keccak256 hash of the length-prefixed redeemer output script a
+        // redemption generation must pay to. Zero for other action types.
+        bytes32 redeemerOutputScriptHash;
+        // Wallet main UTXO hash expected by a dissolution generation
+        // (`registeredWallets[wallet].mainUtxoHash` at request time).
+        // Zero for other action types, and for dissolutions of wallets
+        // with no main UTXO.
+        bytes32 expectedMainUtxoHash;
+    }
+
+    event ReservationAcceptanceRequested(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed walletPubKeyHash,
+        uint64 depositAmount,
+        uint64 txMaxFee,
+        uint32 timeoutAt
+    );
+
     event ReservationAccepted(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes20 indexed walletPubKeyHash,
         address indexed owner,
         bytes32 anchorTxHash,
@@ -155,36 +247,74 @@ library Reservation {
 
     event ReservedRedemptionRequested(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         address indexed redeemer,
         bytes redeemerOutputScript,
         uint64 mintedAmount,
-        uint64 txMaxFee
+        uint64 txMaxFee,
+        bool feePaid
     );
 
     event ReservedRedemptionCompleted(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes32 redemptionTxHash
     );
 
-    event ReservedRedemptionTimedOut(
+    event ReservationReanchorRequested(
         uint256 indexed reservationKey,
-        bytes20 indexed walletPubKeyHash
+        uint64 requestNonce,
+        bytes20 indexed sourceWalletPubKeyHash,
+        bytes20 indexed targetWalletPubKeyHash,
+        uint64 txMaxFee
     );
-
-    event ReservedRedemptionVetoed(uint256 indexed reservationKey);
 
     event ReservationReanchored(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes20 indexed newWalletPubKeyHash,
         bytes32 newAnchorTxHash,
         uint64 newAnchorAmount
     );
 
+    event ReservationDissolutionRequested(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed walletPubKeyHash,
+        uint64 txMaxFee,
+        bytes32 expectedMainUtxoHash
+    );
+
     event ReservationDissolved(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes20 indexed walletPubKeyHash,
         bytes32 dissolutionTxHash
     );
+
+    event ReservationActionTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        ActionType actionType
+    );
+
+    event ReservedRedemptionVetoed(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationActionSuperseded(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationLateSettled(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        ActionType actionType
+    );
+
+    event ReservationRetryCreditMinted(uint256 indexed reservationKey);
 
     event ReservationParametersUpdated(
         uint64 reservationMinAmount,
@@ -192,166 +322,93 @@ library Reservation {
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint32 reservationActionTimeout
     );
 
     event ReservationVaultUpdated(address reservationVault);
 
-    /// @notice Represents the type of a reservation lifecycle SPV proof.
-    enum ProofType {
-        /// @dev Proof of the anchor transaction accepting a reserved
-        ///      deposit. `mainUtxo` and `reservationKey` parameters are
-        ///      ignored; the reservation key is derived from the spent
-        ///      deposit outpoint.
-        Acceptance,
-        /// @dev Proof of an in-kind reserved redemption transaction.
-        ///      `mainUtxo` parameter is ignored.
-        Redemption,
-        /// @dev Proof of a re-anchor transaction moving the anchor outpoint
-        ///      to another wallet. `mainUtxo` parameter is ignored.
-        Reanchor,
-        /// @dev Proof of a dissolution transaction merging an expired
-        ///      reservation's anchor into the wallet's main UTXO.
-        Dissolution
+    /// @notice Computes the storage key of the action record of the given
+    ///         reservation generation.
+    function actionKey(uint256 reservationKey, uint64 requestNonce)
+        internal
+        pure
+        returns (uint256)
+    {
+        return
+            uint256(keccak256(abi.encodePacked(reservationKey, requestNonce)));
     }
 
     /// @notice Single entry point for all reservation lifecycle SPV proofs.
-    ///         Dispatches to the appropriate handler based on `proofType`.
-    ///         Consolidated into one external function to preserve the
-    ///         Bridge contract's EIP-170 deployment size margin.
-    /// @param proofType The type of the submitted proof, see `ProofType`.
-    /// @param txInfo Bitcoin transaction data.
-    /// @param proof Bitcoin proof data.
-    /// @param mainUtxo Data of the wallet's main UTXO; only used for
-    ///        `Dissolution` proofs and ignored otherwise.
-    /// @param reservationKey The key of the target reservation; ignored for
-    ///        `Acceptance` proofs where the key is derived from the spent
-    ///        deposit outpoint.
+    ///         Forwards to the `ReservationProofs` settlement library. The
+    ///         forwarding hop exists so the `ReservationRouter` links
+    ///         exactly one external library; see the router for the
+    ///         architecture.
     function submitReservationProof(
         BridgeState.Storage storage self,
         uint8 proofType,
         BitcoinTx.Info calldata txInfo,
         BitcoinTx.Proof calldata proof,
         BitcoinTx.UTXO calldata mainUtxo,
-        uint256 reservationKey
+        uint256 reservationKey,
+        uint64 requestNonce
     ) external {
-        ProofType parsedProofType = ProofType(proofType);
-
-        if (parsedProofType == ProofType.Acceptance) {
-            submitReservationAcceptanceProof(self, txInfo, proof);
-        } else if (parsedProofType == ProofType.Redemption) {
-            submitReservedRedemptionProof(self, txInfo, proof, reservationKey);
-        } else if (parsedProofType == ProofType.Reanchor) {
-            submitReservationReanchorProof(self, txInfo, proof, reservationKey);
-        } else {
-            submitReservationDissolutionProof(
-                self,
-                txInfo,
-                proof,
-                mainUtxo,
-                reservationKey
-            );
-        }
+        ReservationProofs.submitReservationProof(
+            self,
+            proofType,
+            txInfo,
+            proof,
+            mainUtxo,
+            reservationKey,
+            requestNonce
+        );
     }
 
-    /// @notice Used by the wallet to prove the BTC anchor transaction of a
-    ///         reserved deposit and to credit the owner's balance
-    ///         accordingly. The anchor is only accepted if it satisfies SPV
-    ///         proof.
-    ///
-    ///         The anchor transaction must spend exactly the revealed
-    ///         reserved deposit as its sole input and create exactly one
-    ///         P2(W)PKH output controlled by a registered wallet. Proving it
-    ///         marks the deposit as swept (blocking any regular sweep and
-    ///         enabling fraud challenge defeats for the deposit outpoint),
-    ///         registers the reservation and credits the gross anchor value
-    ///         to the depositor through the reservation vault.
-    /// @param anchorTx Bitcoin anchor transaction data.
-    /// @param anchorProof Bitcoin anchor proof data.
+    /// @notice Returns the action record of the given reservation
+    ///         generation.
+    function getAction(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal view returns (ReservationAction storage) {
+        return self.reservationActions[actionKey(reservationKey, requestNonce)];
+    }
+
+    /// @notice Requests the acceptance of a revealed reserved deposit: the
+    ///         authorization for the designated wallet to perform the
+    ///         1-input-1-output anchor spend killing the deposit's refund
+    ///         path. Checks and reserves capacity so that the anchor, once
+    ///         signed, can always be proven.
+    /// @param reservationKey The deposit key of the revealed reserved
+    ///        deposit (`keccak256(fundingTxHash | fundingOutputIndex)`),
+    ///        which doubles as the reservation key.
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet that
+    ///        will anchor the deposit. Must be the wallet the deposit was
+    ///        revealed for.
     /// @dev Requirements:
     ///      - The reservation vault must be set,
-    ///      - `anchorTx` must have exactly one input pointing to a revealed,
-    ///        unswept deposit routed to the reservation vault,
-    ///      - `anchorTx` must have exactly one P2(W)PKH output locking funds
-    ///        on a 20-byte public key hash of a Live or MovingFunds wallet,
-    ///      - The anchor output value must respect the reservation minimum
-    ///        amount, the per-transaction max fee, and the reservation caps.
-    function submitReservationAcceptanceProof(
+    ///      - The deposit must be revealed to the reservation vault and not
+    ///        swept,
+    ///      - No acceptance authorization for the deposit may be pending,
+    ///      - The wallet must be Live,
+    ///      - The deposit amount must satisfy the reservation minimum plus
+    ///        the transaction fee allowance, so a compliant anchor always
+    ///        satisfies the minimum after fees,
+    ///      - The authorization window (now + action timeout) must end
+    ///        before the deposit's guaranteed refund-locktime margin
+    ///        (`revealedAt + depositRevealAheadPeriod`), so an authorized
+    ///        anchor can never race the depositor's refund,
+    ///      - Reservation capacity (total amount, per-wallet count) must
+    ///        allow the deposit; both are reserved by this call and
+    ///        released if the authorization times out.
+    function requestReservationAcceptance(
         BridgeState.Storage storage self,
-        BitcoinTx.Info calldata anchorTx,
-        BitcoinTx.Proof calldata anchorProof
-    ) internal {
+        uint256 reservationKey,
+        bytes20 walletPubKeyHash
+    ) external {
         require(
             self.reservationVault != address(0),
             "Reservations are disabled"
-        );
-
-        bytes32 anchorTxHash = self.validateProof(anchorTx, anchorProof);
-
-        uint256 reservationKey = resolveAcceptedDeposit(
-            self,
-            anchorTx.inputVector
-        );
-
-        (bytes20 walletPubKeyHash, uint64 anchorAmount) = processAnchorOutput(
-            self,
-            anchorTx.outputVector
-        );
-
-        Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
-
-        require(
-            anchorAmount >= self.reservationMinAmount,
-            "Reservation amount too small"
-        );
-        // The difference between the deposit value and the anchor output
-        // value is the Bitcoin miner fee of the anchor transaction -- the
-        // only in-kind deduction the reservation lifecycle allows.
-        require(
-            deposit.amount - anchorAmount <= self.reservationTxMaxFee,
-            "Transaction fee is too high"
-        );
-
-        registerReservation(
-            self,
-            reservationKey,
-            deposit.depositor,
-            walletPubKeyHash,
-            anchorAmount,
-            anchorTxHash
-        );
-
-        // Credit the gross anchored amount through the reservation vault.
-        // The per-deposit treasury fee computed at reveal time is
-        // deliberately ignored: reservation claims are minted gross and all
-        // protocol fees are charged as explicit transfers by the vault.
-        address[] memory depositors = new address[](1);
-        depositors[0] = deposit.depositor;
-        uint256[] memory amounts = new uint256[](1);
-        amounts[0] = anchorAmount;
-        self.bank.increaseBalanceAndCall(
-            self.reservationVault,
-            depositors,
-            amounts
-        );
-    }
-
-    /// @notice Resolves the reserved deposit spent by the anchor transaction
-    ///         input vector, validates it and marks it as swept. Marking the
-    ///         deposit as swept blocks any future regular sweep, prevents
-    ///         double acceptance, and makes the deposit outpoint recognized
-    ///         as correctly spent by the fraud challenge defeat path.
-    /// @return reservationKey The deposit key of the reserved deposit, used
-    ///         as the reservation key.
-    function resolveAcceptedDeposit(
-        BridgeState.Storage storage self,
-        bytes memory inputVector
-    ) internal returns (uint256 reservationKey) {
-        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
-            .parseWalletOutboundTxInput(inputVector);
-
-        reservationKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
         );
 
         Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
@@ -362,42 +419,50 @@ library Reservation {
             "Deposit not routed to the reservation vault"
         );
 
-        /* solhint-disable-next-line not-rely-on-time */
-        deposit.sweptAt = uint32(block.timestamp);
-    }
-
-    /// @notice Parses the anchor transaction single output and validates it
-    ///         is controlled by a Live or MovingFunds wallet.
-    function processAnchorOutput(
-        BridgeState.Storage storage self,
-        bytes memory outputVector
-    ) internal view returns (bytes20 walletPubKeyHash, uint64 anchorAmount) {
-        bytes memory anchorOutput = parseSingleOutput(outputVector);
-        walletPubKeyHash = self.extractPubKeyHash(anchorOutput);
-        anchorAmount = anchorOutput.extractValue();
-
-        Wallets.WalletState walletState = self
-            .registeredWallets[walletPubKeyHash]
-            .state;
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
         require(
-            walletState == Wallets.WalletState.Live ||
-                walletState == Wallets.WalletState.MovingFunds,
-            "Anchor wallet must be in Live or MovingFunds state"
+            reservation.state == ReservationState.Unknown,
+            "Reservation already exists"
         );
-    }
+        require(
+            getAction(self, reservationKey, reservation.requestNonce).state !=
+                ActionState.Pending,
+            "Acceptance already pending"
+        );
 
-    /// @notice Registers a new reservation: checks and adjusts the caps,
-    ///         stores the reservation record and indexes the anchor
-    ///         outpoint.
-    function registerReservation(
-        BridgeState.Storage storage self,
-        uint256 reservationKey,
-        address owner,
-        bytes20 walletPubKeyHash,
-        uint64 anchorAmount,
-        bytes32 anchorTxHash
-    ) internal {
-        uint64 newTotal = self.reservationTotalAmount + anchorAmount;
+        require(
+            self.registeredWallets[walletPubKeyHash].state ==
+                Wallets.WalletState.Live,
+            "Wallet must be in Live state"
+        );
+
+        require(
+            deposit.amount >=
+                self.reservationMinAmount + self.reservationTxMaxFee,
+            "Deposit amount too small for a reservation"
+        );
+
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 timeoutAt = uint32(block.timestamp) +
+            self.reservationActionTimeout;
+
+        // The reveal-ahead validation guarantees the deposit refund
+        // locktime is at least `depositRevealAheadPeriod` after the reveal.
+        // The authorization window must fit inside that guaranteed margin:
+        // the wallet must never hold an authorization that is still valid
+        // when the depositor's refund path may open.
+        if (self.depositRevealAheadPeriod > 0) {
+            require(
+                timeoutAt <= deposit.revealedAt + self.depositRevealAheadPeriod,
+                "Authorization window would overlap the deposit refund window"
+            );
+        }
+
+        // Reserve capacity using the deposit value as the upper bound of
+        // the anchor value; the settlement releases the miner-fee delta.
+        uint64 newTotal = self.reservationTotalAmount + deposit.amount;
         require(
             newTotal <= self.reservationMaxTotalAmount,
             "Total reserved amount cap exceeded"
@@ -411,109 +476,74 @@ library Reservation {
         );
         self.walletReservationsCount[walletPubKeyHash] = walletCount;
 
-        /* solhint-disable-next-line not-rely-on-time */
-        uint32 expiresAt = uint32(block.timestamp) +
-            self.reservationTermSeconds;
+        uint64 requestNonce = ++reservation.requestNonce;
 
-        ReservationRequest storage reservation = self.reservations[
-            reservationKey
-        ];
-        reservation.owner = owner;
-        reservation.mintedAmount = anchorAmount;
-        /* solhint-disable-next-line not-rely-on-time */
-        reservation.acceptedAt = uint32(block.timestamp);
-        reservation.walletPubKeyHash = walletPubKeyHash;
-        reservation.anchorAmount = anchorAmount;
-        reservation.expiresAt = expiresAt;
-        reservation.anchorTxHash = anchorTxHash;
-        reservation.anchorTxOutputIndex = 0;
-        reservation.state = ReservationState.Active;
-
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(anchorTxHash, uint32(0))))
-        ] = reservationKey;
-
-        // slither-disable-next-line reentrancy-events
-        emit ReservationAccepted(
+        ReservationAction storage action = getAction(
+            self,
             reservationKey,
-            walletPubKeyHash,
-            owner,
-            anchorTxHash,
-            anchorAmount,
-            expiresAt
+            requestNonce
         );
-    }
-
-    /// @notice Extends the custody term of a reservation by the current
-    ///         reservation term length. The custody fee for the extension is
-    ///         collected by the reservation vault before this call.
-    /// @param reservationKey The key of the reservation to extend.
-    /// @dev Requirements:
-    ///      - The caller must be the reservation vault,
-    ///      - The reservation must be in the Active or RedemptionRequested
-    ///        state,
-    ///      - The reservation must not be past its grace period.
-    function extendReservation(
-        BridgeState.Storage storage self,
-        uint256 reservationKey
-    ) external {
-        require(
-            msg.sender == self.reservationVault,
-            "Caller is not the reservation vault"
-        );
-
-        ReservationRequest storage reservation = self.reservations[
-            reservationKey
-        ];
-        require(
-            reservation.state == ReservationState.Active ||
-                reservation.state == ReservationState.RedemptionRequested,
-            "Reservation is not active"
-        );
-        require(
-            /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp <=
-                uint256(reservation.expiresAt) + self.reservationGracePeriod,
-            "Reservation past grace period"
-        );
-
-        uint32 base = reservation.expiresAt;
+        action.actionType = ActionType.Acceptance;
+        action.state = ActionState.Pending;
         /* solhint-disable-next-line not-rely-on-time */
-        if (base < block.timestamp) {
-            /* solhint-disable-next-line not-rely-on-time */
-            base = uint32(block.timestamp);
-        }
-        reservation.expiresAt = base + self.reservationTermSeconds;
+        action.requestedAt = uint32(block.timestamp);
+        action.timeoutAt = timeoutAt;
+        action.txMaxFee = self.reservationTxMaxFee;
+        action.targetWalletPubKeyHash = walletPubKeyHash;
+        action.amount = deposit.amount;
 
-        emit ReservationExtended(reservationKey, reservation.expiresAt);
+        emit ReservationAcceptanceRequested(
+            reservationKey,
+            requestNonce,
+            walletPubKeyHash,
+            deposit.amount,
+            action.txMaxFee,
+            timeoutAt
+        );
     }
 
     /// @notice Requests an in-kind redemption of a reservation: the wallet
     ///         is expected to spend exactly the reservation's anchor
     ///         outpoint to the redeemer output script in a 1-input-1-output
-    ///         transaction. The gross minted amount is taken from the
-    ///         reservation vault's Bank balance and held by the Bridge until
-    ///         the redemption is proven (burned) or times out (returned to
-    ///         the redeemer).
+    ///         transaction, once the watchtower delay elapses without a
+    ///         veto. The gross minted amount is taken from the reservation
+    ///         vault's Bank balance and held by the Bridge until the
+    ///         redemption is proven (burned) or times out (returned to the
+    ///         redeemer).
     /// @param reservationKey The key of the reservation to redeem.
-    /// @param redeemer The address able to claim the surrendered balance
-    ///        back if the redemption times out.
+    /// @param redeemer The address able to claim the escrowed balance back
+    ///        if the redemption times out.
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH) that will be used to
     ///        lock the redeemed BTC.
+    /// @param feePaid True when the vault collected the redemption fee for
+    ///        this request; a fee-paid generation that times out mints the
+    ///        single-use retry entitlement.
+    /// @param useRetryCredit True when the request consumes the fee-free
+    ///        retry entitlement instead of paying the fee.
     /// @dev Requirements:
     ///      - The caller must be the reservation vault, which must have
     ///        approved the Bridge in the Bank for the gross minted amount,
-    ///      - The reservation must be in the Active state,
-    ///      - If the redemption watchtower is set, the request must be
-    ///        considered safe by the watchtower,
+    ///      - The reservation must be Active and custodied by a Live or
+    ///        MovingFunds wallet,
+    ///      - The custody term plus (snapshotted) grace period must not
+    ///        have elapsed — after grace only dissolution is possible, so
+    ///        request/timeout cycling cannot defeat the stranding bound.
+    ///        A retry-entitled request is exempt until a dissolution is
+    ///        requested (which voids the entitlement),
+    ///      - When `useRetryCredit` is set, the position must hold the
+    ///        retry entitlement (consumed by this call),
+    ///      - If the redemption watchtower is set, neither the owner nor
+    ///        the redeemer may be banned,
     ///      - `redeemerOutputScript` must be a standard type and must not
     ///        pay to the custodying wallet's public key hash.
     function requestReservedRedemption(
         BridgeState.Storage storage self,
         uint256 reservationKey,
         address redeemer,
-        bytes calldata redeemerOutputScript
+        bytes calldata redeemerOutputScript,
+        bool feePaid,
+        bool useRetryCredit
     ) external {
         require(
             msg.sender == self.reservationVault,
@@ -532,15 +562,33 @@ library Reservation {
             "Reservation is not active"
         );
 
+        {
+            Wallets.WalletState walletState = self
+                .registeredWallets[reservation.walletPubKeyHash]
+                .state;
+            require(
+                walletState == Wallets.WalletState.Live ||
+                    walletState == Wallets.WalletState.MovingFunds,
+                "Wallet must be in Live or MovingFunds state"
+            );
+        }
+
+        if (useRetryCredit) {
+            require(reservation.retryCredit, "No retry entitlement");
+            reservation.retryCredit = false;
+        } else {
+            require(
+                /* solhint-disable-next-line not-rely-on-time */
+                block.timestamp <=
+                    uint256(reservation.expiresAt) + reservation.gracePeriod,
+                "Reservation past grace period"
+            );
+        }
+
         if (self.redemptionWatchtower != address(0)) {
             require(
                 IRedemptionWatchtower(self.redemptionWatchtower)
-                    .isSafeRedemption(
-                        reservation.walletPubKeyHash,
-                        redeemerOutputScript,
-                        self.reservationVault,
-                        redeemer
-                    ),
+                    .isSafeReservedRedemption(reservation.owner, redeemer),
                 "Redemption request rejected by the watchtower"
             );
         }
@@ -562,22 +610,35 @@ library Reservation {
             "Redeemer output script must not point to the wallet PKH"
         );
 
-        reservation.state = ReservationState.RedemptionRequested;
-        reservation.redeemer = redeemer;
-        reservation.redeemerOutputScriptHash = keccak256(
-            redeemerOutputScriptMem
+        reservation.state = ReservationState.ActionPending;
+        uint64 requestNonce = ++reservation.requestNonce;
+
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            requestNonce
         );
+        action.actionType = ActionType.Redemption;
+        action.state = ActionState.Pending;
         /* solhint-disable-next-line not-rely-on-time */
-        reservation.redemptionRequestedAt = uint32(block.timestamp);
-        reservation.redemptionTxMaxFee = self.reservationTxMaxFee;
+        action.requestedAt = uint32(block.timestamp);
+        /* solhint-disable-next-line not-rely-on-time */
+        action.timeoutAt = uint32(block.timestamp) + self.redemptionTimeout;
+        action.txMaxFee = self.reservationTxMaxFee;
+        action.feePaid = feePaid;
+        action.redeemer = redeemer;
+        action.amount = reservation.mintedAmount;
+        action.redeemerOutputScriptHash = keccak256(redeemerOutputScriptMem);
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionRequested(
             reservationKey,
+            requestNonce,
             redeemer,
             redeemerOutputScript,
             reservation.mintedAmount,
-            reservation.redemptionTxMaxFee
+            action.txMaxFee,
+            feePaid
         );
 
         self.bank.transferBalanceFrom(
@@ -587,209 +648,32 @@ library Reservation {
         );
     }
 
-    /// @notice Used by the wallet to prove the BTC reserved redemption
-    ///         transaction and close the reservation. The transaction must
-    ///         spend exactly the reservation's anchor outpoint as its sole
-    ///         input and pay the requested redeemer output script as its
-    ///         sole output. The full gross minted amount is burned: the
-    ///         difference between the burned amount and the BTC paid out is
-    ///         the Bitcoin miner fee (plus any re-anchor fees accrued
-    ///         in-kind during custody), so supply and backing reconcile
-    ///         exactly.
-    /// @param redemptionTx Bitcoin reserved redemption transaction data.
-    /// @param redemptionProof Bitcoin reserved redemption proof data.
-    /// @param reservationKey The key of the reservation being redeemed.
+    /// @notice Requests the re-anchoring of a reservation to another
+    ///         wallet: the authorization for the source wallet to spend the
+    ///         anchor in a 1-input-1-output transaction paying the target
+    ///         wallet. Used during wallet migration so reservations never
+    ///         pin retiring wallets, and for governance-approved rotations.
+    /// @param reservationKey The key of the reservation to re-anchor.
+    /// @param targetWalletPubKeyHash 20-byte public key hash of the target
+    ///        wallet.
+    /// @param privileged True when the call is made by the governance
+    ///        (checked by the calling contract), which may rotate anchors
+    ///        away from Live wallets.
     /// @dev Requirements:
-    ///      - The reservation must have a pending reserved redemption,
-    ///      - `redemptionTx` must spend the reservation's current anchor
-    ///        outpoint as its sole input,
-    ///      - `redemptionTx` must have a single output paying the requested
-    ///        redeemer output script with a value within the acceptable
-    ///        range.
-    function submitReservedRedemptionProof(
-        BridgeState.Storage storage self,
-        BitcoinTx.Info calldata redemptionTx,
-        BitcoinTx.Proof calldata redemptionProof,
-        uint256 reservationKey
-    ) internal {
-        bytes32 redemptionTxHash = self.validateProof(
-            redemptionTx,
-            redemptionProof
-        );
-
-        ReservationRequest storage reservation = self.reservations[
-            reservationKey
-        ];
-        require(
-            reservation.state == ReservationState.RedemptionRequested,
-            "No pending reserved redemption"
-        );
-
-        consumeAnchor(self, reservation, redemptionTx.inputVector);
-
-        bytes memory output = parseSingleOutput(redemptionTx.outputVector);
-        uint64 outputValue = output.extractValue();
-
-        {
-            bytes memory outputScript = output.slice(8, output.length - 8);
-            require(
-                keccak256(outputScript) == reservation.redeemerOutputScriptHash,
-                "Output does not pay the requested redeemer script"
-            );
-        }
-
-        // Underflow-safe range check. `redemptionTxMaxFee` is a governable
-        // parameter, not a value derived from the proven transaction, so it
-        // may exceed `anchorAmount` after re-anchor hops shrink the anchor
-        // or after a governance fee increase. The equivalent formulation
-        // below avoids the `anchorAmount - redemptionTxMaxFee` subtraction
-        // that would otherwise revert and permanently strand the
-        // reservation. `outputValue <= anchorAmount` is guaranteed by
-        // Bitcoin consensus (an output cannot exceed its input) but is
-        // asserted defensively.
-        require(
-            outputValue <= reservation.anchorAmount &&
-                reservation.anchorAmount - outputValue <=
-                reservation.redemptionTxMaxFee,
-            "Output value is not within the acceptable range"
-        );
-
-        closeReservation(self, reservation);
-
-        // slither-disable-next-line reentrancy-events
-        emit ReservedRedemptionCompleted(reservationKey, redemptionTxHash);
-
-        // Burn the gross minted amount held by the Bridge since the
-        // redemption request.
-        self.bank.decreaseBalance(reservation.mintedAmount);
-    }
-
-    /// @notice Notifies that a pending reserved redemption has timed out.
-    ///         The surrendered balance is returned to the redeemer, the
-    ///         wallet operators are slashed the same way as for a regular
-    ///         redemption timeout, and the reservation returns to the
-    ///         Active state -- the anchor outpoint was not spent, so the
-    ///         in-kind claim survives and the redemption can be re-requested.
-    /// @param reservationKey The key of the reservation with the timed out
-    ///        redemption.
-    /// @param walletMembersIDs Identifiers of the wallet signing group
-    ///        members.
-    /// @dev Requirements:
-    ///      - The reservation must have a pending reserved redemption,
-    ///      - The amount of time defined by `redemptionTimeout` must have
-    ///        passed since the reserved redemption was requested.
-    function notifyReservedRedemptionTimeout(
+    ///      - The reservation must be Active,
+    ///      - The source wallet must be in the MovingFunds state (anyone
+    ///        may then request — migration is the system's duty), or Live
+    ///        with the governance as the caller (approved rotation),
+    ///      - The target wallet must be Live and different from the source,
+    ///      - The target wallet's reservation-count capacity must allow the
+    ///        move; the capacity is reserved by this call and released if
+    ///        the authorization times out.
+    function requestReservationReanchor(
         BridgeState.Storage storage self,
         uint256 reservationKey,
-        uint32[] calldata walletMembersIDs
+        bytes20 targetWalletPubKeyHash,
+        bool privileged
     ) external {
-        ReservationRequest storage reservation = self.reservations[
-            reservationKey
-        ];
-        require(
-            reservation.state == ReservationState.RedemptionRequested,
-            "No pending reserved redemption"
-        );
-        require(
-            /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp >
-                reservation.redemptionRequestedAt + self.redemptionTimeout,
-            "Redemption request has not timed out"
-        );
-
-        address redeemer = reservation.redeemer;
-        uint64 refundAmount = reservation.mintedAmount;
-        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
-
-        reservation.state = ReservationState.Active;
-        reservation.redeemer = address(0);
-        reservation.redeemerOutputScriptHash = bytes32(0);
-        reservation.redemptionRequestedAt = 0;
-        reservation.redemptionTxMaxFee = 0;
-
-        // Propagate timeout consequences to the wallet: slashing and state
-        // transition follow exactly the regular redemption timeout rules.
-        self.notifyWalletRedemptionTimeout(walletPubKeyHash, walletMembersIDs);
-
-        // slither-disable-next-line reentrancy-events
-        emit ReservedRedemptionTimedOut(reservationKey, walletPubKeyHash);
-
-        // Return the surrendered balance to the redeemer as Bank balance.
-        self.bank.transferBalance(redeemer, refundAmount);
-    }
-
-    /// @notice Notifies that a pending reserved redemption was vetoed in the
-    ///         redemption watchtower. Mirrors
-    ///         `Redemption.notifyRedemptionVeto`: the surrendered balance is
-    ///         detained and passed to the watchtower (as Bank balance) for
-    ///         further processing, the pending request is cleared, and the
-    ///         reservation returns to the Active state -- the anchor
-    ///         outpoint was not spent, so the in-kind claim survives.
-    /// @param reservationKey The key of the reservation with the vetoed
-    ///        redemption.
-    /// @dev Requirements:
-    ///      - The caller must be the redemption watchtower,
-    ///      - The reservation must have a pending reserved redemption.
-    function notifyReservedRedemptionVeto(
-        BridgeState.Storage storage self,
-        uint256 reservationKey
-    ) external {
-        require(
-            msg.sender == self.redemptionWatchtower,
-            "Caller is not the redemption watchtower"
-        );
-
-        ReservationRequest storage reservation = self.reservations[
-            reservationKey
-        ];
-        require(
-            reservation.state == ReservationState.RedemptionRequested,
-            "No pending reserved redemption"
-        );
-
-        uint64 detainedAmount = reservation.mintedAmount;
-
-        reservation.state = ReservationState.Active;
-        reservation.redeemer = address(0);
-        reservation.redeemerOutputScriptHash = bytes32(0);
-        reservation.redemptionRequestedAt = 0;
-        reservation.redemptionTxMaxFee = 0;
-
-        // slither-disable-next-line reentrancy-events
-        emit ReservedRedemptionVetoed(reservationKey);
-
-        self.bank.transferBalance(self.redemptionWatchtower, detainedAmount);
-    }
-
-    /// @notice Used by the wallet to prove a re-anchor transaction moving a
-    ///         reservation's anchor outpoint to another (or a fresh output
-    ///         of the same) wallet in a 1-input-1-output spend. Used during
-    ///         wallet migration so reservations never pin retiring wallets.
-    /// @param reanchorTx Bitcoin re-anchor transaction data.
-    /// @param reanchorProof Bitcoin re-anchor proof data.
-    /// @param reservationKey The key of the reservation being re-anchored.
-    /// @dev Requirements:
-    ///      - The reservation must be in the Active state (a pending
-    ///        reserved redemption blocks re-anchoring),
-    ///      - `reanchorTx` must spend the current anchor outpoint as its
-    ///        sole input and create a single P2(W)PKH output controlled by
-    ///        a Live wallet,
-    ///      - The value difference (Bitcoin miner fee) must not exceed the
-    ///        reservation transaction max fee.
-    ///
-    ///      The source wallet state is deliberately not restricted: the
-    ///      ability to produce the transaction is enforced by Bitcoin (only
-    ///      the custodying wallet can sign the anchor spend) and moving
-    ///      reservations out must remain possible for wallets in any
-    ///      lifecycle state.
-    function submitReservationReanchorProof(
-        BridgeState.Storage storage self,
-        BitcoinTx.Info calldata reanchorTx,
-        BitcoinTx.Proof calldata reanchorProof,
-        uint256 reservationKey
-    ) internal {
-        bytes32 reanchorTxHash = self.validateProof(reanchorTx, reanchorProof);
-
         ReservationRequest storage reservation = self.reservations[
             reservationKey
         ];
@@ -798,119 +682,95 @@ library Reservation {
             "Reservation is not active"
         );
 
-        consumeAnchor(self, reservation, reanchorTx.inputVector);
-
-        bytes memory output = parseSingleOutput(reanchorTx.outputVector);
-        bytes20 newWalletPubKeyHash = self.extractPubKeyHash(output);
-        uint64 newAnchorAmount = output.extractValue();
+        {
+            Wallets.WalletState sourceState = self
+                .registeredWallets[reservation.walletPubKeyHash]
+                .state;
+            if (sourceState == Wallets.WalletState.Live) {
+                require(
+                    privileged,
+                    "Only governance can rotate a Live wallet's anchor"
+                );
+            } else {
+                require(
+                    sourceState == Wallets.WalletState.MovingFunds,
+                    "Source wallet must be in Live or MovingFunds state"
+                );
+            }
+        }
 
         require(
-            self.registeredWallets[newWalletPubKeyHash].state ==
+            targetWalletPubKeyHash != reservation.walletPubKeyHash,
+            "Target wallet must differ from the source wallet"
+        );
+        require(
+            self.registeredWallets[targetWalletPubKeyHash].state ==
                 Wallets.WalletState.Live,
             "Target wallet must be in Live state"
         );
 
-        // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
-        // consensus (the re-anchor output cannot exceed its input).
+        // Reserve the target wallet's count capacity; the source wallet's
+        // count is released at settlement (or kept on timeout).
+        uint32 targetCount = self.walletReservationsCount[
+            targetWalletPubKeyHash
+        ] + 1;
         require(
-            reservation.anchorAmount - newAnchorAmount <=
-                self.reservationTxMaxFee,
-            "Transaction fee is too high"
+            targetCount <= self.maxReservationsPerWallet,
+            "Wallet reservations cap exceeded"
         );
+        self.walletReservationsCount[targetWalletPubKeyHash] = targetCount;
 
-        // Dust floor: the re-anchored amount must stay strictly above the
-        // per-transaction fee bound, keeping the anchor clear of dust and
-        // preserving positive redemption value. This is deliberately a dust
-        // floor rather than `reservationMinAmount`: a minimum-sized
-        // reservation must remain migratable (a `reservationMinAmount` floor
-        // combined with the proposal validator's positive-fee requirement
-        // would leave no compliant re-anchor for an exactly-minimum anchor,
-        // pinning a retiring wallet). Bounding cumulative Byzantine
-        // re-anchor grinding is deferred to the authorized-action model (an
-        // explicit migration request with nonce, owner/target authorization,
-        // and a cumulative fee budget), tracked as a follow-up.
-        require(
-            newAnchorAmount > self.reservationTxMaxFee,
-            "Re-anchor amount below the dust floor"
-        );
+        reservation.state = ReservationState.ActionPending;
+        uint64 requestNonce = ++reservation.requestNonce;
 
-        bytes20 oldWalletPubKeyHash = reservation.walletPubKeyHash;
-        if (oldWalletPubKeyHash != newWalletPubKeyHash) {
-            self.walletReservationsCount[oldWalletPubKeyHash] -= 1;
-            uint32 newCount = self.walletReservationsCount[
-                newWalletPubKeyHash
-            ] + 1;
-            require(
-                newCount <= self.maxReservationsPerWallet,
-                "Wallet reservations cap exceeded"
-            );
-            self.walletReservationsCount[newWalletPubKeyHash] = newCount;
-        }
-
-        // The miner fee reduces the on-chain earmarked amount. The gross
-        // claim (`mintedAmount`) is unchanged; the accumulated in-kind fees
-        // are settled when the reservation is redeemed (full gross burn).
-        self.reservationTotalAmount -= (reservation.anchorAmount -
-            newAnchorAmount);
-
-        reservation.walletPubKeyHash = newWalletPubKeyHash;
-        reservation.anchorAmount = newAnchorAmount;
-        reservation.anchorTxHash = reanchorTxHash;
-        reservation.anchorTxOutputIndex = 0;
-
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
-        ] = reservationKey;
-
-        emit ReservationReanchored(
+        ReservationAction storage action = getAction(
+            self,
             reservationKey,
-            newWalletPubKeyHash,
-            reanchorTxHash,
-            newAnchorAmount
+            requestNonce
+        );
+        action.actionType = ActionType.Reanchor;
+        action.state = ActionState.Pending;
+        /* solhint-disable not-rely-on-time */
+        action.requestedAt = uint32(block.timestamp);
+        action.timeoutAt =
+            uint32(block.timestamp) +
+            self.reservationActionTimeout;
+        /* solhint-enable not-rely-on-time */
+        action.txMaxFee = self.reservationTxMaxFee;
+        action.targetWalletPubKeyHash = targetWalletPubKeyHash;
+        action.amount = reservation.anchorAmount;
+
+        emit ReservationReanchorRequested(
+            reservationKey,
+            requestNonce,
+            reservation.walletPubKeyHash,
+            targetWalletPubKeyHash,
+            action.txMaxFee
         );
     }
 
-    /// @notice Used by the wallet to prove a dissolution transaction merging
-    ///         an expired reservation's anchor outpoint into the wallet's
-    ///         main UTXO. After dissolution the owner's minted balance
-    ///         simply remains an ordinary pooled claim; no balances are
-    ///         moved or burned.
-    /// @param dissolutionTx Bitcoin dissolution transaction data.
-    /// @param dissolutionProof Bitcoin dissolution proof data.
-    /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
-    ///        the Ethereum chain. Ignored if the wallet has no main UTXO.
-    /// @param reservationKey The key of the reservation being dissolved.
+    /// @notice Requests the dissolution of an expired reservation: the
+    ///         authorization for the custodying wallet to merge the anchor
+    ///         into its main UTXO. After dissolution the owner's minted
+    ///         balance simply remains an ordinary pooled claim.
+    /// @param reservationKey The key of the reservation to dissolve.
     /// @dev Requirements:
-    ///      - The reservation must be in the Active state (a pending
-    ///        reserved redemption always wins over dissolution),
-    ///      - The custody term plus grace period must have elapsed,
+    ///      - The reservation must be Active,
+    ///      - The custody term plus (snapshotted) grace period must have
+    ///        elapsed,
     ///      - The custodying wallet must be in Live or MovingFunds state,
-    ///      - If the wallet has a main UTXO, `dissolutionTx` must spend
-    ///        exactly the anchor outpoint (first input) and that main UTXO
-    ///        (second input); otherwise it must spend exactly the anchor
-    ///        outpoint,
-    ///      - `dissolutionTx` must have a single P2(W)PKH output locking
-    ///        funds back on the custodying wallet's public key hash; that
-    ///        output becomes the wallet's new main UTXO.
+    ///      - No other dissolution may be in flight for the wallet (the
+    ///        per-wallet main-UTXO action lock): concurrent dissolutions
+    ///        of a no-main-UTXO wallet could otherwise all confirm on
+    ///        Bitcoin with only the first being provable.
     ///
-    ///      Note the Bridge cannot verify *when* the dissolution transaction
-    ///      was signed. A wallet signing it before the grace period elapses
-    ///      cannot prove it here (this function reverts), so such a spend is
-    ///      an undefeatable fraud challenge target until the grace period
-    ///      passes -- premature dissolution is deterred economically by the
-    ///      fraud slashing machinery.
-    function submitReservationDissolutionProof(
+    ///      Requesting a dissolution voids the position's redemption retry
+    ///      entitlement: dissolution is the terminal cleanup and the
+    ///      stranding bound takes precedence.
+    function requestReservationDissolution(
         BridgeState.Storage storage self,
-        BitcoinTx.Info calldata dissolutionTx,
-        BitcoinTx.Proof calldata dissolutionProof,
-        BitcoinTx.UTXO calldata mainUtxo,
         uint256 reservationKey
-    ) internal {
-        bytes32 dissolutionTxHash = self.validateProof(
-            dissolutionTx,
-            dissolutionProof
-        );
-
+    ) external {
         ReservationRequest storage reservation = self.reservations[
             reservationKey
         ];
@@ -921,12 +781,13 @@ library Reservation {
         require(
             /* solhint-disable-next-line not-rely-on-time */
             block.timestamp >
-                uint256(reservation.expiresAt) + self.reservationGracePeriod,
+                uint256(reservation.expiresAt) + reservation.gracePeriod,
             "Reservation term or grace period not elapsed"
         );
 
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
         Wallets.Wallet storage wallet = self.registeredWallets[
-            reservation.walletPubKeyHash
+            walletPubKeyHash
         ];
         {
             Wallets.WalletState walletState = wallet.state;
@@ -937,38 +798,233 @@ library Reservation {
             );
         }
 
-        uint64 inputsTotalValue = processDissolutionInputs(
+        require(
+            self.walletPendingDissolution[walletPubKeyHash] == 0,
+            "Another dissolution is pending for the wallet"
+        );
+        self.walletPendingDissolution[walletPubKeyHash] = reservationKey;
+
+        reservation.retryCredit = false;
+        reservation.state = ReservationState.ActionPending;
+        uint64 requestNonce = ++reservation.requestNonce;
+
+        ReservationAction storage action = getAction(
             self,
-            reservation,
-            dissolutionTx.inputVector,
-            wallet.mainUtxoHash,
-            mainUtxo
-        );
-
-        bytes memory output = parseSingleOutput(dissolutionTx.outputVector);
-        uint64 outputValue = output.extractValue();
-        require(
-            self.extractPubKeyHash(output) == reservation.walletPubKeyHash,
-            "Dissolution output must pay to the custodying wallet"
-        );
-        require(
-            inputsTotalValue - outputValue <= self.reservationTxMaxFee,
-            "Transaction fee is too high"
-        );
-
-        // The dissolution output becomes the wallet's new main UTXO: the
-        // reserved backing rejoins the pooled supply.
-        wallet.mainUtxoHash = keccak256(
-            abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
-        );
-
-        closeReservation(self, reservation);
-
-        emit ReservationDissolved(
             reservationKey,
-            reservation.walletPubKeyHash,
-            dissolutionTxHash
+            requestNonce
         );
+        action.actionType = ActionType.Dissolution;
+        action.state = ActionState.Pending;
+        /* solhint-disable not-rely-on-time */
+        action.requestedAt = uint32(block.timestamp);
+        action.timeoutAt =
+            uint32(block.timestamp) +
+            self.reservationActionTimeout;
+        /* solhint-enable not-rely-on-time */
+        action.txMaxFee = self.reservationTxMaxFee;
+        action.targetWalletPubKeyHash = walletPubKeyHash;
+        action.amount = reservation.anchorAmount;
+        action.expectedMainUtxoHash = wallet.mainUtxoHash;
+
+        emit ReservationDissolutionRequested(
+            reservationKey,
+            requestNonce,
+            walletPubKeyHash,
+            action.txMaxFee,
+            action.expectedMainUtxoHash
+        );
+    }
+
+    /// @notice Notifies that the pending action of the given reservation
+    ///         has timed out. Writes the terminal `TimedOut` record —
+    ///         which still accepts a late proof — releases the capacity
+    ///         and locks reserved at request time, refunds the escrowed
+    ///         claim for redemptions (minting the fee-free retry
+    ///         entitlement when the generation had paid the fee), and
+    ///         propagates wallet consequences: redemption and dissolution
+    ///         timeouts slash the wallet operators exactly like a pooled
+    ///         redemption timeout.
+    /// @param reservationKey The key of the reservation with the timed out
+    ///        action.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members. Only consulted for redemption and dissolution
+    ///        timeouts (the slashing path); pass an empty array otherwise.
+    /// @dev Requirements:
+    ///      - The reservation must have a pending action (or a pending
+    ///        acceptance authorization),
+    ///      - The action's timeout must have elapsed.
+    function notifyReservationActionTimeout(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        uint64 requestNonce = reservation.requestNonce;
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            requestNonce
+        );
+        require(action.state == ActionState.Pending, "No pending action");
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp > action.timeoutAt,
+            "Action has not timed out"
+        );
+
+        action.state = ActionState.TimedOut;
+
+        ActionType actionType = action.actionType;
+
+        if (actionType == ActionType.Acceptance) {
+            // Release the capacity reserved at request time; the deposit
+            // remains revealed and a new acceptance can be requested while
+            // the refund-locktime margin allows.
+            self.reservationTotalAmount -= action.amount;
+            self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
+        } else if (actionType == ActionType.Redemption) {
+            reservation.state = ReservationState.Active;
+
+            if (action.feePaid) {
+                reservation.retryCredit = true;
+                emit ReservationRetryCreditMinted(reservationKey);
+            }
+
+            // Propagate timeout consequences to the wallet: slashing and
+            // state transition follow the regular redemption timeout rules.
+            self.notifyWalletRedemptionTimeout(
+                reservation.walletPubKeyHash,
+                walletMembersIDs
+            );
+
+            // Return the escrowed balance to the redeemer as Bank balance.
+            self.bank.transferBalance(action.redeemer, action.amount);
+        } else if (actionType == ActionType.Reanchor) {
+            reservation.state = ReservationState.Active;
+            // Release the target wallet's reserved count capacity.
+            self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
+        } else {
+            // Dissolution.
+            reservation.state = ReservationState.Active;
+            delete self.walletPendingDissolution[reservation.walletPubKeyHash];
+
+            // A wallet failing its dissolution duty is slashed like a
+            // wallet failing a redemption: dissolution is the mechanism
+            // that makes term + grace a hard stranding bound.
+            self.notifyWalletRedemptionTimeout(
+                reservation.walletPubKeyHash,
+                walletMembersIDs
+            );
+        }
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservationActionTimedOut(
+            reservationKey,
+            requestNonce,
+            actionType
+        );
+    }
+
+    /// @notice Notifies that the pending reserved redemption of the given
+    ///         reservation was vetoed in the redemption watchtower. The
+    ///         escrowed balance is detained and passed to the watchtower
+    ///         (as Bank balance) for penalty/freeze processing, the
+    ///         generation becomes terminally `Vetoed` — a proof against it
+    ///         is rejected forever — and the position returns to Active:
+    ///         the anchor was not spent (an honest wallet does not sign
+    ///         before authorization), so the in-kind claim survives.
+    /// @param reservationKey The key of the reservation with the vetoed
+    ///        redemption.
+    /// @param requestNonce The generation being vetoed.
+    /// @dev Requirements:
+    ///      - The caller must be the redemption watchtower,
+    ///      - The generation must be the position's pending redemption.
+    function notifyReservedRedemptionVeto(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external {
+        require(
+            msg.sender == self.redemptionWatchtower,
+            "Caller is not the redemption watchtower"
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.requestNonce == requestNonce,
+            "Not the current generation"
+        );
+
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            requestNonce
+        );
+        require(
+            action.actionType == ActionType.Redemption &&
+                action.state == ActionState.Pending,
+            "No pending reserved redemption"
+        );
+
+        action.state = ActionState.Vetoed;
+        reservation.state = ReservationState.Active;
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionVetoed(reservationKey, requestNonce);
+
+        self.bank.transferBalance(self.redemptionWatchtower, action.amount);
+    }
+
+    /// @notice Extends the custody term of a reservation by its snapshotted
+    ///         term length. The custody fee for the extension is collected
+    ///         by the reservation vault before this call.
+    /// @param reservationKey The key of the reservation to extend.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation vault,
+    ///      - The reservation must be Active, or awaiting the settlement
+    ///        of a pending redemption,
+    ///      - The reservation must not be past its (snapshotted) grace
+    ///        period.
+    function extendReservation(
+        BridgeState.Storage storage self,
+        uint256 reservationKey
+    ) external {
+        require(
+            msg.sender == self.reservationVault,
+            "Caller is not the reservation vault"
+        );
+
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.Active ||
+                (reservation.state == ReservationState.ActionPending &&
+                    getAction(self, reservationKey, reservation.requestNonce)
+                        .actionType ==
+                    ActionType.Redemption),
+            "Reservation is not active"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <=
+                uint256(reservation.expiresAt) + reservation.gracePeriod,
+            "Reservation past grace period"
+        );
+
+        uint32 base = reservation.expiresAt;
+        /* solhint-disable-next-line not-rely-on-time */
+        if (base < block.timestamp) {
+            /* solhint-disable-next-line not-rely-on-time */
+            base = uint32(block.timestamp);
+        }
+        reservation.expiresAt = base + reservation.termSeconds;
+
+        emit ReservationExtended(reservationKey, reservation.expiresAt);
     }
 
     /// @notice Updates the reservation parameters, including the
@@ -979,8 +1035,13 @@ library Reservation {
     ///      - Reservation minimum amount must be greater than the
     ///        reservation transaction max fee,
     ///      - Reservation term must be greater than zero,
+    ///      - Reservation action timeout must be greater than zero,
     ///      - The reservation vault can only be changed while there are no
     ///        active reservations (total reserved amount is zero).
+    ///
+    ///      Term, grace period and fee bounds are snapshotted into
+    ///      positions and action records when they are created; updates
+    ///      apply prospectively only.
     function updateReservationParameters(
         BridgeState.Storage storage self,
         address reservationVault,
@@ -989,7 +1050,8 @@ library Reservation {
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint32 reservationActionTimeout
     ) external {
         require(
             reservationTxMaxFee > 0,
@@ -1002,6 +1064,10 @@ library Reservation {
         require(
             reservationTermSeconds > 0,
             "Reservation term must be greater than zero"
+        );
+        require(
+            reservationActionTimeout > 0,
+            "Reservation action timeout must be greater than zero"
         );
 
         if (reservationVault != self.reservationVault) {
@@ -1019,6 +1085,7 @@ library Reservation {
         self.reservationGracePeriod = reservationGracePeriod;
         self.reservationMaxTotalAmount = reservationMaxTotalAmount;
         self.maxReservationsPerWallet = maxReservationsPerWallet;
+        self.reservationActionTimeout = reservationActionTimeout;
 
         emit ReservationParametersUpdated(
             reservationMinAmount,
@@ -1026,165 +1093,9 @@ library Reservation {
             reservationTermSeconds,
             reservationGracePeriod,
             reservationMaxTotalAmount,
-            maxReservationsPerWallet
+            maxReservationsPerWallet,
+            reservationActionTimeout
         );
-    }
-
-    /// @notice Parses the given output vector and returns its single output.
-    ///         Reverts if the vector does not contain exactly one output.
-    function parseSingleOutput(bytes memory outputVector)
-        internal
-        pure
-        returns (bytes memory output)
-    {
-        (, uint256 outputsCount) = outputVector.parseVarInt();
-        require(
-            outputsCount == 1,
-            "Reservation transaction must have a single output"
-        );
-
-        output = outputVector.extractOutputAtIndex(0);
-    }
-
-    /// @notice Asserts the given input vector contains exactly one input
-    ///         pointing to the reservation's current anchor outpoint, marks
-    ///         that outpoint as correctly spent (making it recognized by the
-    ///         fraud challenge defeat path) and clears its anchor index
-    ///         entry.
-    function consumeAnchor(
-        BridgeState.Storage storage self,
-        ReservationRequest storage reservation,
-        bytes memory inputVector
-    ) internal {
-        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
-            .parseWalletOutboundTxInput(inputVector);
-
-        require(
-            reservation.anchorTxHash == outpointTxHash &&
-                reservation.anchorTxOutputIndex == outpointIndex,
-            "Transaction input must point to the reservation anchor"
-        );
-
-        uint256 anchorUtxoKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
-
-        // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
-        // anchor in `spentMainUTXOs` -- the existing registry of honestly
-        // spent wallet UTXOs -- makes the spend recognized by
-        // `Fraud.defeatFraudChallenge` without modifying the fraud library.
-        self.spentMainUTXOs[anchorUtxoKey] = true;
-        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
-    }
-
-    /// @notice Processes the dissolution transaction inputs: the first
-    ///         input must spend the reservation's anchor outpoint and, if
-    ///         the wallet has a main UTXO, the second input must spend
-    ///         exactly that main UTXO. Marks both consumed outpoints as
-    ///         correctly spent.
-    /// @return inputsTotalValue Sum of all inputs values.
-    function processDissolutionInputs(
-        BridgeState.Storage storage self,
-        ReservationRequest storage reservation,
-        bytes memory inputVector,
-        bytes32 mainUtxoHash,
-        BitcoinTx.UTXO calldata mainUtxo
-    ) internal returns (uint64 inputsTotalValue) {
-        bool mainUtxoExpected = mainUtxoHash != bytes32(0);
-
-        (uint256 varIntLength, uint256 inputsCount) = inputVector.parseVarInt();
-        require(
-            inputsCount == (mainUtxoExpected ? 2 : 1),
-            "Wrong number of dissolution transaction inputs"
-        );
-
-        // The first input must spend the reservation's anchor outpoint.
-        uint256 nextInputIndex = consumeAnchorInputAt(
-            self,
-            reservation,
-            inputVector,
-            1 + varIntLength
-        );
-        inputsTotalValue = reservation.anchorAmount;
-
-        if (mainUtxoExpected) {
-            require(
-                keccak256(
-                    abi.encodePacked(
-                        mainUtxo.txHash,
-                        mainUtxo.txOutputIndex,
-                        mainUtxo.txOutputValue
-                    )
-                ) == mainUtxoHash,
-                "Invalid main UTXO data"
-            );
-
-            consumeMainUtxoInputAt(self, inputVector, nextInputIndex, mainUtxo);
-            inputsTotalValue += mainUtxo.txOutputValue;
-        }
-
-        return inputsTotalValue;
-    }
-
-    /// @notice Asserts the input at the given starting index spends the
-    ///         reservation's current anchor outpoint, marks that outpoint as
-    ///         correctly spent and clears its anchor index entry.
-    /// @return nextInputIndex Starting index of the next input.
-    function consumeAnchorInputAt(
-        BridgeState.Storage storage self,
-        ReservationRequest storage reservation,
-        bytes memory inputVector,
-        uint256 inputStartingIndex
-    ) internal returns (uint256 nextInputIndex) {
-        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
-            inputStartingIndex
-        );
-        uint32 outpointIndex = BTCUtils.reverseUint32(
-            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
-        );
-
-        require(
-            reservation.anchorTxHash == outpointTxHash &&
-                reservation.anchorTxOutputIndex == outpointIndex,
-            "Transaction input must point to the reservation anchor"
-        );
-
-        uint256 anchorUtxoKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
-        // See `consumeAnchor` for the `spentMainUTXOs` rationale.
-        self.spentMainUTXOs[anchorUtxoKey] = true;
-        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
-
-        nextInputIndex =
-            inputStartingIndex +
-            inputVector.determineInputLengthAt(inputStartingIndex);
-    }
-
-    /// @notice Asserts the input at the given starting index spends the
-    ///         wallet's main UTXO and marks it as correctly spent.
-    function consumeMainUtxoInputAt(
-        BridgeState.Storage storage self,
-        bytes memory inputVector,
-        uint256 inputStartingIndex,
-        BitcoinTx.UTXO calldata mainUtxo
-    ) internal {
-        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
-            inputStartingIndex
-        );
-        uint32 outpointIndex = BTCUtils.reverseUint32(
-            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
-        );
-
-        require(
-            mainUtxo.txHash == outpointTxHash &&
-                mainUtxo.txOutputIndex == outpointIndex,
-            "Transaction input must point to the wallet's main UTXO"
-        );
-
-        self.spentMainUTXOs[
-            uint256(keccak256(abi.encodePacked(outpointTxHash, outpointIndex)))
-        ] = true;
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -230,16 +230,6 @@ library Reservation {
         uint32 timeoutAt
     );
 
-    event ReservationAccepted(
-        uint256 indexed reservationKey,
-        uint64 requestNonce,
-        bytes20 indexed walletPubKeyHash,
-        address indexed owner,
-        bytes32 anchorTxHash,
-        uint64 anchorAmount,
-        uint32 expiresAt
-    );
-
     event ReservationExtended(
         uint256 indexed reservationKey,
         uint32 newExpiresAt
@@ -255,12 +245,6 @@ library Reservation {
         bool feePaid
     );
 
-    event ReservedRedemptionCompleted(
-        uint256 indexed reservationKey,
-        uint64 requestNonce,
-        bytes32 redemptionTxHash
-    );
-
     event ReservationReanchorRequested(
         uint256 indexed reservationKey,
         uint64 requestNonce,
@@ -269,27 +253,12 @@ library Reservation {
         uint64 txMaxFee
     );
 
-    event ReservationReanchored(
-        uint256 indexed reservationKey,
-        uint64 requestNonce,
-        bytes20 indexed newWalletPubKeyHash,
-        bytes32 newAnchorTxHash,
-        uint64 newAnchorAmount
-    );
-
     event ReservationDissolutionRequested(
         uint256 indexed reservationKey,
         uint64 requestNonce,
         bytes20 indexed walletPubKeyHash,
         uint64 txMaxFee,
         bytes32 expectedMainUtxoHash
-    );
-
-    event ReservationDissolved(
-        uint256 indexed reservationKey,
-        uint64 requestNonce,
-        bytes20 indexed walletPubKeyHash,
-        bytes32 dissolutionTxHash
     );
 
     event ReservationActionTimedOut(
@@ -301,17 +270,6 @@ library Reservation {
     event ReservedRedemptionVetoed(
         uint256 indexed reservationKey,
         uint64 requestNonce
-    );
-
-    event ReservationActionSuperseded(
-        uint256 indexed reservationKey,
-        uint64 requestNonce
-    );
-
-    event ReservationLateSettled(
-        uint256 indexed reservationKey,
-        uint64 requestNonce,
-        ActionType actionType
     );
 
     event ReservationRetryCreditMinted(uint256 indexed reservationKey);

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -1102,7 +1102,8 @@ library Reservation {
     ///      - Reservation minimum amount must be greater than the
     ///        reservation transaction max fee,
     ///      - Reservation term must be greater than zero,
-    ///      - Reservation action timeout must be greater than zero,
+    ///      - Reservation action timeout must exceed the wallet proposal
+    ///        validator's final signing safety margin,
     ///      - The reservation vault can only be changed while there are no
     ///        active reservations (total reserved amount is zero).
     ///
@@ -1133,8 +1134,9 @@ library Reservation {
             "Reservation term must be greater than zero"
         );
         require(
-            reservationActionTimeout > 0,
-            "Reservation action timeout must be greater than zero"
+            reservationActionTimeout >
+                WalletProposalValidatorConstants.REQUEST_TIMEOUT_SAFETY_MARGIN,
+            "Reservation action timeout must exceed the safety margin"
         );
 
         if (reservationVault != self.reservationVault) {

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -224,6 +224,17 @@ library Reservation {
         // single-use retry entitlement. Needed to return the entitlement if
         // a late re-anchor makes the generation impossible to settle.
         bool usedRetryCredit;
+        // Reserved-redemption veto delay with no guardian objections,
+        // snapshotted from the watchtower policy at request time. Zero when
+        // the watchtower is absent, not enabled, disabled, or the amount is
+        // waived.
+        uint32 watchtowerDefaultDelay;
+        // Reserved-redemption veto delay after one guardian objection,
+        // snapshotted from the watchtower policy at request time.
+        uint32 watchtowerLevelOneDelay;
+        // Reserved-redemption veto delay after two guardian objections,
+        // snapshotted from the watchtower policy at request time.
+        uint32 watchtowerLevelTwoDelay;
     }
 
     event ReservationAcceptanceRequested(
@@ -598,6 +609,15 @@ library Reservation {
         action.redeemer = redeemer;
         action.amount = reservation.mintedAmount;
         action.redeemerOutputScriptHash = keccak256(redeemerOutputScriptMem);
+
+        if (self.redemptionWatchtower != address(0)) {
+            (
+                action.watchtowerDefaultDelay,
+                action.watchtowerLevelOneDelay,
+                action.watchtowerLevelTwoDelay
+            ) = IRedemptionWatchtower(self.redemptionWatchtower)
+                .getReservedRedemptionDelaySchedule(reservation.mintedAmount);
+        }
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionRequested(

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -376,8 +376,8 @@ library Reservation {
             "Deposit not routed to the reservation vault"
         );
 
-        BridgeState.ReservedDepositInfo storage reservedDeposit = self
-            .reservedDeposits[reservationKey];
+        BridgeState.PendingReservedDeposit storage reservedDeposit = self
+            .pendingReservedDeposit[reservationKey];
         require(
             reservedDeposit.walletPubKeyHash == walletPubKeyHash,
             "Wallet is not the deposit's designated wallet"

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -24,6 +24,7 @@ import "./Deposit.sol";
 import "./Redemption.sol";
 import "./ReservationProofs.sol";
 import "./Wallets.sol";
+import "./WalletProposalValidatorConstants.sol";
 
 import "../bank/Bank.sol";
 
@@ -387,9 +388,13 @@ library Reservation {
     ///      - The deposit amount must satisfy the reservation minimum plus
     ///        the transaction fee allowance, so a compliant anchor always
     ///        satisfies the minimum after fees,
-    ///      - The authorization window (now + action timeout) must end
-    ///        before the deposit's exact reveal-time refund deadline, so an
-    ///        authorized anchor can never race the depositor's refund,
+    ///      - At least one integer timestamp must remain after the deposit
+    ///        minimum age and before both the action-timeout and exact
+    ///        reveal-time refund safety margins, so every created action has
+    ///        a proposal the wallet validator can sign,
+    ///      - The authorization window (now + action timeout) must end before
+    ///        the exact refund deadline, so an authorized anchor can never
+    ///        race the depositor's refund,
     ///      - Reservation capacity (total amount, per-wallet count) must
     ///        allow the deposit; both are reserved by this call and
     ///        released if the authorization times out.
@@ -447,16 +452,44 @@ library Reservation {
         uint32 timeoutAt = uint32(block.timestamp) +
             self.reservationActionTimeout;
 
+        // Proposal timestamps are integer seconds and must be later than both
+        // the strict deposit-age boundary and the block creating the action.
+        // The first admissible timestamp is therefore one second after the
+        // greater of those two lower bounds.
+        uint256 signingLowerBound = uint256(deposit.revealedAt) +
+            WalletProposalValidatorConstants.DEPOSIT_MIN_AGE;
+        /* solhint-disable-next-line not-rely-on-time */
+        if (signingLowerBound < block.timestamp) {
+            /* solhint-disable-next-line not-rely-on-time */
+            signingLowerBound = block.timestamp;
+        }
+        uint256 earliestSigningAt = signingLowerBound + 1;
+
+        uint256 actionSigningDeadline = uint256(timeoutAt) -
+            WalletProposalValidatorConstants.REQUEST_TIMEOUT_SAFETY_MARGIN;
+        require(
+            earliestSigningAt < actionSigningDeadline,
+            "Acceptance authorization has no signing window"
+        );
+
         // Use the exact refund locktime captured at reveal. A later
         // governance update of `depositRevealAheadPeriod` must neither
-        // extend nor shorten this deposit's authorization window. Zero
-        // means the reveal-ahead validation was disabled at reveal time.
-        if (reservedDeposit.refundDeadline != 0) {
-            require(
-                timeoutAt <= reservedDeposit.refundDeadline,
-                "Authorization window would overlap the deposit refund window"
-            );
-        }
+        // extend nor shorten this deposit's authorization window. The raw
+        // deadline is retained even when reveal-ahead validation is disabled
+        // because the wallet validator always enforces its refund margin.
+        require(
+            timeoutAt <= reservedDeposit.refundDeadline,
+            "Authorization window would overlap the deposit refund window"
+        );
+        require(
+            uint256(reservedDeposit.refundDeadline) >
+                WalletProposalValidatorConstants.DEPOSIT_REFUND_SAFETY_MARGIN &&
+                earliestSigningAt <
+                uint256(reservedDeposit.refundDeadline) -
+                    WalletProposalValidatorConstants
+                        .DEPOSIT_REFUND_SAFETY_MARGIN,
+            "Acceptance authorization has no signing window"
+        );
 
         // Reserve capacity using the deposit value as the upper bound of
         // the anchor value; the settlement releases the miner-fee delta.

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -1144,10 +1144,7 @@ library Reservation {
                 self.reservationTotalAmount == 0,
                 "Active reservations exist"
             );
-            require(
-                self.reservationRouter != address(0),
-                "Router not set"
-            );
+            require(self.reservationRouter != address(0), "Router not set");
             self.reservationVault = reservationVault;
             emit ReservationVaultUpdated(reservationVault);
         }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -353,9 +353,8 @@ library Reservation {
     ///        the transaction fee allowance, so a compliant anchor always
     ///        satisfies the minimum after fees,
     ///      - The authorization window (now + action timeout) must end
-    ///        before the deposit's guaranteed refund-locktime margin
-    ///        (`revealedAt + depositRevealAheadPeriod`), so an authorized
-    ///        anchor can never race the depositor's refund,
+    ///        before the deposit's exact reveal-time refund deadline, so an
+    ///        authorized anchor can never race the depositor's refund,
     ///      - Reservation capacity (total amount, per-wallet count) must
     ///        allow the deposit; both are reserved by this call and
     ///        released if the authorization times out.
@@ -375,6 +374,13 @@ library Reservation {
         require(
             deposit.vault == self.reservationVault,
             "Deposit not routed to the reservation vault"
+        );
+
+        BridgeState.ReservedDepositInfo storage reservedDeposit = self
+            .reservedDeposits[reservationKey];
+        require(
+            reservedDeposit.walletPubKeyHash == walletPubKeyHash,
+            "Wallet is not the deposit's designated wallet"
         );
 
         ReservationRequest storage reservation = self.reservations[
@@ -406,14 +412,13 @@ library Reservation {
         uint32 timeoutAt = uint32(block.timestamp) +
             self.reservationActionTimeout;
 
-        // The reveal-ahead validation guarantees the deposit refund
-        // locktime is at least `depositRevealAheadPeriod` after the reveal.
-        // The authorization window must fit inside that guaranteed margin:
-        // the wallet must never hold an authorization that is still valid
-        // when the depositor's refund path may open.
-        if (self.depositRevealAheadPeriod > 0) {
+        // Use the exact refund locktime captured at reveal. A later
+        // governance update of `depositRevealAheadPeriod` must neither
+        // extend nor shorten this deposit's authorization window. Zero
+        // means the reveal-ahead validation was disabled at reveal time.
+        if (reservedDeposit.refundDeadline != 0) {
             require(
-                timeoutAt <= deposit.revealedAt + self.depositRevealAheadPeriod,
+                timeoutAt <= reservedDeposit.refundDeadline,
                 "Authorization window would overlap the deposit refund window"
             );
         }
@@ -619,6 +624,7 @@ library Reservation {
     ///        away from Live wallets.
     /// @dev Requirements:
     ///      - The reservation must be Active,
+    ///      - The reservation must not yet be eligible for dissolution,
     ///      - The source wallet must be in the MovingFunds state (anyone
     ///        may then request — migration is the system's duty), or Live
     ///        with the governance as the caller (approved rotation),
@@ -638,6 +644,12 @@ library Reservation {
         require(
             reservation.state == ReservationState.Active,
             "Reservation is not active"
+        );
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <=
+                uint256(reservation.expiresAt) + reservation.gracePeriod,
+            "Reservation past grace period"
         );
 
         {

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -164,8 +164,9 @@ library Reservation {
         uint64 requestNonce;
         // True when the owner holds a single-use, fee-free redemption
         // retry entitlement, minted when a fee-paid redemption request
-        // times out through the wallet's fault. Consumed by the next
-        // retry request; voided by a dissolution request.
+        // times out through the wallet's fault. It is returned if a late
+        // re-anchor supersedes the retry that consumed it. Consumed by the
+        // next retry request; voided by a dissolution request.
         bool retryCredit;
         // Custody term length in seconds, snapshotted at acceptance.
         // Extensions extend by this value; later governance changes apply
@@ -219,6 +220,10 @@ library Reservation {
         // Zero for other action types, and for dissolutions of wallets
         // with no main UTXO.
         bytes32 expectedMainUtxoHash;
+        // True when this redemption generation consumed the reservation's
+        // single-use retry entitlement. Needed to return the entitlement if
+        // a late re-anchor makes the generation impossible to settle.
+        bool usedRetryCredit;
     }
 
     event ReservationAcceptanceRequested(
@@ -589,6 +594,7 @@ library Reservation {
         action.timeoutAt = uint32(block.timestamp) + self.redemptionTimeout;
         action.txMaxFee = self.reservationTxMaxFee;
         action.feePaid = feePaid;
+        action.usedRetryCredit = useRetryCredit;
         action.redeemer = redeemer;
         action.amount = reservation.mintedAmount;
         action.redeemerOutputScriptHash = keccak256(redeemerOutputScriptMem);

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -298,6 +298,7 @@ library ReservationProofs {
 
         /* solhint-disable-next-line not-rely-on-time */
         deposit.sweptAt = uint32(block.timestamp);
+        delete self.reservedDeposits[reservationKey];
     }
 
     /// @notice Parses the anchor transaction's single output, validates it
@@ -793,6 +794,18 @@ library ReservationProofs {
         ];
 
         if (wallet.mainUtxoHash == action.expectedMainUtxoHash) {
+            // A timed-out dissolution may settle after a different
+            // reservation acquired the wallet lock against the same main
+            // UTXO. This proof consumes that shared snapshot, so the newer
+            // generation can no longer confirm and must be superseded now.
+            if (late && action.expectedMainUtxoHash != bytes32(0)) {
+                supersedeConflictingDissolution(
+                    self,
+                    walletPubKeyHash,
+                    reservationKey
+                );
+            }
+
             // The dissolution output becomes the wallet's new main UTXO:
             // the reserved backing rejoins the pooled supply.
             wallet.mainUtxoHash = keccak256(
@@ -823,6 +836,7 @@ library ReservationProofs {
             sweepRequest.state = MovingFunds
                 .MovedFundsSweepRequestState
                 .Pending;
+            wallet.pendingMovedFundsSweepRequestsCount++;
         }
 
         if (late) {
@@ -859,6 +873,45 @@ library ReservationProofs {
             walletPubKeyHash,
             dissolutionTxHash
         );
+    }
+
+    /// @notice Supersedes another reservation's pending dissolution when a
+    ///         late proof consumes the wallet main UTXO it snapshotted.
+    function supersedeConflictingDissolution(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash,
+        uint256 settledReservationKey
+    ) internal {
+        uint256 pendingReservationKey = self.walletPendingDissolution[
+            walletPubKeyHash
+        ];
+        if (
+            pendingReservationKey == 0 ||
+            pendingReservationKey == settledReservationKey
+        ) {
+            return;
+        }
+
+        Reservation.ReservationRequest storage pendingReservation = self
+            .reservations[pendingReservationKey];
+        Reservation.ReservationAction storage pendingAction = self
+            .reservationActions[
+                Reservation.actionKey(
+                    pendingReservationKey,
+                    pendingReservation.requestNonce
+                )
+            ];
+        require(
+            pendingReservation.state ==
+                Reservation.ReservationState.ActionPending &&
+                pendingAction.actionType ==
+                Reservation.ActionType.Dissolution &&
+                pendingAction.state == Reservation.ActionState.Pending,
+            "Invalid wallet dissolution lock"
+        );
+
+        unwindPendingAction(self, pendingReservation, pendingReservationKey);
+        pendingReservation.state = Reservation.ReservationState.Active;
     }
 
     /// @notice Resolves a late redemption settlement against the position's

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -67,6 +67,48 @@ library ReservationProofs {
     using BTCUtils for bytes;
     using BytesLib for bytes;
 
+    event ReservationAccepted(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed walletPubKeyHash,
+        address indexed owner,
+        bytes32 anchorTxHash,
+        uint64 anchorAmount,
+        uint32 expiresAt
+    );
+
+    event ReservedRedemptionCompleted(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes32 redemptionTxHash
+    );
+
+    event ReservationReanchored(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed newWalletPubKeyHash,
+        bytes32 newAnchorTxHash,
+        uint64 newAnchorAmount
+    );
+
+    event ReservationDissolved(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed walletPubKeyHash,
+        bytes32 dissolutionTxHash
+    );
+
+    event ReservationActionSuperseded(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationLateSettled(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType
+    );
+
     /// @notice Represents the type of a reservation lifecycle SPV proof.
     ///         Numbering matches `Reservation.ActionType` minus `None`.
     enum ProofType {
@@ -300,7 +342,7 @@ library ReservationProofs {
             // already confirmed on Bitcoin.
             self.reservationTotalAmount += anchorAmount;
             self.walletReservationsCount[action.targetWalletPubKeyHash] += 1;
-            emit Reservation.ReservationLateSettled(
+            emit ReservationLateSettled(
                 reservationKey,
                 requestNonce,
                 Reservation.ActionType.Acceptance
@@ -339,7 +381,7 @@ library ReservationProofs {
         ] = reservationKey;
 
         // slither-disable-next-line reentrancy-events
-        emit Reservation.ReservationAccepted(
+        emit ReservationAccepted(
             reservationKey,
             requestNonce,
             action.targetWalletPubKeyHash,
@@ -471,7 +513,7 @@ library ReservationProofs {
                 outputValue
             );
 
-            emit Reservation.ReservationLateSettled(
+            emit ReservationLateSettled(
                 reservationKey,
                 requestNonce,
                 Reservation.ActionType.Redemption
@@ -485,7 +527,7 @@ library ReservationProofs {
         self.closeReservation(reservation);
 
         // slither-disable-next-line reentrancy-events
-        emit Reservation.ReservedRedemptionCompleted(
+        emit ReservedRedemptionCompleted(
             reservationKey,
             requestNonce,
             redemptionTxHash
@@ -583,7 +625,8 @@ library ReservationProofs {
                 unwindPendingAction(self, reservation, reservationKey);
             }
 
-            emit Reservation.ReservationLateSettled(
+            // slither-disable-next-line reentrancy-events
+            emit ReservationLateSettled(
                 reservationKey,
                 requestNonce,
                 Reservation.ActionType.Reanchor
@@ -610,7 +653,8 @@ library ReservationProofs {
             uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
         ] = reservationKey;
 
-        emit Reservation.ReservationReanchored(
+        // slither-disable-next-line reentrancy-events
+        emit ReservationReanchored(
             reservationKey,
             requestNonce,
             newWalletPubKeyHash,
@@ -787,7 +831,8 @@ library ReservationProofs {
             ) {
                 unwindPendingAction(self, reservation, reservationKey);
             }
-            emit Reservation.ReservationLateSettled(
+            // slither-disable-next-line reentrancy-events
+            emit ReservationLateSettled(
                 reservationKey,
                 requestNonce,
                 Reservation.ActionType.Dissolution
@@ -807,7 +852,8 @@ library ReservationProofs {
         action.state = Reservation.ActionState.Settled;
         self.closeReservation(reservation);
 
-        emit Reservation.ReservationDissolved(
+        // slither-disable-next-line reentrancy-events
+        emit ReservationDissolved(
             reservationKey,
             requestNonce,
             walletPubKeyHash,
@@ -901,10 +947,10 @@ library ReservationProofs {
             }
         }
 
-        emit Reservation.ReservationActionSuperseded(
-            reservationKey,
-            pendingNonce
-        );
+        // The Bank is a trusted protocol contract; the refund above cannot
+        // reenter in a way that makes this event misleading.
+        // slither-disable-next-line reentrancy-events
+        emit ReservationActionSuperseded(reservationKey, pendingNonce);
     }
 
     /// @notice Parses the given output vector and returns its single output.

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -271,6 +271,36 @@ library ReservationProofs {
             "Deposit was not revealed as reserved"
         );
 
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+
+        if (late && reservation.requestNonce != requestNonce) {
+            // A newer pending acceptance generation exists. Its anchor can
+            // never confirm: the deposit this late proof consumes is the
+            // only input it was authorized to spend, and the deposit is
+            // irrevocably swept below. Release its reserved capacity and
+            // mark it Superseded so the capacity and per-wallet count do
+            // not leak permanently. Guard on it being Pending; a newer
+            // generation that already timed out or settled needs no unwind
+            // here (its capacity was already released or its own proof
+            // settled it).
+            Reservation.ReservationAction storage newerAction = self
+                .reservationActions[
+                    Reservation.actionKey(
+                        reservationKey,
+                        reservation.requestNonce
+                    )
+                ];
+            if (
+                newerAction.actionType ==
+                Reservation.ActionType.Acceptance &&
+                newerAction.state == Reservation.ActionState.Pending
+            ) {
+                unwindPendingAction(self, reservation, reservationKey, false);
+            }
+        }
+
         bytes32 anchorTxHash = self.validateProof(anchorTx, anchorProof);
 
         consumeAcceptedDeposit(self, anchorTx.inputVector, reservationKey);
@@ -363,13 +393,48 @@ library ReservationProofs {
     ) internal {
         action.state = Reservation.ActionState.Settled;
 
+        address depositor = self.deposits[reservationKey].depositor;
+        bytes20 targetWalletPubKeyHash = action.targetWalletPubKeyHash;
+
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+
+        bool walletTerminated =
+            self.registeredWallets[targetWalletPubKeyHash].state ==
+            Wallets.WalletState.Terminated;
+
         if (late) {
+            if (walletTerminated) {
+                // The wallet was terminated while this timed-out acceptance
+                // generation's anchor may already have confirmed on
+                // Bitcoin. Minting here would create unbacked TBTC: the
+                // dissolving signing group that holds the anchor can never
+                // unwind it through the tracked settlement paths (mirrors
+                // the terminated-wallet branch of `settleDissolution`).
+                // Record the position as Stranded for off-chain recovery
+                // and emit the event; no Bank movement is performed.
+                reservation.owner = depositor;
+                reservation.walletPubKeyHash = targetWalletPubKeyHash;
+                reservation.anchorAmount = anchorAmount;
+                reservation.anchorTxHash = anchorTxHash;
+                reservation.state = Reservation.ReservationState.Stranded;
+
+                // slither-disable-next-line reentrancy-events
+                emit ReservationLateSettled(
+                    reservationKey,
+                    requestNonce,
+                    Reservation.ActionType.Acceptance
+                );
+                return;
+            }
+
             // The timeout released the capacity reserved at request time;
             // re-take it for the actual anchor value. Deliberately no cap
             // check: caps are request-time throttles and the anchor is
             // already confirmed on Bitcoin.
             self.reservationTotalAmount += anchorAmount;
-            self.walletReservationsCount[action.targetWalletPubKeyHash] += 1;
+            self.walletReservationsCount[targetWalletPubKeyHash] += 1;
             emit ReservationLateSettled(
                 reservationKey,
                 requestNonce,
@@ -380,12 +445,6 @@ library ReservationProofs {
             // (deposit value) and the actual anchor value (miner fee).
             self.reservationTotalAmount -= (action.amount - anchorAmount);
         }
-
-        address depositor = self.deposits[reservationKey].depositor;
-
-        Reservation.ReservationRequest storage reservation = self.reservations[
-            reservationKey
-        ];
 
         /* solhint-disable-next-line not-rely-on-time */
         uint32 expiresAt = uint32(block.timestamp) +
@@ -644,18 +703,61 @@ library ReservationProofs {
             "Re-anchor amount below the dust floor"
         );
 
+        bool targetWalletTerminated =
+            self.registeredWallets[newWalletPubKeyHash].state ==
+            Wallets.WalletState.Terminated;
+
         if (late) {
+            if (targetWalletTerminated) {
+                // The target wallet was terminated while this timed-out
+                // re-anchor generation's transaction may already have
+                // confirmed. Re-anchoring onto a terminated wallet's count
+                // would re-take capacity against a dead wallet that can
+                // never unwind it (mirrors the terminated-wallet branch of
+                // `settleDissolution`). Release the source wallet's count,
+                // remove the anchor's full value from the tracked reserved
+                // amount (the position is no longer an in-kind claim: the
+                // owner's minted balance is ordinary pooled backing), and
+                // strand the position for off-chain recovery. No newer
+                // pending generation is unwound here -- a late re-anchor
+                // that strands never consumes an anchor a newer generation
+                // could still settle (the newer generation's anchor is the
+                // source anchor this transaction provably consumed, so it
+                // is unwound via the normal late-settle path instead).
+                self.walletReservationsCount[reservation.walletPubKeyHash] -=
+                    1;
+                self.reservationTotalAmount -= reservation.anchorAmount;
+
+                reservation.walletPubKeyHash = newWalletPubKeyHash;
+                reservation.state = Reservation.ReservationState.Stranded;
+
+                action.state = Reservation.ActionState.Settled;
+
+                // slither-disable-next-line reentrancy-events
+                emit ReservationLateSettled(
+                    reservationKey,
+                    requestNonce,
+                    Reservation.ActionType.Reanchor
+                );
+                return;
+            }
+
             // The timeout released the target wallet's reserved count;
             // re-take it. Deliberately no cap check (see acceptance).
             self.walletReservationsCount[newWalletPubKeyHash] += 1;
 
             // A newer pending generation references an anchor this
-            // transaction just consumed; unwind it.
-            if (
-                reservation.state == Reservation.ReservationState.ActionPending
-            ) {
-                unwindPendingAction(self, reservation, reservationKey, true);
-            }
+            // transaction just consumed; unless it also matches the
+            // transaction (same target wallet within fee bound -- the
+            // wallet could have signed either generation's authorization
+            // for this exact spend), unwind it.
+            resolveLateReanchorAgainstPending(
+                self,
+                reservation,
+                reservationKey,
+                action,
+                newAnchorAmount
+            );
 
             // slither-disable-next-line reentrancy-events
             emit ReservationLateSettled(
@@ -1015,6 +1117,45 @@ library ReservationProofs {
         unwindPendingAction(self, reservation, reservationKey, false);
     }
 
+    /// @notice Resolves a late re-anchor settlement against the position's
+    ///         current pending generation. If the pending generation is
+    ///         also a re-anchor authorizing the same target wallet within
+    ///         its own fee bound, the proof must settle against it instead
+    ///         (the wallet could have signed either generation's
+    ///         authorization for this exact spend, and attributing the
+    ///         re-taken capacity to the wrong generation's bookkeeping
+    ///         would be incorrect); otherwise the pending generation's
+    ///         anchor is provably gone and it is unwound.
+    function resolveLateReanchorAgainstPending(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        Reservation.ReservationAction storage action,
+        uint64 newAnchorAmount
+    ) internal {
+        if (reservation.state != Reservation.ReservationState.ActionPending) {
+            return;
+        }
+
+        Reservation.ReservationAction storage pendingAction = self
+            .reservationActions[
+                Reservation.actionKey(reservationKey, reservation.requestNonce)
+            ];
+        if (
+            pendingAction.actionType == Reservation.ActionType.Reanchor &&
+            pendingAction.targetWalletPubKeyHash ==
+            action.targetWalletPubKeyHash &&
+            reservation.anchorAmount - newAnchorAmount <=
+            pendingAction.txMaxFee
+        ) {
+            revert("Must settle the pending generation");
+        }
+
+        // The pending generation cannot claim the transaction; its anchor
+        // is gone, so unwind it.
+        unwindPendingAction(self, reservation, reservationKey, true);
+    }
+
     /// @notice Unwinds the position's current pending generation during a
     ///         late settlement of an older generation: the anchor the
     ///         pending generation was authorized to spend has provably been
@@ -1054,6 +1195,17 @@ library ReservationProofs {
                 pendingAction.redeemer,
                 pendingAction.amount
             );
+        } else if (
+            pendingAction.actionType == Reservation.ActionType.Acceptance
+        ) {
+            // Release the capacity reserved by the superseded acceptance
+            // request. The generation it was authorized to settle was
+            // provably consumed by the late settlement that superseded it
+            // (the deposit it would accept is already swept).
+            self.reservationTotalAmount -= pendingAction.amount;
+            self.walletReservationsCount[
+                pendingAction.targetWalletPubKeyHash
+            ] -= 1;
         } else if (
             pendingAction.actionType == Reservation.ActionType.Reanchor
         ) {

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -204,6 +204,22 @@ library ReservationProofs {
         late = action.state == Reservation.ActionState.TimedOut;
     }
 
+    /// @notice Reverts unless the reservation still points at the exact
+    ///         anchor outpoint this generation was authorized to spend.
+    ///         This prevents a timed-out generation from being replayed
+    ///         against a later anchor whose transaction merely has the old
+    ///         generation's output shape.
+    function requireCurrentSourceAnchor(
+        Reservation.ReservationRequest storage reservation,
+        Reservation.ReservationAction storage action
+    ) internal view {
+        require(
+            Reservation.anchorUtxoHash(reservation) ==
+                action.sourceAnchorUtxoHash,
+            "Action source anchor is no longer current"
+        );
+    }
+
     /// @notice Used by the wallet to prove the BTC anchor transaction of an
     ///         authorized reserved deposit acceptance and to credit the
     ///         owner's balance accordingly.
@@ -479,6 +495,8 @@ library ReservationProofs {
             }
         }
 
+        requireCurrentSourceAnchor(reservation, action);
+
         bytes32 redemptionTxHash = self.validateProof(
             redemptionTx,
             redemptionProof
@@ -492,7 +510,7 @@ library ReservationProofs {
         {
             bytes memory outputScript = output.slice(8, output.length - 8);
             require(
-                keccak256(outputScript) == action.redeemerOutputScriptHash,
+                keccak256(outputScript) == action.actionDataHash,
                 "Output does not pay the requested redeemer script"
             );
         }
@@ -586,6 +604,8 @@ library ReservationProofs {
                 "Not the current generation"
             );
         }
+
+        requireCurrentSourceAnchor(reservation, action);
 
         bytes32 reanchorTxHash = self.validateProof(reanchorTx, reanchorProof);
 
@@ -718,6 +738,8 @@ library ReservationProofs {
             );
         }
 
+        requireCurrentSourceAnchor(reservation, action);
+
         bytes32 dissolutionTxHash = self.validateProof(
             dissolutionTx,
             dissolutionProof
@@ -727,7 +749,7 @@ library ReservationProofs {
             self,
             reservation,
             dissolutionTx.inputVector,
-            action.expectedMainUtxoHash,
+            action.actionDataHash,
             mainUtxo
         );
 
@@ -799,12 +821,12 @@ library ReservationProofs {
         ];
         bool walletTerminated = wallet.state == Wallets.WalletState.Terminated;
 
-        if (wallet.mainUtxoHash == action.expectedMainUtxoHash) {
+        if (wallet.mainUtxoHash == action.actionDataHash) {
             // A timed-out dissolution may settle after a different
             // reservation acquired the wallet lock against the same main
             // UTXO. This proof consumes that shared snapshot, so the newer
             // generation can no longer confirm and must be superseded now.
-            if (late && action.expectedMainUtxoHash != bytes32(0)) {
+            if (late && action.actionDataHash != bytes32(0)) {
                 supersedeConflictingDissolution(
                     self,
                     walletPubKeyHash,
@@ -818,7 +840,7 @@ library ReservationProofs {
                 // UTXO. The dissolution output is deliberately not installed
                 // as a replacement: Bridge spending paths reject Terminated
                 // wallets and their registry group is already closed.
-                if (action.expectedMainUtxoHash != bytes32(0)) {
+                if (action.actionDataHash != bytes32(0)) {
                     delete wallet.mainUtxoHash;
                 }
             } else {
@@ -831,7 +853,7 @@ library ReservationProofs {
             }
         } else {
             require(
-                action.expectedMainUtxoHash == bytes32(0),
+                action.actionDataHash == bytes32(0),
                 "Recorded main UTXO can no longer be spent"
             );
 
@@ -973,8 +995,7 @@ library ReservationProofs {
             ];
         if (
             pendingAction.actionType == Reservation.ActionType.Redemption &&
-            pendingAction.redeemerOutputScriptHash ==
-            action.redeemerOutputScriptHash &&
+            pendingAction.actionDataHash == action.actionDataHash &&
             reservation.anchorAmount - outputValue <= pendingAction.txMaxFee
         ) {
             revert("Must settle the pending generation");

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -298,7 +298,7 @@ library ReservationProofs {
 
         /* solhint-disable-next-line not-rely-on-time */
         deposit.sweptAt = uint32(block.timestamp);
-        delete self.reservedDeposits[reservationKey];
+        delete self.pendingReservedDeposit[reservationKey];
     }
 
     /// @notice Parses the anchor transaction's single output, validates it
@@ -811,6 +811,7 @@ library ReservationProofs {
             wallet.mainUtxoHash = keccak256(
                 abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
             );
+            Wallets.rearmMovingFundsTimeout(self, walletPubKeyHash);
         } else {
             // Registry drift: another transaction (e.g. a deposit sweep)
             // registered a main UTXO after this no-main-UTXO dissolution

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -772,9 +772,12 @@ library ReservationProofs {
 
     /// @notice Finalizes a dissolution settlement: registers the output as
     ///         the wallet's new main UTXO (or as a moved-funds sweep
-    ///         request when the registry drifted), releases the per-wallet
-    ///         main-UTXO action lock, unwinds a superseded pending
-    ///         generation on late settlements and closes the position.
+    ///         request when the registry drifted), unless the wallet was
+    ///         terminated after authorization. In that case, settles the
+    ///         confirmed spend as stranded recovery evidence instead.
+    ///         Releases the per-wallet main-UTXO action lock, unwinds a
+    ///         superseded pending generation on late settlements and closes
+    ///         or strands the position.
     function settleDissolution(
         BridgeState.Storage storage self,
         uint256 reservationKey,
@@ -792,6 +795,7 @@ library ReservationProofs {
         Wallets.Wallet storage wallet = self.registeredWallets[
             walletPubKeyHash
         ];
+        bool walletTerminated = wallet.state == Wallets.WalletState.Terminated;
 
         if (wallet.mainUtxoHash == action.expectedMainUtxoHash) {
             // A timed-out dissolution may settle after a different
@@ -806,38 +810,52 @@ library ReservationProofs {
                 );
             }
 
-            // The dissolution output becomes the wallet's new main UTXO:
-            // the reserved backing rejoins the pooled supply.
-            wallet.mainUtxoHash = keccak256(
-                abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
-            );
-            Wallets.rearmMovingFundsTimeout(self, walletPubKeyHash);
+            if (walletTerminated) {
+                // A nonzero snapshot was consumed by the proven transaction.
+                // Do not leave the terminated wallet pointing at that spent
+                // UTXO. The dissolution output is deliberately not installed
+                // as a replacement: Bridge spending paths reject Terminated
+                // wallets and their registry group is already closed.
+                if (action.expectedMainUtxoHash != bytes32(0)) {
+                    delete wallet.mainUtxoHash;
+                }
+            } else {
+                // The dissolution output becomes the wallet's new main UTXO:
+                // the reserved backing rejoins the pooled supply.
+                wallet.mainUtxoHash = keccak256(
+                    abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
+                );
+                Wallets.rearmMovingFundsTimeout(self, walletPubKeyHash);
+            }
         } else {
-            // Registry drift: another transaction (e.g. a deposit sweep)
-            // registered a main UTXO after this no-main-UTXO dissolution
-            // was authorized. The confirmed dissolution output is a
-            // wallet-held UTXO the registry must keep tracking; register
-            // it for the moved-funds sweep machinery to consolidate.
             require(
                 action.expectedMainUtxoHash == bytes32(0),
                 "Recorded main UTXO can no longer be spent"
             );
-            MovingFunds.MovedFundsSweepRequest storage sweepRequest = self
-                .movedFundsSweepRequests[
-                    uint256(
-                        keccak256(
-                            abi.encodePacked(dissolutionTxHash, uint32(0))
+
+            if (!walletTerminated) {
+                // Registry drift: another transaction (e.g. a deposit sweep)
+                // registered a main UTXO after this no-main-UTXO dissolution
+                // was authorized. The confirmed dissolution output is a
+                // wallet-held UTXO the registry must keep tracking; register
+                // it for the moved-funds sweep machinery to consolidate.
+                MovingFunds.MovedFundsSweepRequest storage sweepRequest = self
+                    .movedFundsSweepRequests[
+                        uint256(
+                            keccak256(
+                                abi.encodePacked(dissolutionTxHash, uint32(0))
+                            )
                         )
-                    )
-                ];
-            sweepRequest.walletPubKeyHash = walletPubKeyHash;
-            sweepRequest.value = outputValue;
-            /* solhint-disable-next-line not-rely-on-time */
-            sweepRequest.createdAt = uint32(block.timestamp);
-            sweepRequest.state = MovingFunds
-                .MovedFundsSweepRequestState
-                .Pending;
-            wallet.pendingMovedFundsSweepRequestsCount++;
+                    ];
+                sweepRequest.walletPubKeyHash = walletPubKeyHash;
+                sweepRequest.value = outputValue;
+                /* solhint-disable-next-line not-rely-on-time */
+                sweepRequest.createdAt = uint32(block.timestamp);
+                sweepRequest.state = MovingFunds
+                    .MovedFundsSweepRequestState
+                    .Pending;
+                wallet.pendingMovedFundsSweepRequestsCount++;
+            }
         }
 
         if (late) {
@@ -866,6 +884,14 @@ library ReservationProofs {
 
         action.state = Reservation.ActionState.Settled;
         self.closeReservation(reservation);
+        if (walletTerminated) {
+            // The confirmed transaction and the event below provide the
+            // evidence needed for off-chain recovery, while the owner's
+            // minted balance remains an ordinary pooled claim. Classifying
+            // the position as Stranded socializes the unavailable backing in
+            // the same way as any other Terminated-wallet UTXO.
+            reservation.state = Reservation.ReservationState.Stranded;
+        }
 
         // slither-disable-next-line reentrancy-events
         emit ReservationDissolved(

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -103,6 +103,8 @@ library ReservationProofs {
         uint64 requestNonce
     );
 
+    event ReservationRetryCreditMinted(uint256 indexed reservationKey);
+
     event ReservationLateSettled(
         uint256 indexed reservationKey,
         uint64 requestNonce,
@@ -623,7 +625,7 @@ library ReservationProofs {
             if (
                 reservation.state == Reservation.ReservationState.ActionPending
             ) {
-                unwindPendingAction(self, reservation, reservationKey);
+                unwindPendingAction(self, reservation, reservationKey, true);
             }
 
             // slither-disable-next-line reentrancy-events
@@ -862,7 +864,7 @@ library ReservationProofs {
             if (
                 reservation.state == Reservation.ReservationState.ActionPending
             ) {
-                unwindPendingAction(self, reservation, reservationKey);
+                unwindPendingAction(self, reservation, reservationKey, false);
             }
             // slither-disable-next-line reentrancy-events
             emit ReservationLateSettled(
@@ -937,7 +939,12 @@ library ReservationProofs {
             "Invalid wallet dissolution lock"
         );
 
-        unwindPendingAction(self, pendingReservation, pendingReservationKey);
+        unwindPendingAction(
+            self,
+            pendingReservation,
+            pendingReservationKey,
+            false
+        );
         pendingReservation.state = Reservation.ReservationState.Active;
     }
 
@@ -975,7 +982,7 @@ library ReservationProofs {
 
         // The pending generation cannot claim the transaction; its anchor
         // is gone, so unwind it.
-        unwindPendingAction(self, reservation, reservationKey);
+        unwindPendingAction(self, reservation, reservationKey, false);
     }
 
     /// @notice Unwinds the position's current pending generation during a
@@ -983,11 +990,15 @@ library ReservationProofs {
     ///         pending generation was authorized to spend has provably been
     ///         consumed, so the generation can never settle. Its escrow is
     ///         refunded (redemptions), its reserved capacity and locks are
-    ///         released, and it is terminally marked `Superseded`.
+    ///         released, and it is terminally marked `Superseded`. Retry
+    ///         credit restoration is enabled only by the late-reanchor call
+    ///         site, whose successful settlement leaves the reservation
+    ///         Active on a replacement anchor.
     function unwindPendingAction(
         BridgeState.Storage storage self,
         Reservation.ReservationRequest storage reservation,
-        uint256 reservationKey
+        uint256 reservationKey,
+        bool restoreRetryCredit
     ) internal {
         uint64 pendingNonce = reservation.requestNonce;
         Reservation.ReservationAction storage pendingAction = self
@@ -1002,6 +1013,11 @@ library ReservationProofs {
         pendingAction.state = Reservation.ActionState.Superseded;
 
         if (pendingAction.actionType == Reservation.ActionType.Redemption) {
+            if (restoreRetryCredit && pendingAction.usedRetryCredit) {
+                reservation.retryCredit = true;
+                emit ReservationRetryCreditMinted(reservationKey);
+            }
+
             // Return the escrowed balance: the redeemer surrendered it for
             // an anchor that no longer exists.
             self.bank.transferBalance(

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -293,8 +293,7 @@ library ReservationProofs {
                     )
                 ];
             if (
-                newerAction.actionType ==
-                Reservation.ActionType.Acceptance &&
+                newerAction.actionType == Reservation.ActionType.Acceptance &&
                 newerAction.state == Reservation.ActionState.Pending
             ) {
                 unwindPendingAction(self, reservation, reservationKey, false);
@@ -400,9 +399,9 @@ library ReservationProofs {
             reservationKey
         ];
 
-        bool walletTerminated =
-            self.registeredWallets[targetWalletPubKeyHash].state ==
-            Wallets.WalletState.Terminated;
+        bool walletTerminated = self
+            .registeredWallets[targetWalletPubKeyHash]
+            .state == Wallets.WalletState.Terminated;
 
         if (late) {
             if (walletTerminated) {
@@ -703,9 +702,9 @@ library ReservationProofs {
             "Re-anchor amount below the dust floor"
         );
 
-        bool targetWalletTerminated =
-            self.registeredWallets[newWalletPubKeyHash].state ==
-            Wallets.WalletState.Terminated;
+        bool targetWalletTerminated = self
+            .registeredWallets[newWalletPubKeyHash]
+            .state == Wallets.WalletState.Terminated;
 
         if (late) {
             if (targetWalletTerminated) {
@@ -724,8 +723,7 @@ library ReservationProofs {
                 // could still settle (the newer generation's anchor is the
                 // source anchor this transaction provably consumed, so it
                 // is unwound via the normal late-settle path instead).
-                self.walletReservationsCount[reservation.walletPubKeyHash] -=
-                    1;
+                self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
                 self.reservationTotalAmount -= reservation.anchorAmount;
 
                 reservation.walletPubKeyHash = newWalletPubKeyHash;
@@ -1145,8 +1143,7 @@ library ReservationProofs {
             pendingAction.actionType == Reservation.ActionType.Reanchor &&
             pendingAction.targetWalletPubKeyHash ==
             action.targetWalletPubKeyHash &&
-            reservation.anchorAmount - newAnchorAmount <=
-            pendingAction.txMaxFee
+            reservation.anchorAmount - newAnchorAmount <= pendingAction.txMaxFee
         ) {
             revert("Must settle the pending generation");
         }

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -1,0 +1,1066 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import {BTCUtils} from "@keep-network/bitcoin-spv-sol/contracts/BTCUtils.sol";
+import {BytesLib} from "@keep-network/bitcoin-spv-sol/contracts/BytesLib.sol";
+
+import "./BitcoinTx.sol";
+import "./BridgeState.sol";
+import "./Deposit.sol";
+import "./MovingFunds.sol";
+import "./Redemption.sol";
+import "./Reservation.sol";
+import "./Wallets.sol";
+
+import "../bank/Bank.sol";
+
+/// @title Bridge UTXO reservations — settlement
+/// @notice SPV settlement side of the two-phase reservation model (see
+///         `Reservation` for the request/authorization side and RFC 13 for
+///         the architecture). Every proof settles one requested
+///         *generation*, named explicitly by `(reservationKey,
+///         requestNonce)`, and is validated exclusively against that
+///         generation's snapshotted action record — never against live
+///         parameters.
+/// @dev Settlement rules shared by all action types:
+///
+///      - A `Pending` generation settles normally. For redemptions the
+///        proof additionally requires the watchtower delay of the
+///        generation to have elapsed — a Byzantine wallet broadcasting
+///        before authorization cannot finalize early, and if the
+///        generation is vetoed its transaction is unprovable forever
+///        (the fraud machinery handles the unauthorized signature).
+///
+///      - A `TimedOut` generation still settles ("late settlement"): the
+///        Bitcoin transaction confirmed and the anchor is irrevocably
+///        spent, so the registry records reality — consumed outpoints are
+///        marked honestly spent (defeating fraud challenges against the
+///        honest-but-late signature), the anchor lineage closes, and any
+///        newer pending generation whose anchor no longer exists is
+///        unwound (its escrow refunded). What late settlement never does
+///        is repeat a Bank movement: the timeout already refunded the
+///        escrow, so nothing is burned or paid again. If the position's
+///        *current pending* redemption generation matches the transaction
+///        as well, the proof must settle against it instead — the
+///        deterministic, economically correct target.
+///
+///      - A `Vetoed` generation never settles.
+library ReservationProofs {
+    using BridgeState for BridgeState.Storage;
+    using BitcoinTx for BridgeState.Storage;
+    using Reservation for BridgeState.Storage;
+
+    using BTCUtils for bytes;
+    using BytesLib for bytes;
+
+    /// @notice Represents the type of a reservation lifecycle SPV proof.
+    ///         Numbering matches `Reservation.ActionType` minus `None`.
+    enum ProofType {
+        Acceptance,
+        Redemption,
+        Reanchor,
+        Dissolution
+    }
+
+    /// @notice Single entry point for all reservation lifecycle SPV proofs.
+    ///         Dispatches to the appropriate handler based on `proofType`.
+    /// @param proofType The type of the submitted proof, see `ProofType`.
+    /// @param txInfo Bitcoin transaction data.
+    /// @param proof Bitcoin proof data.
+    /// @param mainUtxo Data of the main UTXO expected by a `Dissolution`
+    ///        generation; ignored otherwise.
+    /// @param reservationKey The key of the target reservation.
+    /// @param requestNonce The generation being settled. Late settlements
+    ///        name an older, timed-out generation.
+    function submitReservationProof(
+        BridgeState.Storage storage self,
+        uint8 proofType,
+        BitcoinTx.Info calldata txInfo,
+        BitcoinTx.Proof calldata proof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external {
+        ProofType parsedProofType = ProofType(proofType);
+
+        if (parsedProofType == ProofType.Acceptance) {
+            submitReservationAcceptanceProof(
+                self,
+                txInfo,
+                proof,
+                reservationKey,
+                requestNonce
+            );
+        } else if (parsedProofType == ProofType.Redemption) {
+            submitReservedRedemptionProof(
+                self,
+                txInfo,
+                proof,
+                reservationKey,
+                requestNonce
+            );
+        } else if (parsedProofType == ProofType.Reanchor) {
+            submitReservationReanchorProof(
+                self,
+                txInfo,
+                proof,
+                reservationKey,
+                requestNonce
+            );
+        } else {
+            submitReservationDissolutionProof(
+                self,
+                txInfo,
+                proof,
+                mainUtxo,
+                reservationKey,
+                requestNonce
+            );
+        }
+    }
+
+    /// @notice Loads the action record of the generation being settled and
+    ///         validates it is settleable (`Pending` or `TimedOut`) and of
+    ///         the expected type.
+    /// @return action The action record.
+    /// @return late True when settling a timed-out generation.
+    function loadSettleableAction(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType expectedType
+    )
+        internal
+        view
+        returns (Reservation.ReservationAction storage action, bool late)
+    {
+        action = self.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
+        require(action.actionType == expectedType, "Action type mismatch");
+        require(
+            action.state == Reservation.ActionState.Pending ||
+                action.state == Reservation.ActionState.TimedOut,
+            "Action is not settleable"
+        );
+        late = action.state == Reservation.ActionState.TimedOut;
+    }
+
+    /// @notice Used by the wallet to prove the BTC anchor transaction of an
+    ///         authorized reserved deposit acceptance and to credit the
+    ///         owner's balance accordingly.
+    ///
+    ///         The anchor transaction must spend exactly the revealed
+    ///         reserved deposit as its sole input and create exactly one
+    ///         P2(W)PKH output controlled by the wallet the acceptance
+    ///         request authorized. Proving it marks the deposit as swept
+    ///         (blocking any regular sweep and enabling fraud challenge
+    ///         defeats for the deposit outpoint), registers the reservation
+    ///         and credits the gross anchor value to the depositor through
+    ///         the reservation vault.
+    /// @dev Requirements:
+    ///      - The named generation must be a settleable acceptance
+    ///        authorization for the deposit,
+    ///      - `anchorTx` must spend the revealed reserved deposit as its
+    ///        sole input,
+    ///      - `anchorTx` must have exactly one P2(W)PKH output locking
+    ///        funds on the authorized wallet's public key hash,
+    ///      - The Bitcoin miner fee must not exceed the authorization's
+    ///        snapshotted fee bound. Together with the request-time check
+    ///        `depositAmount >= minAmount + txMaxFee` this guarantees the
+    ///        anchor value satisfies the reservation minimum without any
+    ///        proof-time dependency on live parameters.
+    function submitReservationAcceptanceProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata anchorTx,
+        BitcoinTx.Proof calldata anchorProof,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal {
+        (
+            Reservation.ReservationAction storage action,
+            bool late
+        ) = loadSettleableAction(
+                self,
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Acceptance
+            );
+
+        require(
+            self.reservations[reservationKey].state ==
+                Reservation.ReservationState.Unknown,
+            "Reservation already exists"
+        );
+
+        bytes32 anchorTxHash = self.validateProof(anchorTx, anchorProof);
+
+        consumeAcceptedDeposit(self, anchorTx.inputVector, reservationKey);
+
+        uint64 anchorAmount = validateAnchorOutput(
+            self,
+            anchorTx.outputVector,
+            action
+        );
+
+        settleAcceptance(
+            self,
+            reservationKey,
+            requestNonce,
+            action,
+            late,
+            anchorTxHash,
+            anchorAmount
+        );
+    }
+
+    /// @notice Asserts the anchor transaction's sole input spends the
+    ///         reserved deposit the generation was authorized for and marks
+    ///         the deposit as swept: any regular sweep is blocked and the
+    ///         deposit outpoint becomes recognized by the fraud challenge
+    ///         defeat path.
+    /// @dev The deposit was validated against the reservation vault at
+    ///      request time; the routing cannot change while the total
+    ///      reserved amount (which includes this authorization's reserved
+    ///      capacity) is non-zero.
+    function consumeAcceptedDeposit(
+        BridgeState.Storage storage self,
+        bytes memory inputVector,
+        uint256 reservationKey
+    ) internal {
+        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+            .parseWalletOutboundTxInput(inputVector);
+        require(
+            uint256(
+                keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+            ) == reservationKey,
+            "Transaction input must spend the reserved deposit"
+        );
+
+        Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
+        require(deposit.sweptAt == 0, "Deposit already swept");
+
+        /* solhint-disable-next-line not-rely-on-time */
+        deposit.sweptAt = uint32(block.timestamp);
+    }
+
+    /// @notice Parses the anchor transaction's single output, validates it
+    ///         pays the authorized wallet within the snapshotted fee bound
+    ///         and returns its value.
+    function validateAnchorOutput(
+        BridgeState.Storage storage self,
+        bytes memory outputVector,
+        Reservation.ReservationAction storage action
+    ) internal view returns (uint64 anchorAmount) {
+        bytes memory output = parseSingleOutput(outputVector);
+        anchorAmount = output.extractValue();
+        require(
+            self.extractPubKeyHash(output) == action.targetWalletPubKeyHash,
+            "Anchor output must pay the authorized wallet"
+        );
+        require(
+            action.amount - anchorAmount <= action.txMaxFee,
+            "Transaction fee is too high"
+        );
+    }
+
+    /// @notice Finalizes an acceptance settlement: adjusts the reserved
+    ///         capacity, creates the reservation position, indexes the
+    ///         anchor outpoint and credits the gross anchor value through
+    ///         the reservation vault.
+    function settleAcceptance(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ReservationAction storage action,
+        bool late,
+        bytes32 anchorTxHash,
+        uint64 anchorAmount
+    ) internal {
+        action.state = Reservation.ActionState.Settled;
+
+        if (late) {
+            // The timeout released the capacity reserved at request time;
+            // re-take it for the actual anchor value. Deliberately no cap
+            // check: caps are request-time throttles and the anchor is
+            // already confirmed on Bitcoin.
+            self.reservationTotalAmount += anchorAmount;
+            self.walletReservationsCount[action.targetWalletPubKeyHash] += 1;
+            emit Reservation.ReservationLateSettled(
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Acceptance
+            );
+        } else {
+            // Release the difference between the reserved upper bound
+            // (deposit value) and the actual anchor value (miner fee).
+            self.reservationTotalAmount -= (action.amount - anchorAmount);
+        }
+
+        address depositor = self.deposits[reservationKey].depositor;
+
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 expiresAt = uint32(block.timestamp) +
+            self.reservationTermSeconds;
+
+        reservation.owner = depositor;
+        reservation.mintedAmount = anchorAmount;
+        /* solhint-disable-next-line not-rely-on-time */
+        reservation.acceptedAt = uint32(block.timestamp);
+        reservation.walletPubKeyHash = action.targetWalletPubKeyHash;
+        reservation.anchorAmount = anchorAmount;
+        reservation.expiresAt = expiresAt;
+        reservation.anchorTxHash = anchorTxHash;
+        reservation.anchorTxOutputIndex = 0;
+        reservation.state = Reservation.ReservationState.Active;
+        reservation.termSeconds = self.reservationTermSeconds;
+        reservation.gracePeriod = self.reservationGracePeriod;
+
+        self.reservationsByAnchorUtxo[
+            uint256(keccak256(abi.encodePacked(anchorTxHash, uint32(0))))
+        ] = reservationKey;
+
+        // slither-disable-next-line reentrancy-events
+        emit Reservation.ReservationAccepted(
+            reservationKey,
+            requestNonce,
+            action.targetWalletPubKeyHash,
+            depositor,
+            anchorTxHash,
+            anchorAmount,
+            expiresAt
+        );
+
+        // Credit the gross anchored amount through the reservation vault.
+        // The per-deposit treasury fee computed at reveal time is
+        // deliberately ignored: reservation claims are minted gross and all
+        // protocol fees are charged as explicit transfers by the vault.
+        address[] memory depositors = new address[](1);
+        depositors[0] = depositor;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = anchorAmount;
+        self.bank.increaseBalanceAndCall(
+            self.reservationVault,
+            depositors,
+            amounts
+        );
+    }
+
+    /// @notice Used by the wallet to prove the BTC reserved redemption
+    ///         transaction of a generation and settle it. The transaction
+    ///         must spend exactly the reservation's anchor outpoint as its
+    ///         sole input and pay the generation's redeemer output script
+    ///         as its sole output.
+    /// @dev Requirements:
+    ///      - The named generation must be a settleable redemption,
+    ///      - For a pending generation, the watchtower delay applicable to
+    ///        the generation must have elapsed (the on-chain enforcement
+    ///        of the authorize-before-signing rule),
+    ///      - `redemptionTx` must spend the reservation's current anchor
+    ///        outpoint as its sole input,
+    ///      - `redemptionTx` must have a single output paying the
+    ///        generation's redeemer script with a value within the
+    ///        snapshotted range,
+    ///      - A late settlement is rejected when the position's current
+    ///        pending redemption generation matches the transaction as
+    ///        well; the proof must then settle the pending generation.
+    function submitReservedRedemptionProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata redemptionTx,
+        BitcoinTx.Proof calldata redemptionProof,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal {
+        (
+            Reservation.ReservationAction storage action,
+            bool late
+        ) = loadSettleableAction(
+                self,
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Redemption
+            );
+
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == Reservation.ReservationState.Active ||
+                reservation.state == Reservation.ReservationState.ActionPending,
+            "Reservation is not settleable"
+        );
+
+        if (!late) {
+            require(
+                reservation.requestNonce == requestNonce,
+                "Not the current generation"
+            );
+
+            // On-chain authorization enforcement: the wallet may only sign
+            // once the watchtower delay of this generation has elapsed
+            // without a veto, and the proof path verifies it — an early
+            // broadcast cannot finalize before the guardians' window
+            // closes.
+            if (self.redemptionWatchtower != address(0)) {
+                require(
+                    /* solhint-disable-next-line not-rely-on-time */
+                    block.timestamp >=
+                        uint256(action.requestedAt) +
+                            IRedemptionWatchtower(self.redemptionWatchtower)
+                                .getReservedRedemptionDelay(
+                                    reservationKey,
+                                    requestNonce
+                                ),
+                    "Watchtower delay has not elapsed"
+                );
+            }
+        }
+
+        bytes32 redemptionTxHash = self.validateProof(
+            redemptionTx,
+            redemptionProof
+        );
+
+        consumeAnchor(self, reservation, redemptionTx.inputVector);
+
+        bytes memory output = parseSingleOutput(redemptionTx.outputVector);
+        uint64 outputValue = output.extractValue();
+
+        {
+            bytes memory outputScript = output.slice(8, output.length - 8);
+            require(
+                keccak256(outputScript) == action.redeemerOutputScriptHash,
+                "Output does not pay the requested redeemer script"
+            );
+        }
+
+        // Underflow-safe range check against the position's anchor value
+        // (unchanged since the generation was requested: the anchor can
+        // only be consumed by proving a transaction that spends it) and
+        // the generation's snapshotted fee bound.
+        require(
+            outputValue <= reservation.anchorAmount &&
+                reservation.anchorAmount - outputValue <= action.txMaxFee,
+            "Output value is not within the acceptable range"
+        );
+
+        if (late) {
+            resolveLateRedemptionAgainstPending(
+                self,
+                reservation,
+                reservationKey,
+                action,
+                outputValue
+            );
+
+            emit Reservation.ReservationLateSettled(
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Redemption
+            );
+            // No Bank movement: the timeout already refunded the escrowed
+            // claim and slashed the wallet. The registry records the
+            // confirmed spend and closes the lineage.
+        }
+
+        action.state = Reservation.ActionState.Settled;
+        self.closeReservation(reservation);
+
+        // slither-disable-next-line reentrancy-events
+        emit Reservation.ReservedRedemptionCompleted(
+            reservationKey,
+            requestNonce,
+            redemptionTxHash
+        );
+
+        if (!late) {
+            // Burn the gross minted amount held by the Bridge since the
+            // redemption request.
+            self.bank.decreaseBalance(action.amount);
+        }
+    }
+
+    /// @notice Used by the wallet to prove a re-anchor transaction moving a
+    ///         reservation's anchor outpoint to the authorized target
+    ///         wallet in a 1-input-1-output spend.
+    /// @dev Requirements:
+    ///      - The named generation must be a settleable re-anchor,
+    ///      - `reanchorTx` must spend the current anchor outpoint as its
+    ///        sole input and create a single P2(W)PKH output paying the
+    ///        generation's authorized target wallet,
+    ///      - The miner fee must respect the snapshotted bound and the
+    ///        re-anchored value must stay above the dust floor (the
+    ///        snapshotted fee bound), preserving positive redemption
+    ///        value.
+    function submitReservationReanchorProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata reanchorTx,
+        BitcoinTx.Proof calldata reanchorProof,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal {
+        (
+            Reservation.ReservationAction storage action,
+            bool late
+        ) = loadSettleableAction(
+                self,
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Reanchor
+            );
+
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == Reservation.ReservationState.Active ||
+                reservation.state == Reservation.ReservationState.ActionPending,
+            "Reservation is not settleable"
+        );
+        if (!late) {
+            require(
+                reservation.requestNonce == requestNonce,
+                "Not the current generation"
+            );
+        }
+
+        bytes32 reanchorTxHash = self.validateProof(reanchorTx, reanchorProof);
+
+        consumeAnchor(self, reservation, reanchorTx.inputVector);
+
+        bytes memory output = parseSingleOutput(reanchorTx.outputVector);
+        bytes20 newWalletPubKeyHash = self.extractPubKeyHash(output);
+        uint64 newAnchorAmount = output.extractValue();
+
+        require(
+            newWalletPubKeyHash == action.targetWalletPubKeyHash,
+            "Output must pay the authorized target wallet"
+        );
+
+        // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
+        // consensus (the re-anchor output cannot exceed its input).
+        require(
+            reservation.anchorAmount - newAnchorAmount <= action.txMaxFee,
+            "Transaction fee is too high"
+        );
+
+        // Dust floor: the re-anchored amount must stay strictly above the
+        // snapshotted per-transaction fee bound, keeping the anchor clear
+        // of dust and preserving positive redemption value.
+        require(
+            newAnchorAmount > action.txMaxFee,
+            "Re-anchor amount below the dust floor"
+        );
+
+        if (late) {
+            // The timeout released the target wallet's reserved count;
+            // re-take it. Deliberately no cap check (see acceptance).
+            self.walletReservationsCount[newWalletPubKeyHash] += 1;
+
+            // A newer pending generation references an anchor this
+            // transaction just consumed; unwind it.
+            if (
+                reservation.state == Reservation.ReservationState.ActionPending
+            ) {
+                unwindPendingAction(self, reservation, reservationKey);
+            }
+
+            emit Reservation.ReservationLateSettled(
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Reanchor
+            );
+        }
+
+        // The source wallet's count is released now; the target wallet's
+        // count was reserved at request time (or re-taken above).
+        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
+
+        // The miner fee reduces the on-chain earmarked amount.
+        self.reservationTotalAmount -= (reservation.anchorAmount -
+            newAnchorAmount);
+
+        reservation.walletPubKeyHash = newWalletPubKeyHash;
+        reservation.anchorAmount = newAnchorAmount;
+        reservation.anchorTxHash = reanchorTxHash;
+        reservation.anchorTxOutputIndex = 0;
+        reservation.state = Reservation.ReservationState.Active;
+
+        action.state = Reservation.ActionState.Settled;
+
+        self.reservationsByAnchorUtxo[
+            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
+        ] = reservationKey;
+
+        emit Reservation.ReservationReanchored(
+            reservationKey,
+            requestNonce,
+            newWalletPubKeyHash,
+            reanchorTxHash,
+            newAnchorAmount
+        );
+    }
+
+    /// @notice Used by the wallet to prove a dissolution transaction
+    ///         merging an expired reservation's anchor outpoint into the
+    ///         wallet's main UTXO, per the generation's authorization.
+    /// @dev Requirements:
+    ///      - The named generation must be a settleable dissolution,
+    ///      - If the generation's snapshot recorded a main UTXO,
+    ///        `dissolutionTx` must spend exactly the anchor outpoint
+    ///        (first input) and that main UTXO (second input, matching the
+    ///        `mainUtxo` parameter); otherwise it must spend exactly the
+    ///        anchor outpoint,
+    ///      - `dissolutionTx` must have a single P2(W)PKH output locking
+    ///        funds back on the custodying wallet's public key hash.
+    ///
+    ///      If the wallet's registry main UTXO still equals the snapshot,
+    ///      the output becomes the wallet's new main UTXO. If it drifted —
+    ///      possible only for no-main-UTXO snapshots, when e.g. a deposit
+    ///      sweep landed first — the output is registered as a moved-funds
+    ///      sweep request so the wallet later consolidates it, keeping the
+    ///      backing tracked either way.
+    function submitReservationDissolutionProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata dissolutionTx,
+        BitcoinTx.Proof calldata dissolutionProof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal {
+        (
+            Reservation.ReservationAction storage action,
+            bool late
+        ) = loadSettleableAction(
+                self,
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Dissolution
+            );
+
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == Reservation.ReservationState.Active ||
+                reservation.state == Reservation.ReservationState.ActionPending,
+            "Reservation is not settleable"
+        );
+        if (!late) {
+            require(
+                reservation.requestNonce == requestNonce,
+                "Not the current generation"
+            );
+        }
+
+        bytes32 dissolutionTxHash = self.validateProof(
+            dissolutionTx,
+            dissolutionProof
+        );
+
+        uint64 inputsTotalValue = processDissolutionInputs(
+            self,
+            reservation,
+            dissolutionTx.inputVector,
+            action.expectedMainUtxoHash,
+            mainUtxo
+        );
+
+        uint64 outputValue = validateDissolutionOutput(
+            self,
+            dissolutionTx.outputVector,
+            reservation.walletPubKeyHash,
+            inputsTotalValue,
+            action.txMaxFee
+        );
+
+        settleDissolution(
+            self,
+            reservationKey,
+            requestNonce,
+            action,
+            late,
+            dissolutionTxHash,
+            outputValue
+        );
+    }
+
+    /// @notice Parses the dissolution transaction's single output, validates
+    ///         it pays the custodying wallet within the snapshotted fee
+    ///         bound and returns its value.
+    function validateDissolutionOutput(
+        BridgeState.Storage storage self,
+        bytes memory outputVector,
+        bytes20 walletPubKeyHash,
+        uint64 inputsTotalValue,
+        uint64 txMaxFee
+    ) internal view returns (uint64 outputValue) {
+        bytes memory output = parseSingleOutput(outputVector);
+        outputValue = output.extractValue();
+        require(
+            self.extractPubKeyHash(output) == walletPubKeyHash,
+            "Dissolution output must pay to the custodying wallet"
+        );
+        require(
+            inputsTotalValue - outputValue <= txMaxFee,
+            "Transaction fee is too high"
+        );
+    }
+
+    /// @notice Finalizes a dissolution settlement: registers the output as
+    ///         the wallet's new main UTXO (or as a moved-funds sweep
+    ///         request when the registry drifted), releases the per-wallet
+    ///         main-UTXO action lock, unwinds a superseded pending
+    ///         generation on late settlements and closes the position.
+    function settleDissolution(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ReservationAction storage action,
+        bool late,
+        bytes32 dissolutionTxHash,
+        uint64 outputValue
+    ) internal {
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+
+        Wallets.Wallet storage wallet = self.registeredWallets[
+            walletPubKeyHash
+        ];
+
+        if (wallet.mainUtxoHash == action.expectedMainUtxoHash) {
+            // The dissolution output becomes the wallet's new main UTXO:
+            // the reserved backing rejoins the pooled supply.
+            wallet.mainUtxoHash = keccak256(
+                abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
+            );
+        } else {
+            // Registry drift: another transaction (e.g. a deposit sweep)
+            // registered a main UTXO after this no-main-UTXO dissolution
+            // was authorized. The confirmed dissolution output is a
+            // wallet-held UTXO the registry must keep tracking; register
+            // it for the moved-funds sweep machinery to consolidate.
+            require(
+                action.expectedMainUtxoHash == bytes32(0),
+                "Recorded main UTXO can no longer be spent"
+            );
+            MovingFunds.MovedFundsSweepRequest storage sweepRequest = self
+                .movedFundsSweepRequests[
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(dissolutionTxHash, uint32(0))
+                        )
+                    )
+                ];
+            sweepRequest.walletPubKeyHash = walletPubKeyHash;
+            sweepRequest.value = outputValue;
+            /* solhint-disable-next-line not-rely-on-time */
+            sweepRequest.createdAt = uint32(block.timestamp);
+            sweepRequest.state = MovingFunds
+                .MovedFundsSweepRequestState
+                .Pending;
+        }
+
+        if (late) {
+            if (
+                reservation.state == Reservation.ReservationState.ActionPending
+            ) {
+                unwindPendingAction(self, reservation, reservationKey);
+            }
+            emit Reservation.ReservationLateSettled(
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Dissolution
+            );
+        } else {
+            // Release the per-wallet main-UTXO action lock taken at
+            // request time (a timed-out generation released it already,
+            // and it may have been re-taken by another reservation since).
+            if (
+                self.walletPendingDissolution[walletPubKeyHash] ==
+                reservationKey
+            ) {
+                delete self.walletPendingDissolution[walletPubKeyHash];
+            }
+        }
+
+        action.state = Reservation.ActionState.Settled;
+        self.closeReservation(reservation);
+
+        emit Reservation.ReservationDissolved(
+            reservationKey,
+            requestNonce,
+            walletPubKeyHash,
+            dissolutionTxHash
+        );
+    }
+
+    /// @notice Resolves a late redemption settlement against the position's
+    ///         current pending generation. If the pending generation is a
+    ///         redemption that matches the proven transaction as well, the
+    ///         proof must settle against it instead (the pending settlement
+    ///         burns the escrow — the correct accounting whenever both
+    ///         generations can claim the transaction); otherwise the
+    ///         pending generation's anchor is provably gone and it is
+    ///         unwound.
+    function resolveLateRedemptionAgainstPending(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        Reservation.ReservationAction storage action,
+        uint64 outputValue
+    ) internal {
+        if (reservation.state != Reservation.ReservationState.ActionPending) {
+            return;
+        }
+
+        Reservation.ReservationAction storage pendingAction = self
+            .reservationActions[
+                Reservation.actionKey(reservationKey, reservation.requestNonce)
+            ];
+        if (
+            pendingAction.actionType == Reservation.ActionType.Redemption &&
+            pendingAction.redeemerOutputScriptHash ==
+            action.redeemerOutputScriptHash &&
+            reservation.anchorAmount - outputValue <= pendingAction.txMaxFee
+        ) {
+            revert("Must settle the pending generation");
+        }
+
+        // The pending generation cannot claim the transaction; its anchor
+        // is gone, so unwind it.
+        unwindPendingAction(self, reservation, reservationKey);
+    }
+
+    /// @notice Unwinds the position's current pending generation during a
+    ///         late settlement of an older generation: the anchor the
+    ///         pending generation was authorized to spend has provably been
+    ///         consumed, so the generation can never settle. Its escrow is
+    ///         refunded (redemptions), its reserved capacity and locks are
+    ///         released, and it is terminally marked `Superseded`.
+    function unwindPendingAction(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey
+    ) internal {
+        uint64 pendingNonce = reservation.requestNonce;
+        Reservation.ReservationAction storage pendingAction = self
+            .reservationActions[
+                Reservation.actionKey(reservationKey, pendingNonce)
+            ];
+        require(
+            pendingAction.state == Reservation.ActionState.Pending,
+            "No pending action to unwind"
+        );
+
+        pendingAction.state = Reservation.ActionState.Superseded;
+
+        if (pendingAction.actionType == Reservation.ActionType.Redemption) {
+            // Return the escrowed balance: the redeemer surrendered it for
+            // an anchor that no longer exists.
+            self.bank.transferBalance(
+                pendingAction.redeemer,
+                pendingAction.amount
+            );
+        } else if (
+            pendingAction.actionType == Reservation.ActionType.Reanchor
+        ) {
+            self.walletReservationsCount[
+                pendingAction.targetWalletPubKeyHash
+            ] -= 1;
+        } else if (
+            pendingAction.actionType == Reservation.ActionType.Dissolution
+        ) {
+            if (
+                self.walletPendingDissolution[reservation.walletPubKeyHash] ==
+                reservationKey
+            ) {
+                delete self.walletPendingDissolution[
+                    reservation.walletPubKeyHash
+                ];
+            }
+        }
+
+        emit Reservation.ReservationActionSuperseded(
+            reservationKey,
+            pendingNonce
+        );
+    }
+
+    /// @notice Parses the given output vector and returns its single output.
+    ///         Reverts if the vector does not contain exactly one output.
+    function parseSingleOutput(bytes memory outputVector)
+        internal
+        pure
+        returns (bytes memory output)
+    {
+        (, uint256 outputsCount) = outputVector.parseVarInt();
+        require(
+            outputsCount == 1,
+            "Reservation transaction must have a single output"
+        );
+
+        output = outputVector.extractOutputAtIndex(0);
+    }
+
+    /// @notice Asserts the given input vector contains exactly one input
+    ///         pointing to the reservation's current anchor outpoint, marks
+    ///         that outpoint as correctly spent (making it recognized by the
+    ///         fraud challenge defeat path) and clears its anchor index
+    ///         entry.
+    function consumeAnchor(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        bytes memory inputVector
+    ) internal {
+        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+            .parseWalletOutboundTxInput(inputVector);
+
+        require(
+            reservation.anchorTxHash == outpointTxHash &&
+                reservation.anchorTxOutputIndex == outpointIndex,
+            "Transaction input must point to the reservation anchor"
+        );
+
+        uint256 anchorUtxoKey = uint256(
+            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+        );
+
+        // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
+        // anchor in `spentMainUTXOs` -- the existing registry of honestly
+        // spent wallet UTXOs -- makes the spend recognized by
+        // `Fraud.defeatFraudChallenge` without modifying the fraud library.
+        self.spentMainUTXOs[anchorUtxoKey] = true;
+        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
+    }
+
+    /// @notice Processes the dissolution transaction inputs: the first
+    ///         input must spend the reservation's anchor outpoint and, if
+    ///         the generation's snapshot recorded a main UTXO, the second
+    ///         input must spend exactly that main UTXO. Marks both consumed
+    ///         outpoints as correctly spent.
+    /// @return inputsTotalValue Sum of all inputs values.
+    function processDissolutionInputs(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        bytes memory inputVector,
+        bytes32 expectedMainUtxoHash,
+        BitcoinTx.UTXO calldata mainUtxo
+    ) internal returns (uint64 inputsTotalValue) {
+        bool mainUtxoExpected = expectedMainUtxoHash != bytes32(0);
+
+        (uint256 varIntLength, uint256 inputsCount) = inputVector.parseVarInt();
+        require(
+            inputsCount == (mainUtxoExpected ? 2 : 1),
+            "Wrong number of dissolution transaction inputs"
+        );
+
+        // The first input must spend the reservation's anchor outpoint.
+        uint256 nextInputIndex = consumeAnchorInputAt(
+            self,
+            reservation,
+            inputVector,
+            1 + varIntLength
+        );
+        inputsTotalValue = reservation.anchorAmount;
+
+        if (mainUtxoExpected) {
+            require(
+                keccak256(
+                    abi.encodePacked(
+                        mainUtxo.txHash,
+                        mainUtxo.txOutputIndex,
+                        mainUtxo.txOutputValue
+                    )
+                ) == expectedMainUtxoHash,
+                "Invalid main UTXO data"
+            );
+
+            consumeMainUtxoInputAt(self, inputVector, nextInputIndex, mainUtxo);
+            inputsTotalValue += mainUtxo.txOutputValue;
+        }
+
+        return inputsTotalValue;
+    }
+
+    /// @notice Asserts the input at the given starting index spends the
+    ///         reservation's current anchor outpoint, marks that outpoint as
+    ///         correctly spent and clears its anchor index entry.
+    /// @return nextInputIndex Starting index of the next input.
+    function consumeAnchorInputAt(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        bytes memory inputVector,
+        uint256 inputStartingIndex
+    ) internal returns (uint256 nextInputIndex) {
+        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
+            inputStartingIndex
+        );
+        uint32 outpointIndex = BTCUtils.reverseUint32(
+            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
+        );
+
+        require(
+            reservation.anchorTxHash == outpointTxHash &&
+                reservation.anchorTxOutputIndex == outpointIndex,
+            "Transaction input must point to the reservation anchor"
+        );
+
+        uint256 anchorUtxoKey = uint256(
+            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+        );
+        // See `consumeAnchor` for the `spentMainUTXOs` rationale.
+        self.spentMainUTXOs[anchorUtxoKey] = true;
+        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
+
+        nextInputIndex =
+            inputStartingIndex +
+            inputVector.determineInputLengthAt(inputStartingIndex);
+    }
+
+    /// @notice Asserts the input at the given starting index spends the
+    ///         given main UTXO and marks it as correctly spent.
+    function consumeMainUtxoInputAt(
+        BridgeState.Storage storage self,
+        bytes memory inputVector,
+        uint256 inputStartingIndex,
+        BitcoinTx.UTXO calldata mainUtxo
+    ) internal {
+        bytes32 outpointTxHash = inputVector.extractInputTxIdLeAt(
+            inputStartingIndex
+        );
+        uint32 outpointIndex = BTCUtils.reverseUint32(
+            uint32(inputVector.extractTxIndexLeAt(inputStartingIndex))
+        );
+
+        require(
+            mainUtxo.txHash == outpointTxHash &&
+                mainUtxo.txOutputIndex == outpointIndex,
+            "Transaction input must point to the wallet's main UTXO"
+        );
+
+        self.spentMainUTXOs[
+            uint256(keccak256(abi.encodePacked(outpointTxHash, outpointIndex)))
+        ] = true;
+    }
+}

--- a/solidity/contracts/bridge/ReservationRouter.sol
+++ b/solidity/contracts/bridge/ReservationRouter.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "@keep-network/random-beacon/contracts/Governable.sol";
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import "./BitcoinTx.sol";
+import "./BridgeState.sol";
+import "./Reservation.sol";
+
+/// @title Bridge reservation router
+/// @notice Holds the external UTXO-reservation surface of the Bridge. The
+///         Bridge routes every call with an unmatched function selector to
+///         this contract via `delegatecall` from its fallback function, so
+///         all functions declared here execute at the Bridge address, on the
+///         Bridge storage, with the Bridge's Bank authority — exactly as if
+///         they were declared in `Bridge.sol` itself. Their selectors are
+///         part of the Bridge ABI surface observable at the Bridge address.
+///
+///         The router exists to preserve the Bridge's EIP-170 deployment
+///         size margin: the reservation feature (and its planned two-phase
+///         settlement state machine) does not fit in the ~400 bytes the
+///         monolithic Bridge implementation has left. Moving the surface to
+///         a delegatecall extension gives reservations their own 24 kB
+///         budget while changing nothing about the storage/address/authority
+///         model.
+///
+///         Architecture notes (why delegatecall, not an external router):
+///         the P2TR activation track routes *fraud signature checks* through
+///         external router contracts the Bridge calls into. That shape works
+///         for stateless verification, but reservations mutate core Bridge
+///         state (deposits, wallets, spent-UTXO registry) and rely on the
+///         Bank's Bridge-only authority (`increaseBalanceAndCall`,
+///         `transferBalanceFrom`). An external contract would need a wide
+///         set of privileged Bridge mutator callbacks — more new Bridge
+///         bytecode than the refactor removes, and a brand-new authority
+///         surface to audit. The delegatecall extension keeps the current
+///         model: no new trusted party, no Bank changes, no ABI change for
+///         off-chain clients.
+/// @dev Security invariants, enforced by construction and by tests:
+///
+///      1. STORAGE PARITY. The router inherits the same storage-bearing
+///         bases as the Bridge, in the same order, and declares the single
+///         `BridgeState.Storage internal self` variable as its only storage
+///         — so every storage reference made by router code resolves to the
+///         same slots as in the Bridge. The router MUST NOT declare any
+///         additional state variable; new reservation state goes into
+///         `BridgeState.Storage` (appending, with a matching `__gap`
+///         reduction). A storage-layout parity test guards this.
+///
+///      2. NO SELECTOR SHADOWING. A selector defined by the Bridge never
+///         reaches the router (the fallback only sees unmatched calls). The
+///         router must not declare a function the Bridge also declares; a
+///         selector-disjointness test guards this.
+///
+///      3. NO STANDALONE AUTHORITY. Calling the router directly (not via the
+///         Bridge fallback) executes on the router's own, empty storage:
+///         `governance` is unset, no SPV maintainer is approved, the
+///         reservation vault is zero, and the router holds no Bank balance
+///         or authority — every state-changing entry point reverts. The
+///         router needs no initialization and has no initializer.
+///
+///      4. UPGRADE MODEL. The Bridge stores the router address in
+///         `BridgeState.Storage.reservationRouter`, settable exactly once
+///         via `Bridge.setReservationRouter`. Replacing router code
+///         afterwards requires a Bridge implementation upgrade (the same
+///         ceremony as any Bridge logic change), keeping code-change
+///         authority exactly where it is today: with the proxy admin, not
+///         with the parameter governance.
+contract ReservationRouter is Governable, Initializable {
+    using BridgeState for BridgeState.Storage;
+    using Reservation for BridgeState.Storage;
+
+    // Mirror of the Bridge's storage anchor. `Governable` contributes slots
+    // 0-49 (governance + gap) and `Initializable` the following slot, so
+    // `self` starts at the same slot as in the Bridge. See invariant 1.
+    BridgeState.Storage internal self;
+
+    event ReservationAccepted(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        address indexed owner,
+        bytes32 anchorTxHash,
+        uint64 anchorAmount,
+        uint32 expiresAt
+    );
+
+    event ReservationExtended(
+        uint256 indexed reservationKey,
+        uint32 newExpiresAt
+    );
+
+    event ReservedRedemptionRequested(
+        uint256 indexed reservationKey,
+        address indexed redeemer,
+        bytes redeemerOutputScript,
+        uint64 mintedAmount,
+        uint64 txMaxFee
+    );
+
+    event ReservedRedemptionCompleted(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    event ReservedRedemptionTimedOut(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
+    event ReservedRedemptionVetoed(uint256 indexed reservationKey);
+
+    event ReservationReanchored(
+        uint256 indexed reservationKey,
+        bytes20 indexed newWalletPubKeyHash,
+        bytes32 newAnchorTxHash,
+        uint64 newAnchorAmount
+    );
+
+    event ReservationDissolved(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        bytes32 dissolutionTxHash
+    );
+
+    event ReservationParametersUpdated(
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    );
+
+    event ReservationVaultUpdated(address reservationVault);
+
+    // Re-declaration of the event emitted by
+    // `BridgeState.setReservationRouter` (invoked through
+    // `Bridge.setReservationRouter`). Library events are not part of any
+    // contract ABI under solc 0.8.17, so the router — the ABI home of the
+    // reservation surface — declares it for off-chain consumers.
+    event ReservationRouterSet(address reservationRouter);
+
+    modifier onlySpvMaintainer() {
+        require(
+            self.isSpvMaintainer[msg.sender],
+            "Caller is not SPV maintainer"
+        );
+        _;
+    }
+
+    /// @notice Single entry point for all reservation lifecycle SPV proofs:
+    ///         anchor acceptance, in-kind reserved redemption, re-anchoring
+    ///         and dissolution. See `Reservation.submitReservationProof` and
+    ///         the individual handlers in the `Reservation` library for
+    ///         detailed requirements.
+    /// @param proofType The type of the submitted proof, see
+    ///        `Reservation.ProofType`.
+    /// @param txInfo Bitcoin transaction data.
+    /// @param proof Bitcoin proof data.
+    /// @param mainUtxo Data of the wallet's main UTXO; only used for
+    ///        `Dissolution` proofs and ignored otherwise.
+    /// @param reservationKey The key of the target reservation; ignored for
+    ///        `Acceptance` proofs where the key is derived from the spent
+    ///        deposit outpoint.
+    function submitReservationProof(
+        uint8 proofType,
+        BitcoinTx.Info calldata txInfo,
+        BitcoinTx.Proof calldata proof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey
+    ) external onlySpvMaintainer {
+        self.submitReservationProof(
+            proofType,
+            txInfo,
+            proof,
+            mainUtxo,
+            reservationKey
+        );
+    }
+
+    /// @notice Extends the custody term of a reservation by the current
+    ///         reservation term length. Can only be called by the
+    ///         reservation vault, which collects the custody fee for the
+    ///         extension. See `Reservation.extendReservation`.
+    /// @param reservationKey The key of the reservation to extend.
+    function extendReservation(uint256 reservationKey) external {
+        // The caller is checked in the library function.
+        self.extendReservation(reservationKey);
+    }
+
+    /// @notice Requests an in-kind redemption of a reservation: the wallet
+    ///         is expected to spend exactly the reservation's current anchor
+    ///         outpoint to the redeemer output script in a 1-input-1-output
+    ///         transaction. Can only be called by the reservation vault,
+    ///         which must have approved the Bridge in the Bank for the gross
+    ///         minted amount. See `Reservation.requestReservedRedemption`.
+    /// @param reservationKey The key of the reservation to redeem.
+    /// @param redeemer The address able to claim the surrendered balance
+    ///        back if the redemption times out.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    function requestReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript
+    ) external {
+        // The caller is checked in the library function.
+        self.requestReservedRedemption(
+            reservationKey,
+            redeemer,
+            redeemerOutputScript
+        );
+    }
+
+    /// @notice Notifies that a pending reserved redemption has timed out.
+    ///         Returns the surrendered balance to the redeemer, slashes the
+    ///         wallet operators like a regular redemption timeout, and
+    ///         returns the reservation to the Active state. See
+    ///         `Reservation.notifyReservedRedemptionTimeout`.
+    /// @param reservationKey The key of the reservation with the timed out
+    ///        redemption.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members.
+    function notifyReservedRedemptionTimeout(
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        self.notifyReservedRedemptionTimeout(reservationKey, walletMembersIDs);
+    }
+
+    /// @notice Notifies that a pending reserved redemption was vetoed in the
+    ///         redemption watchtower. Detains the surrendered balance to the
+    ///         watchtower and returns the reservation to the Active state.
+    ///         See `Reservation.notifyReservedRedemptionVeto`.
+    /// @param reservationKey The key of the reservation with the vetoed
+    ///        redemption.
+    function notifyReservedRedemptionVeto(uint256 reservationKey) external {
+        // The caller is checked in the library function.
+        self.notifyReservedRedemptionVeto(reservationKey);
+    }
+
+    /// @notice Updates parameters of reservations, including the
+    ///         reservation vault address. Deposits revealed with the
+    ///         reservation vault address are treated as UTXO reservations.
+    /// @param reservationVault Address of the reservation vault. Can only be
+    ///        changed while there are no active reservations.
+    /// @param reservationMinAmount New value of the reservation minimum
+    ///        amount in satoshis. It is the minimal anchor output amount
+    ///        accepted for a reservation.
+    /// @param reservationTxMaxFee New value of the reservation transaction
+    ///        max fee in satoshis. It is the maximum amount of BTC
+    ///        transaction fee that can be incurred by a single reservation
+    ///        lifecycle transaction.
+    /// @param reservationTermSeconds New value of the reservation custody
+    ///        term length in seconds.
+    /// @param reservationGracePeriod New value of the reservation grace
+    ///        period in seconds.
+    /// @param reservationMaxTotalAmount New cap on the total amount in
+    ///        satoshi locked under active reservations.
+    /// @param maxReservationsPerWallet New cap on the number of active
+    ///        reservations a single wallet can custody.
+    /// @dev Requirements:
+    ///      - The caller must be the governance,
+    ///      - See `Reservation.updateReservationParameters` for parameter
+    ///        requirements.
+    function updateReservationParameters(
+        address reservationVault,
+        uint64 reservationMinAmount,
+        uint64 reservationTxMaxFee,
+        uint32 reservationTermSeconds,
+        uint32 reservationGracePeriod,
+        uint64 reservationMaxTotalAmount,
+        uint32 maxReservationsPerWallet
+    ) external onlyGovernance {
+        self.updateReservationParameters(
+            reservationVault,
+            reservationMinAmount,
+            reservationTxMaxFee,
+            reservationTermSeconds,
+            reservationGracePeriod,
+            reservationMaxTotalAmount,
+            maxReservationsPerWallet
+        );
+    }
+
+    /// @notice Collection of all reservations indexed by the deposit key of
+    ///         the underlying reserved deposit, i.e.
+    ///         `keccak256(fundingTxHash | fundingOutputIndex)`.
+    /// @param reservationKey The key of the reservation.
+    function reservations(uint256 reservationKey)
+        external
+        view
+        returns (Reservation.ReservationRequest memory)
+    {
+        return self.reservations[reservationKey];
+    }
+
+    /// @notice Returns the current values of Bridge reservation parameters.
+    function reservationParameters()
+        external
+        view
+        returns (
+            address reservationVault,
+            uint64 reservationMinAmount,
+            uint64 reservationTxMaxFee,
+            uint32 reservationTermSeconds,
+            uint32 reservationGracePeriod,
+            uint64 reservationMaxTotalAmount,
+            uint64 reservationTotalAmount,
+            uint32 maxReservationsPerWallet
+        )
+    {
+        reservationVault = self.reservationVault;
+        reservationMinAmount = self.reservationMinAmount;
+        reservationTxMaxFee = self.reservationTxMaxFee;
+        reservationTermSeconds = self.reservationTermSeconds;
+        reservationGracePeriod = self.reservationGracePeriod;
+        reservationMaxTotalAmount = self.reservationMaxTotalAmount;
+        reservationTotalAmount = self.reservationTotalAmount;
+        maxReservationsPerWallet = self.maxReservationsPerWallet;
+    }
+
+    /// @notice Returns the address of the reservation router the Bridge
+    ///         routes unmatched selectors to — i.e. the address of the
+    ///         contract holding this code.
+    function reservationRouter() external view returns (address) {
+        return self.reservationRouter;
+    }
+}

--- a/solidity/contracts/bridge/ReservationRouter.sol
+++ b/solidity/contracts/bridge/ReservationRouter.sol
@@ -33,12 +33,12 @@ import "./Reservation.sol";
 ///         part of the Bridge ABI surface observable at the Bridge address.
 ///
 ///         The router exists to preserve the Bridge's EIP-170 deployment
-///         size margin: the reservation feature (and its planned two-phase
-///         settlement state machine) does not fit in the ~400 bytes the
-///         monolithic Bridge implementation has left. Moving the surface to
-///         a delegatecall extension gives reservations their own 24 kB
-///         budget while changing nothing about the storage/address/authority
-///         model.
+///         size margin: the reservation feature and its two-phase
+///         settlement state machine do not fit in the bytes the monolithic
+///         Bridge implementation has left. Moving the surface to a
+///         delegatecall extension gives reservations their own 24 kB
+///         budget while changing nothing about the storage/address/
+///         authority model.
 ///
 ///         Architecture notes (why delegatecall, not an external router):
 ///         the P2TR activation track routes *fraud signature checks* through
@@ -91,8 +91,18 @@ contract ReservationRouter is Governable, Initializable {
     // `self` starts at the same slot as in the Bridge. See invariant 1.
     BridgeState.Storage internal self;
 
+    event ReservationAcceptanceRequested(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed walletPubKeyHash,
+        uint64 depositAmount,
+        uint64 txMaxFee,
+        uint32 timeoutAt
+    );
+
     event ReservationAccepted(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes20 indexed walletPubKeyHash,
         address indexed owner,
         bytes32 anchorTxHash,
@@ -107,36 +117,74 @@ contract ReservationRouter is Governable, Initializable {
 
     event ReservedRedemptionRequested(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         address indexed redeemer,
         bytes redeemerOutputScript,
         uint64 mintedAmount,
-        uint64 txMaxFee
+        uint64 txMaxFee,
+        bool feePaid
     );
 
     event ReservedRedemptionCompleted(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes32 redemptionTxHash
     );
 
-    event ReservedRedemptionTimedOut(
+    event ReservationReanchorRequested(
         uint256 indexed reservationKey,
-        bytes20 indexed walletPubKeyHash
+        uint64 requestNonce,
+        bytes20 indexed sourceWalletPubKeyHash,
+        bytes20 indexed targetWalletPubKeyHash,
+        uint64 txMaxFee
     );
-
-    event ReservedRedemptionVetoed(uint256 indexed reservationKey);
 
     event ReservationReanchored(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes20 indexed newWalletPubKeyHash,
         bytes32 newAnchorTxHash,
         uint64 newAnchorAmount
     );
 
+    event ReservationDissolutionRequested(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed walletPubKeyHash,
+        uint64 txMaxFee,
+        bytes32 expectedMainUtxoHash
+    );
+
     event ReservationDissolved(
         uint256 indexed reservationKey,
+        uint64 requestNonce,
         bytes20 indexed walletPubKeyHash,
         bytes32 dissolutionTxHash
     );
+
+    event ReservationActionTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType
+    );
+
+    event ReservedRedemptionVetoed(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationActionSuperseded(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationLateSettled(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType
+    );
+
+    event ReservationRetryCreditMinted(uint256 indexed reservationKey);
 
     event ReservationParametersUpdated(
         uint64 reservationMinAmount,
@@ -144,7 +192,8 @@ contract ReservationRouter is Governable, Initializable {
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint32 reservationActionTimeout
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -164,95 +213,155 @@ contract ReservationRouter is Governable, Initializable {
         _;
     }
 
+    /// @notice Requests the acceptance of a revealed reserved deposit: the
+    ///         authorization for the designated wallet to perform the
+    ///         anchor spend. Checks and reserves reservation capacity so
+    ///         the anchor, once signed, can always be proven. See
+    ///         `Reservation.requestReservationAcceptance`.
+    /// @param reservationKey The deposit key of the revealed reserved
+    ///        deposit (doubles as the reservation key).
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet that
+    ///        will anchor the deposit.
+    function requestReservationAcceptance(
+        uint256 reservationKey,
+        bytes20 walletPubKeyHash
+    ) external {
+        self.requestReservationAcceptance(reservationKey, walletPubKeyHash);
+    }
+
+    /// @notice Requests an in-kind redemption of a reservation. Can only be
+    ///         called by the reservation vault, which must have approved
+    ///         the Bridge in the Bank for the gross minted amount. See
+    ///         `Reservation.requestReservedRedemption`.
+    /// @param reservationKey The key of the reservation to redeem.
+    /// @param redeemer The address able to claim the escrowed balance back
+    ///        if the redemption times out.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param feePaid True when the vault collected the redemption fee for
+    ///        this request.
+    /// @param useRetryCredit True when the request consumes the fee-free
+    ///        retry entitlement minted by a fee-paid timeout.
+    function requestReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript,
+        bool feePaid,
+        bool useRetryCredit
+    ) external {
+        // The caller is checked in the library function.
+        self.requestReservedRedemption(
+            reservationKey,
+            redeemer,
+            redeemerOutputScript,
+            feePaid,
+            useRetryCredit
+        );
+    }
+
+    /// @notice Requests the re-anchoring of a reservation to another
+    ///         wallet: the authorization for the source wallet to move the
+    ///         anchor during migration or a governance-approved rotation.
+    ///         See `Reservation.requestReservationReanchor`.
+    /// @param reservationKey The key of the reservation to re-anchor.
+    /// @param targetWalletPubKeyHash 20-byte public key hash of the target
+    ///        wallet.
+    function requestReservationReanchor(
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash
+    ) external {
+        self.requestReservationReanchor(
+            reservationKey,
+            targetWalletPubKeyHash,
+            msg.sender == governance
+        );
+    }
+
+    /// @notice Requests the dissolution of an expired reservation: the
+    ///         authorization for the custodying wallet to merge the anchor
+    ///         into its main UTXO once the custody term and grace period
+    ///         elapsed. See `Reservation.requestReservationDissolution`.
+    /// @param reservationKey The key of the reservation to dissolve.
+    function requestReservationDissolution(uint256 reservationKey) external {
+        self.requestReservationDissolution(reservationKey);
+    }
+
     /// @notice Single entry point for all reservation lifecycle SPV proofs:
     ///         anchor acceptance, in-kind reserved redemption, re-anchoring
-    ///         and dissolution. See `Reservation.submitReservationProof` and
-    ///         the individual handlers in the `Reservation` library for
-    ///         detailed requirements.
+    ///         and dissolution. Settles the named action generation. See
+    ///         `ReservationProofs.submitReservationProof` (reached through
+    ///         the `Reservation` library so this contract links exactly one
+    ///         external library) and the individual handlers for detailed
+    ///         requirements.
     /// @param proofType The type of the submitted proof, see
-    ///        `Reservation.ProofType`.
+    ///        `ReservationProofs.ProofType`.
     /// @param txInfo Bitcoin transaction data.
     /// @param proof Bitcoin proof data.
-    /// @param mainUtxo Data of the wallet's main UTXO; only used for
-    ///        `Dissolution` proofs and ignored otherwise.
-    /// @param reservationKey The key of the target reservation; ignored for
-    ///        `Acceptance` proofs where the key is derived from the spent
-    ///        deposit outpoint.
+    /// @param mainUtxo Data of the main UTXO expected by a `Dissolution`
+    ///        generation; ignored otherwise.
+    /// @param reservationKey The key of the target reservation.
+    /// @param requestNonce The action generation being settled. Late
+    ///        settlements name an older, timed-out generation.
     function submitReservationProof(
         uint8 proofType,
         BitcoinTx.Info calldata txInfo,
         BitcoinTx.Proof calldata proof,
         BitcoinTx.UTXO calldata mainUtxo,
-        uint256 reservationKey
+        uint256 reservationKey,
+        uint64 requestNonce
     ) external onlySpvMaintainer {
         self.submitReservationProof(
             proofType,
             txInfo,
             proof,
             mainUtxo,
-            reservationKey
+            reservationKey,
+            requestNonce
         );
     }
 
-    /// @notice Extends the custody term of a reservation by the current
-    ///         reservation term length. Can only be called by the
-    ///         reservation vault, which collects the custody fee for the
-    ///         extension. See `Reservation.extendReservation`.
+    /// @notice Notifies that the pending action of the given reservation
+    ///         has timed out. Writes the terminal, late-proof-accepting
+    ///         record, releases reserved capacity and locks, refunds the
+    ///         escrowed claim for redemptions, and slashes the wallet for
+    ///         redemption and dissolution timeouts. See
+    ///         `Reservation.notifyReservationActionTimeout`.
+    /// @param reservationKey The key of the reservation with the timed out
+    ///        action.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members; only consulted on the slashing paths (redemption
+    ///        and dissolution timeouts).
+    function notifyReservationActionTimeout(
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        self.notifyReservationActionTimeout(reservationKey, walletMembersIDs);
+    }
+
+    /// @notice Notifies that a pending reserved redemption generation was
+    ///         vetoed in the redemption watchtower. Detains the escrowed
+    ///         balance to the watchtower, terminally voids the generation
+    ///         and returns the position to Active. See
+    ///         `Reservation.notifyReservedRedemptionVeto`.
+    /// @param reservationKey The key of the reservation with the vetoed
+    ///        redemption.
+    /// @param requestNonce The generation being vetoed.
+    function notifyReservedRedemptionVeto(
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external {
+        // The caller is checked in the library function.
+        self.notifyReservedRedemptionVeto(reservationKey, requestNonce);
+    }
+
+    /// @notice Extends the custody term of a reservation by its snapshotted
+    ///         term length. Can only be called by the reservation vault,
+    ///         which collects the custody fee for the extension. See
+    ///         `Reservation.extendReservation`.
     /// @param reservationKey The key of the reservation to extend.
     function extendReservation(uint256 reservationKey) external {
         // The caller is checked in the library function.
         self.extendReservation(reservationKey);
-    }
-
-    /// @notice Requests an in-kind redemption of a reservation: the wallet
-    ///         is expected to spend exactly the reservation's current anchor
-    ///         outpoint to the redeemer output script in a 1-input-1-output
-    ///         transaction. Can only be called by the reservation vault,
-    ///         which must have approved the Bridge in the Bank for the gross
-    ///         minted amount. See `Reservation.requestReservedRedemption`.
-    /// @param reservationKey The key of the reservation to redeem.
-    /// @param redeemer The address able to claim the surrendered balance
-    ///        back if the redemption times out.
-    /// @param redeemerOutputScript The redeemer's length-prefixed output
-    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
-    function requestReservedRedemption(
-        uint256 reservationKey,
-        address redeemer,
-        bytes calldata redeemerOutputScript
-    ) external {
-        // The caller is checked in the library function.
-        self.requestReservedRedemption(
-            reservationKey,
-            redeemer,
-            redeemerOutputScript
-        );
-    }
-
-    /// @notice Notifies that a pending reserved redemption has timed out.
-    ///         Returns the surrendered balance to the redeemer, slashes the
-    ///         wallet operators like a regular redemption timeout, and
-    ///         returns the reservation to the Active state. See
-    ///         `Reservation.notifyReservedRedemptionTimeout`.
-    /// @param reservationKey The key of the reservation with the timed out
-    ///        redemption.
-    /// @param walletMembersIDs Identifiers of the wallet signing group
-    ///        members.
-    function notifyReservedRedemptionTimeout(
-        uint256 reservationKey,
-        uint32[] calldata walletMembersIDs
-    ) external {
-        self.notifyReservedRedemptionTimeout(reservationKey, walletMembersIDs);
-    }
-
-    /// @notice Notifies that a pending reserved redemption was vetoed in the
-    ///         redemption watchtower. Detains the surrendered balance to the
-    ///         watchtower and returns the reservation to the Active state.
-    ///         See `Reservation.notifyReservedRedemptionVeto`.
-    /// @param reservationKey The key of the reservation with the vetoed
-    ///        redemption.
-    function notifyReservedRedemptionVeto(uint256 reservationKey) external {
-        // The caller is checked in the library function.
-        self.notifyReservedRedemptionVeto(reservationKey);
     }
 
     /// @notice Updates parameters of reservations, including the
@@ -261,20 +370,19 @@ contract ReservationRouter is Governable, Initializable {
     /// @param reservationVault Address of the reservation vault. Can only be
     ///        changed while there are no active reservations.
     /// @param reservationMinAmount New value of the reservation minimum
-    ///        amount in satoshis. It is the minimal anchor output amount
-    ///        accepted for a reservation.
+    ///        amount in satoshis.
     /// @param reservationTxMaxFee New value of the reservation transaction
-    ///        max fee in satoshis. It is the maximum amount of BTC
-    ///        transaction fee that can be incurred by a single reservation
-    ///        lifecycle transaction.
+    ///        max fee in satoshis.
     /// @param reservationTermSeconds New value of the reservation custody
-    ///        term length in seconds.
+    ///        term length in seconds. Snapshotted into new positions.
     /// @param reservationGracePeriod New value of the reservation grace
-    ///        period in seconds.
+    ///        period in seconds. Snapshotted into new positions.
     /// @param reservationMaxTotalAmount New cap on the total amount in
     ///        satoshi locked under active reservations.
     /// @param maxReservationsPerWallet New cap on the number of active
     ///        reservations a single wallet can custody.
+    /// @param reservationActionTimeout New value of the reservation action
+    ///        timeout in seconds.
     /// @dev Requirements:
     ///      - The caller must be the governance,
     ///      - See `Reservation.updateReservationParameters` for parameter
@@ -286,7 +394,8 @@ contract ReservationRouter is Governable, Initializable {
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint32 reservationActionTimeout
     ) external onlyGovernance {
         self.updateReservationParameters(
             reservationVault,
@@ -295,12 +404,13 @@ contract ReservationRouter is Governable, Initializable {
             reservationTermSeconds,
             reservationGracePeriod,
             reservationMaxTotalAmount,
-            maxReservationsPerWallet
+            maxReservationsPerWallet,
+            reservationActionTimeout
         );
     }
 
-    /// @notice Collection of all reservations indexed by the deposit key of
-    ///         the underlying reserved deposit, i.e.
+    /// @notice Collection of all reservation positions indexed by the
+    ///         deposit key of the underlying reserved deposit, i.e.
     ///         `keccak256(fundingTxHash | fundingOutputIndex)`.
     /// @param reservationKey The key of the reservation.
     function reservations(uint256 reservationKey)
@@ -309,6 +419,33 @@ contract ReservationRouter is Governable, Initializable {
         returns (Reservation.ReservationRequest memory)
     {
         return self.reservations[reservationKey];
+    }
+
+    /// @notice Returns the action record of the given reservation
+    ///         generation.
+    /// @param reservationKey The key of the reservation.
+    /// @param requestNonce The action generation.
+    function reservationActions(uint256 reservationKey, uint64 requestNonce)
+        external
+        view
+        returns (Reservation.ReservationAction memory)
+    {
+        return
+            self.reservationActions[
+                Reservation.actionKey(reservationKey, requestNonce)
+            ];
+    }
+
+    /// @notice Returns the reservation key of the wallet's in-flight
+    ///         dissolution, or zero when none is pending (the per-wallet
+    ///         main-UTXO action lock).
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet.
+    function walletPendingDissolution(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint256)
+    {
+        return self.walletPendingDissolution[walletPubKeyHash];
     }
 
     /// @notice Returns the current values of Bridge reservation parameters.
@@ -323,7 +460,8 @@ contract ReservationRouter is Governable, Initializable {
             uint32 reservationGracePeriod,
             uint64 reservationMaxTotalAmount,
             uint64 reservationTotalAmount,
-            uint32 maxReservationsPerWallet
+            uint32 maxReservationsPerWallet,
+            uint32 reservationActionTimeout
         )
     {
         reservationVault = self.reservationVault;
@@ -334,6 +472,7 @@ contract ReservationRouter is Governable, Initializable {
         reservationMaxTotalAmount = self.reservationMaxTotalAmount;
         reservationTotalAmount = self.reservationTotalAmount;
         maxReservationsPerWallet = self.maxReservationsPerWallet;
+        reservationActionTimeout = self.reservationActionTimeout;
     }
 
     /// @notice Returns the address of the reservation router the Bridge

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -825,7 +825,8 @@ contract WalletProposalValidator {
     /// @param proposal The moved funds sweep proposal to validate.
     /// @return True if the proposal is valid. Reverts otherwise.
     /// @dev Requirements:
-    ///      - The source wallet must be in the Live or MovingFunds state,
+    ///      - The sweeping wallet must be in the Live, MovingFunds, or Closing
+    ///        state,
     ///      - The moved funds sweep request identified by the proposed
     ///        transaction hash and output index must be in the Pending state,
     ///      - The transaction hash and output index from the proposal must
@@ -843,11 +844,12 @@ contract WalletProposalValidator {
             proposal.walletPubKeyHash
         );
 
-        // Make sure the wallet is in Live or MovingFunds state.
+        // Make sure the wallet is in Live, MovingFunds, or Closing state.
         require(
             wallet.state == Wallets.WalletState.Live ||
-                wallet.state == Wallets.WalletState.MovingFunds,
-            "Source wallet is not in Live or MovingFunds state"
+                wallet.state == Wallets.WalletState.MovingFunds ||
+                wallet.state == Wallets.WalletState.Closing,
+            "Sweeping wallet is not in Live or MovingFunds or Closing state"
         );
 
         // Make sure the moved funds sweep request is valid.

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -26,6 +26,7 @@ import "./IReservationBridge.sol";
 import "./Reservation.sol";
 import "./MovingFunds.sol";
 import "./Wallets.sol";
+import "./WalletProposalValidatorConstants.sol";
 
 /// @title Wallet proposal validator.
 /// @notice This contract exposes several view functions allowing to validate
@@ -142,7 +143,8 @@ contract WalletProposalValidator {
     ///      In the happy path case, i.e. where the deposit is revealed immediately
     ///      after being broadcast on the Bitcoin network, the minimum age
     ///      check also ensures block finality for Bitcoin.
-    uint32 public constant DEPOSIT_MIN_AGE = 2 hours;
+    uint32 public constant DEPOSIT_MIN_AGE =
+        WalletProposalValidatorConstants.DEPOSIT_MIN_AGE;
 
     /// @notice Each deposit can be technically swept until it reaches its
     ///         refund timestamp after which it can be taken back by the depositor.
@@ -159,7 +161,8 @@ contract WalletProposalValidator {
     ///         For example, if a deposit becomes refundable after 8 pm and
     ///         DEPOSIT_REFUND_SAFETY_MARGIN is 6 hours, the deposit is valid
     ///         for a sweep only before 2 pm.
-    uint32 public constant DEPOSIT_REFUND_SAFETY_MARGIN = 24 hours;
+    uint32 public constant DEPOSIT_REFUND_SAFETY_MARGIN =
+        WalletProposalValidatorConstants.DEPOSIT_REFUND_SAFETY_MARGIN;
 
     /// @notice The maximum count of deposits that can be swept within a
     ///         single sweep.
@@ -192,7 +195,8 @@ contract WalletProposalValidator {
     ///         For example, if a request times out after 8 pm and
     ///         REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN is 2 hours, the
     ///         request is valid for processing only before 6 pm.
-    uint32 public constant REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN = 2 hours;
+    uint32 public constant REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN =
+        WalletProposalValidatorConstants.REQUEST_TIMEOUT_SAFETY_MARGIN;
 
     /// @notice The maximum count of redemption requests that can be processed
     ///         within a single redemption.

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -270,7 +270,7 @@ contract WalletProposalValidator {
 
         address proposalVault = address(0);
 
-        (address reservationVault, , , , , , , ) = IReservationBridge(
+        (address reservationVault, , , , , , , , ) = IReservationBridge(
             address(bridge)
         ).reservationParameters();
 
@@ -918,6 +918,8 @@ contract WalletProposalValidator {
         bytes20 walletPubKeyHash;
         // Key of the reserved deposit to anchor.
         DepositKey depositKey;
+        // Generation of the acceptance authorization being executed.
+        uint64 requestNonce;
         // Proposed BTC fee for the anchor transaction.
         uint256 anchorTxFee;
     }
@@ -928,6 +930,8 @@ contract WalletProposalValidator {
         bytes20 walletPubKeyHash;
         // Key of the reservation with the pending reserved redemption.
         uint256 reservationKey;
+        // Generation of the redemption request being executed.
+        uint64 requestNonce;
         // Proposed BTC fee for the reserved redemption transaction.
         uint256 redemptionTxFee;
     }
@@ -939,6 +943,8 @@ contract WalletProposalValidator {
         bytes20 sourceWalletPubKeyHash;
         // Key of the reservation to re-anchor.
         uint256 reservationKey;
+        // Generation of the re-anchor authorization being executed.
+        uint64 requestNonce;
         // 20-byte public key hash of the wallet receiving the anchor.
         bytes20 targetWalletPubKeyHash;
         // Proposed BTC fee for the re-anchor transaction.
@@ -952,8 +958,32 @@ contract WalletProposalValidator {
         bytes20 walletPubKeyHash;
         // Key of the reservation to dissolve.
         uint256 reservationKey;
+        // Generation of the dissolution authorization being executed.
+        uint64 requestNonce;
         // Proposed BTC fee for the dissolution transaction.
         uint256 dissolutionTxFee;
+    }
+
+    /// @notice Fetches the given reservation action generation and reverts
+    ///         unless it is pending and of the expected type. Wallets must
+    ///         only sign explicitly requested, still-pending generations —
+    ///         the Bridge proof path settles nothing else (except late
+    ///         proofs of timed-out generations, which only exist for
+    ///         transactions signed while the generation was pending).
+    function requirePendingAction(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType expectedType
+    ) internal view returns (Reservation.ReservationAction memory action) {
+        action = IReservationBridge(address(bridge)).reservationActions(
+            reservationKey,
+            requestNonce
+        );
+        require(
+            action.actionType == expectedType &&
+                action.state == Reservation.ActionState.Pending,
+            "No pending action of the expected type"
+        );
     }
 
     /// @notice View function encapsulating the main rules of a valid
@@ -963,13 +993,15 @@ contract WalletProposalValidator {
     ///        validation.
     /// @return True if the proposal is valid. Reverts otherwise.
     /// @dev Requirements:
-    ///      - Reservations must be enabled (reservation vault set),
+    ///      - The named acceptance authorization generation must be
+    ///        pending, authorize the proposal wallet, and not be within
+    ///        the timeout safety margin,
     ///      - The wallet must be in the Live or MovingFunds state,
-    ///      - The deposit must be revealed, old enough, not swept, and
-    ///        routed to the reservation vault,
-    ///      - The proposed fee must be positive, within the reservation
-    ///        transaction max fee, and must leave an anchor amount above
-    ///        the reservation minimum,
+    ///      - The deposit must be revealed, old enough and not swept,
+    ///      - The proposed fee must be positive and within the
+    ///        authorization's snapshotted fee bound (which, with the
+    ///        request-time amount check, keeps the anchor above the
+    ///        reservation minimum),
     ///      - The deposit extra info must be valid and preserve the refund
     ///        safety margin,
     ///      - The deposit must be controlled by the proposal wallet.
@@ -977,19 +1009,6 @@ contract WalletProposalValidator {
         ReservationAnchorProposal calldata proposal,
         DepositExtraInfo calldata depositExtraInfo
     ) external view returns (bool) {
-        (
-            address reservationVault,
-            uint64 reservationMinAmount,
-            uint64 reservationTxMaxFee,
-            ,
-            ,
-            ,
-            ,
-
-        ) = IReservationBridge(address(bridge)).reservationParameters();
-
-        require(reservationVault != address(0), "Reservations are disabled");
-
         requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
 
         uint256 depositKeyUint = uint256(
@@ -999,6 +1018,24 @@ contract WalletProposalValidator {
                     proposal.depositKey.fundingOutputIndex
                 )
             )
+        );
+
+        Reservation.ReservationAction memory action = requirePendingAction(
+            depositKeyUint,
+            proposal.requestNonce,
+            Reservation.ActionType.Acceptance
+        );
+
+        require(
+            action.targetWalletPubKeyHash == proposal.walletPubKeyHash,
+            "Acceptance authorized for different wallet"
+        );
+
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <
+                action.timeoutAt - REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN,
+            "Authorization timeout safety margin is not preserved"
         );
 
         Deposit.DepositRequest memory depositRequest = bridge.deposits(
@@ -1016,22 +1053,12 @@ contract WalletProposalValidator {
         require(depositRequest.sweptAt == 0, "Deposit already swept");
 
         require(
-            depositRequest.vault == reservationVault,
-            "Deposit not routed to the reservation vault"
-        );
-
-        require(
             proposal.anchorTxFee > 0,
             "Proposed transaction fee cannot be zero"
         );
         require(
-            proposal.anchorTxFee <= reservationTxMaxFee,
+            proposal.anchorTxFee <= action.txMaxFee,
             "Proposed transaction fee is too high"
-        );
-        require(
-            depositRequest.amount - proposal.anchorTxFee >=
-                reservationMinAmount,
-            "Anchor amount below the reservation minimum"
         );
 
         validateDepositExtraInfo(
@@ -1083,20 +1110,29 @@ contract WalletProposalValidator {
         ).reservations(proposal.reservationKey);
 
         require(
-            reservation.state ==
-                Reservation.ReservationState.RedemptionRequested,
-            "No pending reserved redemption"
-        );
-        require(
             reservation.walletPubKeyHash == proposal.walletPubKeyHash,
             "Reservation custodied by different wallet"
         );
 
+        Reservation.ReservationAction memory action = requirePendingAction(
+            proposal.reservationKey,
+            proposal.requestNonce,
+            Reservation.ActionType.Redemption
+        );
+
+        // The authorization gate: the watchtower delay applicable to this
+        // generation must have elapsed before the wallet signs. The Bridge
+        // proof path enforces the same rule, so signing earlier would
+        // produce a transaction that cannot settle before the guardians'
+        // window closes — and never settles if the generation gets vetoed.
         uint32 requestMinAge = REDEMPTION_REQUEST_MIN_AGE;
         address watchtower = bridge.getRedemptionWatchtower();
         if (watchtower != address(0)) {
             uint32 delay = IRedemptionWatchtower(watchtower)
-                .getReservedRedemptionDelay(proposal.reservationKey);
+                .getReservedRedemptionDelay(
+                    proposal.reservationKey,
+                    proposal.requestNonce
+                );
             if (delay > requestMinAge) {
                 requestMinAge = delay;
             }
@@ -1104,17 +1140,14 @@ contract WalletProposalValidator {
 
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp > reservation.redemptionRequestedAt + requestMinAge,
+            block.timestamp > action.requestedAt + requestMinAge,
             "Reserved redemption min age not achieved yet"
         );
 
-        (, , , , uint32 redemptionTimeout, , ) = bridge.redemptionParameters();
         require(
             /* solhint-disable-next-line not-rely-on-time */
             block.timestamp <
-                reservation.redemptionRequestedAt +
-                    redemptionTimeout -
-                    REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN,
+                action.timeoutAt - REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN,
             "Redemption request timeout safety margin is not preserved"
         );
 
@@ -1123,7 +1156,7 @@ contract WalletProposalValidator {
             "Proposed transaction fee cannot be zero"
         );
         require(
-            proposal.redemptionTxFee <= reservation.redemptionTxMaxFee,
+            proposal.redemptionTxFee <= action.txMaxFee,
             "Proposed transaction fee is too high"
         );
 
@@ -1137,13 +1170,12 @@ contract WalletProposalValidator {
     /// @dev Requirements:
     ///      - The reservation must be Active and custodied by the source
     ///        wallet,
-    ///      - The target wallet must be in the Live state,
-    ///      - The proposed fee must be positive and within the reservation
-    ///        transaction max fee.
-    ///
-    ///      The source wallet state is deliberately not restricted, mirroring
-    ///      `Reservation.submitReservationReanchorProof`: moving reservations
-    ///      out must remain possible for wallets in any lifecycle state.
+    ///      - The named re-anchor authorization generation must be pending,
+    ///        target the proposal's target wallet, and not be within the
+    ///        timeout safety margin,
+    ///      - The proposed fee must be positive, within the authorization's
+    ///        snapshotted fee bound, and leave the re-anchored amount above
+    ///        the dust floor.
     function validateReservationReanchorProposal(
         ReservationReanchorProposal calldata proposal
     ) external view returns (bool) {
@@ -1152,30 +1184,39 @@ contract WalletProposalValidator {
         ).reservations(proposal.reservationKey);
 
         require(
-            reservation.state == Reservation.ReservationState.Active,
-            "Reservation is not active"
-        );
-        require(
             reservation.walletPubKeyHash == proposal.sourceWalletPubKeyHash,
             "Reservation custodied by different wallet"
         );
 
-        require(
-            bridge.wallets(proposal.targetWalletPubKeyHash).state ==
-                Wallets.WalletState.Live,
-            "Target wallet must be in Live state"
+        Reservation.ReservationAction memory action = requirePendingAction(
+            proposal.reservationKey,
+            proposal.requestNonce,
+            Reservation.ActionType.Reanchor
         );
 
-        (, , uint64 reservationTxMaxFee, , , , , ) = IReservationBridge(
-            address(bridge)
-        ).reservationParameters();
+        require(
+            action.targetWalletPubKeyHash == proposal.targetWalletPubKeyHash,
+            "Re-anchor authorized for different target wallet"
+        );
+
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp <
+                action.timeoutAt - REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN,
+            "Authorization timeout safety margin is not preserved"
+        );
+
         require(
             proposal.reanchorTxFee > 0,
             "Proposed transaction fee cannot be zero"
         );
         require(
-            proposal.reanchorTxFee <= reservationTxMaxFee,
+            proposal.reanchorTxFee <= action.txMaxFee,
             "Proposed transaction fee is too high"
+        );
+        require(
+            reservation.anchorAmount - proposal.reanchorTxFee > action.txMaxFee,
+            "Re-anchor amount below the dust floor"
         );
 
         return true;
@@ -1187,10 +1228,12 @@ contract WalletProposalValidator {
     /// @return True if the proposal is valid. Reverts otherwise.
     /// @dev Requirements:
     ///      - The wallet must be in the Live or MovingFunds state,
-    ///      - The reservation must be Active, custodied by the proposal
-    ///        wallet, and past its custody term plus grace period,
-    ///      - The proposed fee must be positive and within the reservation
-    ///        transaction max fee.
+    ///      - The reservation must be custodied by the proposal wallet,
+    ///      - The named dissolution authorization generation must be
+    ///        pending (its request already validated the term and grace
+    ///        expiry) and not be within the timeout safety margin,
+    ///      - The proposed fee must be positive and within the
+    ///        authorization's snapshotted fee bound.
     function validateReservationDissolutionProposal(
         ReservationDissolutionProposal calldata proposal
     ) external view returns (bool) {
@@ -1201,30 +1244,21 @@ contract WalletProposalValidator {
         ).reservations(proposal.reservationKey);
 
         require(
-            reservation.state == Reservation.ReservationState.Active,
-            "Reservation is not active"
-        );
-        require(
             reservation.walletPubKeyHash == proposal.walletPubKeyHash,
             "Reservation custodied by different wallet"
         );
 
-        (
-            ,
-            ,
-            uint64 reservationTxMaxFee,
-            ,
-            uint32 reservationGracePeriod,
-            ,
-            ,
-
-        ) = IReservationBridge(address(bridge)).reservationParameters();
+        Reservation.ReservationAction memory action = requirePendingAction(
+            proposal.reservationKey,
+            proposal.requestNonce,
+            Reservation.ActionType.Dissolution
+        );
 
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp >
-                uint256(reservation.expiresAt) + reservationGracePeriod,
-            "Reservation term or grace period not elapsed"
+            block.timestamp <
+                action.timeoutAt - REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN,
+            "Authorization timeout safety margin is not preserved"
         );
 
         require(
@@ -1232,7 +1266,7 @@ contract WalletProposalValidator {
             "Proposed transaction fee cannot be zero"
         );
         require(
-            proposal.dissolutionTxFee <= reservationTxMaxFee,
+            proposal.dissolutionTxFee <= action.txMaxFee,
             "Proposed transaction fee is too high"
         );
 

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -1173,8 +1173,8 @@ contract WalletProposalValidator {
     ///      - The reservation must be Active and custodied by the source
     ///        wallet,
     ///      - The named re-anchor authorization generation must be pending,
-    ///        target the proposal's target wallet, and not be within the
-    ///        timeout safety margin,
+    ///        target the proposal's target wallet, whose current state must
+    ///        still be Live, and not be within the timeout safety margin,
     ///      - The proposed fee must be positive, within the authorization's
     ///        snapshotted fee bound, and leave the re-anchored amount above
     ///        the dust floor.
@@ -1199,6 +1199,12 @@ contract WalletProposalValidator {
         require(
             action.targetWalletPubKeyHash == proposal.targetWalletPubKeyHash,
             "Re-anchor authorized for different target wallet"
+        );
+
+        require(
+            bridge.wallets(proposal.targetWalletPubKeyHash).state ==
+                Wallets.WalletState.Live,
+            "Target wallet must be in Live state"
         );
 
         require(

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -22,6 +22,7 @@ import "./BitcoinTx.sol";
 import "./Bridge.sol";
 import "./Deposit.sol";
 import "./Redemption.sol";
+import "./IReservationBridge.sol";
 import "./Reservation.sol";
 import "./MovingFunds.sol";
 import "./Wallets.sol";
@@ -269,8 +270,9 @@ contract WalletProposalValidator {
 
         address proposalVault = address(0);
 
-        (address reservationVault, , , , , , , ) = bridge
-            .reservationParameters();
+        (address reservationVault, , , , , , , ) = IReservationBridge(
+            address(bridge)
+        ).reservationParameters();
 
         uint256[] memory processedDepositKeys = new uint256[](
             proposal.depositsKeys.length
@@ -984,7 +986,7 @@ contract WalletProposalValidator {
             ,
             ,
 
-        ) = bridge.reservationParameters();
+        ) = IReservationBridge(address(bridge)).reservationParameters();
 
         require(reservationVault != address(0), "Reservations are disabled");
 
@@ -1076,9 +1078,9 @@ contract WalletProposalValidator {
     ) external view returns (bool) {
         requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
 
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
-            proposal.reservationKey
-        );
+        Reservation.ReservationRequest memory reservation = IReservationBridge(
+            address(bridge)
+        ).reservations(proposal.reservationKey);
 
         require(
             reservation.state ==
@@ -1145,9 +1147,9 @@ contract WalletProposalValidator {
     function validateReservationReanchorProposal(
         ReservationReanchorProposal calldata proposal
     ) external view returns (bool) {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
-            proposal.reservationKey
-        );
+        Reservation.ReservationRequest memory reservation = IReservationBridge(
+            address(bridge)
+        ).reservations(proposal.reservationKey);
 
         require(
             reservation.state == Reservation.ReservationState.Active,
@@ -1164,8 +1166,9 @@ contract WalletProposalValidator {
             "Target wallet must be in Live state"
         );
 
-        (, , uint64 reservationTxMaxFee, , , , , ) = bridge
-            .reservationParameters();
+        (, , uint64 reservationTxMaxFee, , , , , ) = IReservationBridge(
+            address(bridge)
+        ).reservationParameters();
         require(
             proposal.reanchorTxFee > 0,
             "Proposed transaction fee cannot be zero"
@@ -1193,9 +1196,9 @@ contract WalletProposalValidator {
     ) external view returns (bool) {
         requireWalletLiveOrMovingFunds(proposal.walletPubKeyHash);
 
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
-            proposal.reservationKey
-        );
+        Reservation.ReservationRequest memory reservation = IReservationBridge(
+            address(bridge)
+        ).reservations(proposal.reservationKey);
 
         require(
             reservation.state == Reservation.ReservationState.Active,
@@ -1215,7 +1218,7 @@ contract WalletProposalValidator {
             ,
             ,
 
-        ) = bridge.reservationParameters();
+        ) = IReservationBridge(address(bridge)).reservationParameters();
 
         require(
             /* solhint-disable-next-line not-rely-on-time */

--- a/solidity/contracts/bridge/WalletProposalValidatorConstants.sol
+++ b/solidity/contracts/bridge/WalletProposalValidatorConstants.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+/// @title Wallet proposal validator timing constants
+/// @notice Shared timing policy used both when a wallet action is requested
+///         and when the resulting proposal is validated for signing.
+library WalletProposalValidatorConstants {
+    uint32 internal constant DEPOSIT_MIN_AGE = 2 hours;
+    uint32 internal constant DEPOSIT_REFUND_SAFETY_MARGIN = 24 hours;
+    uint32 internal constant REQUEST_TIMEOUT_SAFETY_MARGIN = 2 hours;
+}

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -432,10 +432,15 @@ library Wallets {
             "Target wallets don't correspond to the commitment"
         );
 
-        // If funds were moved, the wallet has no longer a main UTXO.
+        // If funds were moved, the wallet no longer has a main UTXO.
         delete wallet.mainUtxoHash;
 
-        beginWalletClosing(self, walletPubKeyHash);
+        if (
+            self.walletReservationsCount[walletPubKeyHash] == 0 &&
+            wallet.pendingMovedFundsSweepRequestsCount == 0
+        ) {
+            beginWalletClosing(self, walletPubKeyHash);
+        }
     }
 
     /// @notice Called when a MovingFunds wallet has a balance below the dust
@@ -595,11 +600,11 @@ library Wallets {
 
         if (
             wallet.mainUtxoHash == bytes32(0) &&
-            self.walletReservationsCount[walletPubKeyHash] == 0
+            self.walletReservationsCount[walletPubKeyHash] == 0 &&
+            wallet.pendingMovedFundsSweepRequestsCount == 0
         ) {
-            // If the wallet has no main UTXO and no reservation anchors,
-            // its BTC balance is zero and the wallet closing should begin
-            // immediately.
+            // If the wallet has no tracked BTC obligations, its BTC balance
+            // is zero and the wallet closing should begin immediately.
             beginWalletClosing(self, walletPubKeyHash);
         } else {
             // The wallet holds funds: a main UTXO, reservation anchors, or
@@ -635,18 +640,21 @@ library Wallets {
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash
     ) internal {
-        // A wallet that still custodies reservation anchors (or reserved
-        // capacity of pending reservation actions) has not finished moving
-        // its funds: reservations must first be redeemed, re-anchored to
-        // other wallets or dissolved into the main UTXO. Entering the
-        // Closing state would strand them — reservation actions require a
-        // Live or MovingFunds wallet.
+        // A wallet that still custodies reservation anchors, reserved
+        // capacity, or pending moved-funds sweep requests has not finished
+        // moving its funds. Entering Closing would make those obligations
+        // unprocessable because their proof and timeout paths require a Live
+        // or MovingFunds wallet.
+        Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
         require(
             self.walletReservationsCount[walletPubKeyHash] == 0,
             "Wallet still custodies reservations"
         );
+        require(
+            wallet.pendingMovedFundsSweepRequestsCount == 0,
+            "Wallet has pending moved funds sweep requests"
+        );
 
-        Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
         // Initialize the closing period.
         wallet.state = WalletState.Closing;
         /* solhint-disable-next-line not-rely-on-time */

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -76,7 +76,8 @@ library Wallets {
         // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 createdAt;
         // UNIX timestamp indicating the moment the wallet was requested to
-        // move their funds.
+        // move their funds. Zero marks a successfully proven generation whose
+        // remaining reservation or sweep obligations kept it in MovingFunds.
         // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 movingFundsRequestedAt;
         // UNIX timestamp indicating the moment the wallet's closing period
@@ -375,21 +376,14 @@ library Wallets {
             "Closing period has not elapsed yet"
         );
 
-        // A wallet still custodying reservation anchors must not close
-        // ultimately; its reservations must first be re-anchored to other
-        // wallets or dissolved into the main UTXO.
-        require(
-            self.walletReservationsCount[walletPubKeyHash] == 0,
-            "Wallet still custodies reservations"
-        );
-
         finalizeWalletClosing(self, walletPubKeyHash);
     }
 
     /// @notice Notifies that the wallet completed the moving funds process
     ///         successfully. Checks if the funds were moved to the expected
-    ///         target wallets. Closes the source wallet if everything went
-    ///         good and reverts otherwise.
+    ///         target wallets. Closes the source wallet when no tracked
+    ///         obligations remain; otherwise disarms the completed generation's
+    ///         timeout and retains MovingFunds until those obligations clear.
     /// @param walletPubKeyHash 20-byte public key hash of the wallet.
     /// @param targetWalletsHash 32-byte keccak256 hash over the list of
     ///        20-byte public key hashes of the target wallets actually used
@@ -434,12 +428,38 @@ library Wallets {
 
         // If funds were moved, the wallet no longer has a main UTXO.
         delete wallet.mainUtxoHash;
+        // A proof records successful completion even when reservation or
+        // incoming-sweep obligations prevent the state from entering Closing.
+        // Zero is the completion sentinel and cannot be reported as a timeout.
+        delete wallet.movingFundsRequestedAt;
+        delete wallet.movingFundsTargetWalletsCommitmentHash;
 
         if (
             self.walletReservationsCount[walletPubKeyHash] == 0 &&
             wallet.pendingMovedFundsSweepRequestsCount == 0
         ) {
             beginWalletClosing(self, walletPubKeyHash);
+        }
+    }
+
+    /// @notice Starts a fresh moving-funds deadline when a completed wallet
+    ///         later gains a new main UTXO. An already-running deadline is
+    ///         deliberately not extended.
+    function rearmMovingFundsTimeout(
+        BridgeState.Storage storage self,
+        bytes20 walletPubKeyHash
+    ) internal {
+        Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
+        if (
+            wallet.state == WalletState.MovingFunds &&
+            wallet.movingFundsRequestedAt == 0
+        ) {
+            /* solhint-disable-next-line not-rely-on-time */
+            wallet.movingFundsRequestedAt = uint32(block.timestamp);
+
+            // Reuse the lifecycle event so monitoring sees that the wallet has
+            // acquired a fresh balance and a new timeout is now running.
+            emit WalletMovingFunds(wallet.ecdsaWalletID, walletPubKeyHash);
         }
     }
 
@@ -502,8 +522,8 @@ library Wallets {
     ///        supposed to sweep funds.
     /// @param walletMembersIDs Identifiers of the wallet signing group members.
     /// @dev Requirements:
-    ///      - The wallet must be in the `Live`, `MovingFunds`,
-    ///        or `Terminated` state.
+    ///      - The wallet must be in the `Live`, `MovingFunds`, `Closing`,
+    ///        `Closed`, or `Terminated` state.
     function notifyWalletMovedFundsSweepTimeout(
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash,
@@ -515,8 +535,10 @@ library Wallets {
         require(
             walletState == WalletState.Live ||
                 walletState == WalletState.MovingFunds ||
+                walletState == WalletState.Closing ||
+                walletState == WalletState.Closed ||
                 walletState == WalletState.Terminated,
-            "Wallet must be in Live or MovingFunds or Terminated state"
+            "Wallet must be in Live or MovingFunds or Closing or Closed or Terminated state"
         );
 
         if (
@@ -533,6 +555,9 @@ library Wallets {
 
             terminateWallet(self, walletPubKeyHash);
         }
+        // Closing, Closed, and Terminated wallets may receive a sweep request
+        // from a source proof submitted after their state transition. Resolve
+        // those requests without another slash or registry state transition.
     }
 
     /// @notice Called when a wallet which was challenged for a fraud did not
@@ -674,6 +699,18 @@ library Wallets {
         bytes20 walletPubKeyHash
     ) internal {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
+
+        // A wallet still custodying reservation anchors or targeted by pending
+        // moved-funds sweeps must not close ultimately. A late source-wallet
+        // proof can register a new sweep after this wallet entered Closing.
+        require(
+            self.walletReservationsCount[walletPubKeyHash] == 0,
+            "Wallet still custodies reservations"
+        );
+        require(
+            wallet.pendingMovedFundsSweepRequestsCount == 0,
+            "Wallet has pending moved funds sweep requests"
+        );
 
         wallet.state = WalletState.Closed;
 

--- a/solidity/contracts/bridge/Wallets.sol
+++ b/solidity/contracts/bridge/Wallets.sol
@@ -593,11 +593,20 @@ library Wallets {
     ) internal {
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
 
-        if (wallet.mainUtxoHash == bytes32(0)) {
-            // If the wallet has no main UTXO, that means its BTC balance
-            // is zero and the wallet closing should begin immediately.
+        if (
+            wallet.mainUtxoHash == bytes32(0) &&
+            self.walletReservationsCount[walletPubKeyHash] == 0
+        ) {
+            // If the wallet has no main UTXO and no reservation anchors,
+            // its BTC balance is zero and the wallet closing should begin
+            // immediately.
             beginWalletClosing(self, walletPubKeyHash);
         } else {
+            // The wallet holds funds: a main UTXO, reservation anchors, or
+            // both. A wallet with anchors but no main UTXO still enters
+            // the moving funds process — its reservations must be
+            // re-anchored to other wallets (or redeemed/dissolved) before
+            // it can begin closing via the below-dust notification.
             // Otherwise, initialize the moving funds process.
             wallet.state = WalletState.MovingFunds;
             /* solhint-disable-next-line not-rely-on-time */
@@ -626,6 +635,17 @@ library Wallets {
         BridgeState.Storage storage self,
         bytes20 walletPubKeyHash
     ) internal {
+        // A wallet that still custodies reservation anchors (or reserved
+        // capacity of pending reservation actions) has not finished moving
+        // its funds: reservations must first be redeemed, re-anchored to
+        // other wallets or dissolved into the main UTXO. Entering the
+        // Closing state would strand them — reservation actions require a
+        // Live or MovingFunds wallet.
+        require(
+            self.walletReservationsCount[walletPubKeyHash] == 0,
+            "Wallet still custodies reservations"
+        );
+
         Wallet storage wallet = self.registeredWallets[walletPubKeyHash];
         // Initialize the closing period.
         wallet.state = WalletState.Closing;

--- a/solidity/contracts/maintainer/MaintainerProxyV2.sol
+++ b/solidity/contracts/maintainer/MaintainerProxyV2.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+import "../bridge/IReservationBridge.sol";
+import "./MaintainerProxy.sol";
+
+/// @title Maintainer Proxy V2
+/// @notice Reservation-proof successor of `MaintainerProxy` adding the routed
+///         UTXO-reservation SPV proof endpoint. A separate contract is used
+///         because the production `MaintainerProxy` is not upgradeable; that
+///         proxy can remain active for legacy and wallet-maintainer calls.
+contract MaintainerProxyV2 is MaintainerProxy {
+    /// @notice Gas that is meant to balance the submission of a reservation
+    ///         proof overall cost. Can be updated by governance based on the
+    ///         current market conditions.
+    uint256 public submitReservationProofGasOffset;
+
+    event ReservationProofGasOffsetUpdated(
+        uint256 submitReservationProofGasOffset
+    );
+
+    constructor(Bridge _bridge, ReimbursementPool _reimbursementPool)
+        MaintainerProxy(_bridge, _reimbursementPool)
+    {
+        submitReservationProofGasOffset = 30000;
+    }
+
+    /// @notice Wraps `ReservationRouter.submitReservationProof`, called at the
+    ///         Bridge address, and reimburses the caller's transaction cost.
+    /// @dev See `ReservationRouter.submitReservationProof` documentation.
+    function submitReservationProof(
+        uint8 proofType,
+        BitcoinTx.Info calldata txInfo,
+        BitcoinTx.Proof calldata proof,
+        BitcoinTx.UTXO calldata mainUtxo,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external onlySpvMaintainer {
+        uint256 gasStart = gasleft();
+
+        IReservationBridge(address(bridge)).submitReservationProof(
+            proofType,
+            txInfo,
+            proof,
+            mainUtxo,
+            reservationKey,
+            requestNonce
+        );
+
+        reimbursementPool.refund(
+            (gasStart - gasleft()) + submitReservationProofGasOffset,
+            msg.sender
+        );
+    }
+
+    /// @notice Updates the gas offset used for reservation proof refunds.
+    /// @dev Can be called only by the contract owner. The caller is responsible
+    ///      for validating the parameter.
+    /// @param newSubmitReservationProofGasOffset New reservation proof gas
+    ///        offset.
+    function updateReservationProofGasOffset(
+        uint256 newSubmitReservationProofGasOffset
+    ) external onlyOwner {
+        submitReservationProofGasOffset = newSubmitReservationProofGasOffset;
+
+        emit ReservationProofGasOffsetUpdated(
+            newSubmitReservationProofGasOffset
+        );
+    }
+}

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -220,4 +220,12 @@ contract BridgeStub is Bridge {
     function cancelRebate(address user, uint256 requestedAt) external {
         RebateStaking(self.rebateStaking).cancelRebate(user, requestedAt);
     }
+
+    function getWalletReservationsCount(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint32)
+    {
+        return self.walletReservationsCount[walletPubKeyHash];
+    }
 }

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -33,12 +33,9 @@ contract BridgeStub is Bridge {
         uint256 reservationKey,
         uint64 requestNonce
     ) external {
-        Reservation.ReservationAction storage action = self
-            .reservationActions[
-                uint256(
-                    keccak256(abi.encodePacked(reservationKey, requestNonce))
-                )
-            ];
+        Reservation.ReservationAction storage action = self.reservationActions[
+            uint256(keccak256(abi.encodePacked(reservationKey, requestNonce)))
+        ];
         action.actionType = Reservation.ActionType.Acceptance;
         action.state = Reservation.ActionState.Pending;
     }

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -70,6 +70,10 @@ contract BridgeStub is Bridge {
         self.activeWalletPubKeyHash = activeWalletPubKeyHash;
     }
 
+    function setLiveWalletsCount(uint32 liveWalletsCount) external {
+        self.liveWalletsCount = liveWalletsCount;
+    }
+
     function setWalletMainUtxo(
         bytes20 walletPubKeyHash,
         BitcoinTx.UTXO calldata utxo

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -21,27 +21,9 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./IVault.sol";
 import "./TBTCVault.sol";
 import "../bank/Bank.sol";
+import "../bridge/IReservationBridge.sol";
 import "../bridge/Reservation.sol";
 import "../token/TBTC.sol";
-
-/// @notice Minimal interface of the Bridge functions the reservation vault
-///         interacts with.
-interface IReservationBridge {
-    function reservations(uint256 reservationKey)
-        external
-        view
-        returns (Reservation.ReservationRequest memory);
-
-    function requestReservedRedemption(
-        uint256 reservationKey,
-        address redeemer,
-        bytes calldata redeemerOutputScript
-    ) external;
-
-    function extendReservation(uint256 reservationKey) external;
-
-    function treasury() external view returns (address);
-}
 
 /// @title Reservation vault
 /// @notice The reservation vault is the liability-side companion of the

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -256,7 +256,9 @@ contract ReservationVault is IVault, Ownable {
         bridge.requestReservedRedemption(
             reservationKey,
             msg.sender,
-            redeemerOutputScript
+            redeemerOutputScript,
+            true, // The redemption fee was collected above.
+            false
         );
     }
 
@@ -304,7 +306,11 @@ contract ReservationVault is IVault, Ownable {
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
     ///      - The caller must have approved this vault in the Bank for the
-    ///        gross minted amount (`Bank.approveBalance`).
+    ///        gross minted amount (`Bank.approveBalance`),
+    ///      - The reservation must hold the single-use retry entitlement
+    ///        the Bridge mints when a fee-paid redemption request times
+    ///        out through the wallet's fault (enforced by the Bridge and
+    ///        consumed by this call).
     ///
     ///      The redemption fee is not re-charged: it was collected by the
     ///      original `redeemReservation` call and the retry only exists
@@ -348,7 +354,9 @@ contract ReservationVault is IVault, Ownable {
         bridge.requestReservedRedemption(
             reservationKey,
             msg.sender,
-            redeemerOutputScript
+            redeemerOutputScript,
+            false,
+            true // Consume the retry entitlement instead of paying the fee.
         );
     }
 

--- a/solidity/deploy/06_deploy_bridge.ts
+++ b/solidity/deploy/06_deploy_bridge.ts
@@ -39,12 +39,20 @@ const func: DeployFunction = async function deployBridge(
   })
   const Fraud = await deploy("Fraud", deployOptions)
   const MovingFunds = await deploy("MovingFunds", deployOptions)
-  const Reservation = await deploy("Reservation", deployOptions)
+  const ReservationProofs = await deploy("ReservationProofs", deployOptions)
+  const Reservation = await deploy("Reservation", {
+    ...deployOptions,
+    libraries: {
+      ReservationProofs: ReservationProofs.address,
+    },
+  })
 
   // The reservation router holds the Bridge's UTXO-reservation external
   // surface and is reached through the Bridge's fallback via delegatecall.
   // It is stateless code (all storage lives in the Bridge), so a single
-  // instance can serve any number of Bridge deployments.
+  // instance can serve any number of Bridge deployments. The router links
+  // exactly one library (Reservation), which in turn links the settlement
+  // library (ReservationProofs).
   const ReservationRouter = await deploy("ReservationRouter", {
     ...deployOptions,
     libraries: {
@@ -103,6 +111,7 @@ const func: DeployFunction = async function deployBridge(
     await helpers.etherscan.verify(Fraud)
     await helpers.etherscan.verify(MovingFunds)
     await helpers.etherscan.verify(Reservation)
+    await helpers.etherscan.verify(ReservationProofs)
     await helpers.etherscan.verify(ReservationRouter)
 
     // We use `verify` instead of `verify:verify` as the `verify` task is defined

--- a/solidity/deploy/06_deploy_bridge.ts
+++ b/solidity/deploy/06_deploy_bridge.ts
@@ -41,6 +41,17 @@ const func: DeployFunction = async function deployBridge(
   const MovingFunds = await deploy("MovingFunds", deployOptions)
   const Reservation = await deploy("Reservation", deployOptions)
 
+  // The reservation router holds the Bridge's UTXO-reservation external
+  // surface and is reached through the Bridge's fallback via delegatecall.
+  // It is stateless code (all storage lives in the Bridge), so a single
+  // instance can serve any number of Bridge deployments.
+  const ReservationRouter = await deploy("ReservationRouter", {
+    ...deployOptions,
+    libraries: {
+      Reservation: Reservation.address,
+    },
+  })
+
   const [bridge, proxyDeployment] = await helpers.upgrades.deployProxy(
     "Bridge",
     {
@@ -63,7 +74,6 @@ const func: DeployFunction = async function deployBridge(
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
-          Reservation: Reservation.address,
         },
       },
       proxyOpts: {
@@ -77,6 +87,14 @@ const func: DeployFunction = async function deployBridge(
     }
   )
 
+  // Point the Bridge's fallback at the reservation router. The deployer
+  // holds the Bridge governance right after initialization (it is
+  // transferred to the governance account in a later script), so this
+  // one-time wiring can be done here.
+  await (await ethers.getContractAt("Bridge", bridge.address))
+    .connect(await ethers.getSigner(deployer))
+    .setReservationRouter(ReservationRouter.address)
+
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(Deposit)
     await helpers.etherscan.verify(DepositSweep)
@@ -85,6 +103,7 @@ const func: DeployFunction = async function deployBridge(
     await helpers.etherscan.verify(Fraud)
     await helpers.etherscan.verify(MovingFunds)
     await helpers.etherscan.verify(Reservation)
+    await helpers.etherscan.verify(ReservationRouter)
 
     // We use `verify` instead of `verify:verify` as the `verify` task is defined
     // in "@openzeppelin/hardhat-upgrades" to perform Etherscan verification

--- a/solidity/deploy/40_deploy_redemption_watchtower.ts
+++ b/solidity/deploy/40_deploy_redemption_watchtower.ts
@@ -16,6 +16,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       },
       proxyOpts: {
         kind: "transparent",
+        // The watchtower imports the `Reservation` library for its shared
+        // types; that library forwards reservation proofs to the external
+        // `ReservationProofs` library, which trips the upgrades plugin's
+        // source-closure check. The watchtower's own bytecode links no
+        // external library (types and internal helpers are inlined), so
+        // the linking is upgrade safe here — same rationale as the Bridge
+        // deployment.
+        unsafeAllow: ["external-library-linking"],
       },
     })
 

--- a/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
+++ b/solidity/deploy/80_upgrade_bridge_v2_DEPRECATED.ts
@@ -57,7 +57,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     Wallets: Wallets.address,
     Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
-    Reservation: Reservation.address,
   }
 
   const bridgeFactory = await ethers.getContractFactory("Bridge", {

--- a/solidity/deploy/81_upgrade_bridge_v2_vault_fix.ts
+++ b/solidity/deploy/81_upgrade_bridge_v2_vault_fix.ts
@@ -86,7 +86,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
-          Reservation: Reservation.address,
         },
       },
       proxyOpts: {

--- a/solidity/deploy/82_deploy_rebate_and_prepare_txs_DEPRECATED.ts
+++ b/solidity/deploy/82_deploy_rebate_and_prepare_txs_DEPRECATED.ts
@@ -168,7 +168,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       Wallets: Wallets.address,
       Fraud: Fraud.address,
       MovingFunds: MovingFunds.address,
-      Reservation: Reservation.address,
     },
   })
 
@@ -387,7 +386,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
           Wallets: Wallets.address,
           Fraud: Fraud.address,
           MovingFunds: MovingFunds.address,
-          Reservation: Reservation.address,
         },
       })
     } catch (error) {

--- a/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
+++ b/solidity/deploy/84_upgrade_bridge_repair_rebate_staking_DEPRECATED.ts
@@ -75,10 +75,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       "MovingFunds",
       bridgeArtifact.libraries?.MovingFunds
     ),
-    Reservation: await resolveAddress(
-      "Reservation",
-      bridgeArtifact.libraries?.Reservation
-    ),
   }
 
   const currentBridge = await ethers.getContractAt("Bridge", bridgeAddress)

--- a/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
+++ b/solidity/deploy/85_deploy_tip109_governance_upgrade.ts
@@ -356,7 +356,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     Wallets: Wallets.address,
     Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
-    Reservation: Reservation.address,
   }
 
   const bridgeImpl = await deploy("BridgeTIP109Implementation", {

--- a/solidity/deploy/86_deploy_tip109_hotfix.ts
+++ b/solidity/deploy/86_deploy_tip109_hotfix.ts
@@ -148,7 +148,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     Wallets: Wallets.address,
     Fraud: Fraud.address,
     MovingFunds: MovingFunds.address,
-    Reservation: Reservation.address,
   }
 
   const bridgeImpl = await deploy("BridgeTIP109HotfixImplementation", {

--- a/solidity/deploy/96_deploy_maintainer_proxy_v2.ts
+++ b/solidity/deploy/96_deploy_maintainer_proxy_v2.ts
@@ -1,0 +1,79 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function runDeployment(
+  hre: HardhatRuntimeEnvironment
+) {
+  const { deployments, getNamedAccounts, helpers } = hre
+  const { deploy, execute, getOrNull, read } = deployments
+  const { deployer, governance } = await getNamedAccounts()
+
+  const Bridge = await deployments.get("Bridge")
+  const ReimbursementPool = await deployments.get("ReimbursementPool")
+
+  const maintainerProxyV2 = await deploy("MaintainerProxyV2", {
+    contract: "MaintainerProxyV2",
+    from: deployer,
+    args: [Bridge.address, ReimbursementPool.address],
+    log: true,
+    waitConfirmations: 1,
+  })
+
+  // Copy the existing SPV-maintainer allowlist while the deployer still owns
+  // the fresh V2 contract. The index check makes resumed deployments safe.
+  if ((await getOrNull("MaintainerProxy")) !== null) {
+    const spvMaintainers: string[] = await read(
+      "MaintainerProxy",
+      "allSpvMaintainers"
+    )
+
+    await spvMaintainers.reduce<Promise<void>>(async (previous, maintainer) => {
+      await previous
+      const maintainerIndex = await read(
+        "MaintainerProxyV2",
+        "isSpvMaintainer",
+        maintainer
+      )
+
+      if (maintainerIndex.toString() === "0") {
+        await execute(
+          "MaintainerProxyV2",
+          { from: deployer, log: true, waitConfirmations: 1 },
+          "authorizeSpvMaintainer",
+          maintainer
+        )
+      }
+
+      return undefined
+    }, Promise.resolve())
+  }
+
+  await helpers.ownable.transferOwnership(
+    "MaintainerProxyV2",
+    governance,
+    deployer
+  )
+
+  if (hre.network.tags.etherscan) {
+    await helpers.etherscan.verify(maintainerProxyV2)
+  }
+
+  if (hre.network.tags.tenderly) {
+    await hre.tenderly.verify({
+      name: "MaintainerProxyV2",
+      address: maintainerProxyV2.address,
+    })
+  }
+
+  // Activation intentionally remains a governance operation: authorize V2
+  // in both Bridge and ReimbursementPool before trusting ReservationVault.
+}
+
+export default func
+
+func.tags = ["MaintainerProxyV2"]
+
+// Do not declare the legacy Bridge or MaintainerProxy tags as dependencies.
+// Their scripts deploy immutable/proxy contracts and are unsafe to recurse on
+// an existing network. The deployment records read above are prerequisites;
+// a full fresh deployment executes them earlier by numeric script order.

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -66,6 +66,13 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1000,
           },
+          // Storage layouts are asserted by tests guarding the
+          // Bridge / ReservationRouter delegatecall storage parity.
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
+          },
         },
       },
     ],
@@ -73,21 +80,28 @@ const config: HardhatUserConfig = {
       "@keep-network/ecdsa/contracts/WalletRegistry.sol":
         ecdsaSolidityCompilerConfig,
       "contracts/bridge/BridgeGovernance.sol": bridgeGovernanceCompilerConfig,
-      // Reduce the number of optimizer runs to preserve the Bridge's
-      // EIP-170 deployment margin after adding the reservation entry
-      // points. The runtime-gas cost of this is effectively nil: the Bridge
-      // is a thin dispatch shell over linked libraries (Deposit,
-      // DepositSweep, Redemption, Reservation) that stay at runs=1000, so a
-      // measured runs=1000-vs-100 diff over the deposit/redemption/
-      // reservation hot paths is 0-8 gas (noise). DRAFT NOTE: the durable
-      // alternative is a router-style refactor moving entry points out of
-      // the Bridge (as done on the P2TR activation track).
+      // Preserve the Bridge's EIP-170 deployment margin. Even with the
+      // UTXO-reservation surface moved out to the delegatecall
+      // ReservationRouter, the monolithic Bridge sits ~71 bytes over the
+      // limit at runs=1000 (24,647 B measured); runs=100 leaves a ~2.1 kB
+      // margin (22,403 B measured). The runtime-gas cost of the lower runs
+      // value is effectively nil: the Bridge is a thin dispatch shell over
+      // linked libraries (Deposit, DepositSweep, Redemption, ...) that stay
+      // at runs=1000, so a measured runs=1000-vs-100 diff over the
+      // deposit/redemption hot paths is 0-8 gas (noise). New reservation
+      // code goes into the ReservationRouter, which has its own EIP-170
+      // budget.
       "contracts/bridge/Bridge.sol": {
         version: "0.8.17",
         settings: {
           optimizer: {
             enabled: true,
             runs: 100,
+          },
+          outputSelection: {
+            "*": {
+              "*": ["storageLayout"],
+            },
           },
         },
       },

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -47,29 +47,33 @@ loadEnv({ path: path.join(__dirname, "..", ".env") })
     // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
     queryModule.getUnlinkedBytecode = (data: any, bytecode: string) => {
       const dataV3 = normalizeValidationData(data)
-      for (const validation of dataV3.log) {
-        const linkableContracts = Object.keys(validation).filter(
-          (name) => validation[name].linkReferences.length > 0
-        )
-        for (const name of linkableContracts) {
-          try {
-            const unlinkedBytecode = unlinkBytecode(
-              bytecode,
-              validation[name].linkReferences
-            )
-            const version = getVersion(unlinkedBytecode)
-            if (
-              validation[name].version?.withMetadata === version.withMetadata
-            ) {
-              return unlinkedBytecode
+      let result = bytecode
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dataV3.log.some((validation: any) =>
+        Object.keys(validation)
+          .filter((name) => validation[name].linkReferences.length > 0)
+          .some((name) => {
+            try {
+              const unlinkedBytecode = unlinkBytecode(
+                bytecode,
+                validation[name].linkReferences
+              )
+              const version = getVersion(unlinkedBytecode)
+              if (
+                validation[name].version?.withMetadata === version.withMetadata
+              ) {
+                result = unlinkedBytecode
+                return true
+              }
+            } catch {
+              // A foreign contract's link references mangled this bytecode;
+              // it cannot be the contract being deployed — skip the
+              // candidate.
             }
-          } catch {
-            // A foreign contract's link references mangled this bytecode;
-            // it cannot be the contract being deployed — skip the candidate.
-          }
-        }
-      }
-      return bytecode
+            return false
+          })
+      )
+      return result
     }
   }
 

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -19,6 +19,69 @@ import "solidity-docgen"
 // Load .env from tbtc-v2/ (parent of solidity/) so CHAIN_API_URL etc. are available
 loadEnv({ path: path.join(__dirname, "..", ".env") })
 
+// Backport of the upstream fix for a @openzeppelin/upgrades-core@1.20.0 bug:
+// `getUnlinkedBytecode` probes every linkable contract by splicing its
+// library-link placeholders into the bytecode being deployed. When a foreign
+// contract's link position lands inside the metadata-trim boundary of that
+// bytecode, the truncated placeholder makes `getVersion` throw "Bytecode is
+// not a valid hex string" and the whole proxy deployment fails — observed
+// once the ReservationRouter (a delegatecall extension with library link
+// references) entered the compilation set. Newer upgrades-core versions
+// wrap each probe in try/catch; this shim applies the same per-candidate
+// tolerance without a dependency bump.
+/* eslint-disable @typescript-eslint/no-var-requires, global-require */
+{
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const patch = (queryModule: any) => {
+    const {
+      normalizeValidationData,
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+    } = require("@openzeppelin/upgrades-core/dist/validate/data")
+    const {
+      unlinkBytecode,
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+    } = require("@openzeppelin/upgrades-core/dist/link-refs")
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { getVersion } = require("@openzeppelin/upgrades-core/dist/version")
+
+    // eslint-disable-next-line no-param-reassign, @typescript-eslint/no-explicit-any
+    queryModule.getUnlinkedBytecode = (data: any, bytecode: string) => {
+      const dataV3 = normalizeValidationData(data)
+      for (const validation of dataV3.log) {
+        const linkableContracts = Object.keys(validation).filter(
+          (name) => validation[name].linkReferences.length > 0
+        )
+        for (const name of linkableContracts) {
+          try {
+            const unlinkedBytecode = unlinkBytecode(
+              bytecode,
+              validation[name].linkReferences
+            )
+            const version = getVersion(unlinkedBytecode)
+            if (
+              validation[name].version?.withMetadata === version.withMetadata
+            ) {
+              return unlinkedBytecode
+            }
+          } catch {
+            // A foreign contract's link references mangled this bytecode;
+            // it cannot be the contract being deployed — skip the candidate.
+          }
+        }
+      }
+      return bytecode
+    }
+  }
+
+  patch(require("@openzeppelin/upgrades-core/dist/validate/query"))
+  const upgradesCore = require("@openzeppelin/upgrades-core")
+  const queryModule = require("@openzeppelin/upgrades-core/dist/validate/query")
+  if (upgradesCore.getUnlinkedBytecode !== queryModule.getUnlinkedBytecode) {
+    patch(upgradesCore)
+  }
+}
+/* eslint-enable @typescript-eslint/no-var-requires, global-require */
+
 const ecdsaSolidityCompilerConfig = {
   version: "0.8.17",
   settings: {

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -4268,17 +4268,19 @@ describe("Bridge - Deposit", () => {
         await restoreSnapshot()
       })
 
-      it("should succeed", async () => {
-        await expect(
-          bridge
-            .connect(spvMaintainer)
-            .submitDepositSweepProof(
-              data.sweepTx,
-              data.sweepProof,
-              data.mainUtxo,
-              ethers.constants.AddressZero
-            )
-        ).not.to.be.reverted
+      it("should succeed and rearm a completed moving-funds timeout", async () => {
+        await bridge
+          .connect(spvMaintainer)
+          .submitDepositSweepProof(
+            data.sweepTx,
+            data.sweepProof,
+            data.mainUtxo,
+            ethers.constants.AddressZero
+          )
+
+        const wallet = await bridge.wallets(reveal.walletPubKeyHash)
+        expect(wallet.state).to.equal(walletState.MovingFunds)
+        expect(wallet.movingFundsRequestedAt).to.equal(await lastBlockTime())
       })
     })
 

--- a/solidity/test/bridge/Bridge.MovingFunds.test.ts
+++ b/solidity/test/bridge/Bridge.MovingFunds.test.ts
@@ -99,7 +99,7 @@ describe("Bridge - Moving funds", () => {
       mainUtxoHash: ethers.constants.HashZero,
       pendingRedemptionsValue: 0,
       createdAt: 0,
-      movingFundsRequestedAt: 0,
+      movingFundsRequestedAt: 1,
       closingStartedAt: 0,
       pendingMovedFundsSweepRequestsCount: 0,
       state: walletState.Unknown,
@@ -118,6 +118,33 @@ describe("Bridge - Moving funds", () => {
 
       after(async () => {
         await restoreSnapshot()
+      })
+
+      context("when the current moving-funds generation is completed", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await bridge.setWallet(ecdsaWalletTestData.pubKeyHash160, {
+            ...(await bridge.wallets(ecdsaWalletTestData.pubKeyHash160)),
+            movingFundsRequestedAt: 0,
+          })
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should reject a second commitment", async () => {
+          await expect(
+            bridge.submitMovingFundsCommitment(
+              ecdsaWalletTestData.pubKeyHash160,
+              NO_MAIN_UTXO,
+              [],
+              0,
+              []
+            )
+          ).to.be.revertedWith("Moving funds process already completed")
+        })
       })
 
       context("when source wallet has no pending redemptions", () => {
@@ -732,7 +759,7 @@ describe("Bridge - Moving funds", () => {
       mainUtxoHash: ethers.constants.HashZero,
       pendingRedemptionsValue: 0,
       createdAt: 0,
-      movingFundsRequestedAt: 0,
+      movingFundsRequestedAt: 1,
       closingStartedAt: 0,
       pendingMovedFundsSweepRequestsCount: 0,
       state: walletState.Unknown,
@@ -751,6 +778,27 @@ describe("Bridge - Moving funds", () => {
 
       after(async () => {
         await restoreSnapshot()
+      })
+
+      context("when the current moving-funds generation is completed", () => {
+        before(async () => {
+          await createSnapshot()
+
+          await bridge.setWallet(ecdsaWalletTestData.pubKeyHash160, {
+            ...(await bridge.wallets(ecdsaWalletTestData.pubKeyHash160)),
+            movingFundsRequestedAt: 0,
+          })
+        })
+
+        after(async () => {
+          await restoreSnapshot()
+        })
+
+        it("should reject a timeout reset", async () => {
+          await expect(
+            bridge.resetMovingFundsTimeout(ecdsaWalletTestData.pubKeyHash160)
+          ).to.be.revertedWith("Moving funds process already completed")
+        })
       })
 
       context("when the wallet's commitment is not submitted yet", () => {
@@ -2114,6 +2162,116 @@ describe("Bridge - Moving funds", () => {
     })
   })
 
+  describe("late moving-funds proof target lifecycle", () => {
+    const data: MovingFundsTestData = SingleTargetWallet
+    const targetWalletPubKeyHash = data.targetWalletsCommitment[0]
+    const targetWalletID = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+    const sweepRequest = data.expectedMovedFundsSweepRequests[0]
+    const sweepRequestKey = ethers.utils.solidityKeccak256(
+      ["bytes32", "uint32"],
+      [sweepRequest.txHash, sweepRequest.txOutputIndex]
+    )
+
+    async function proveAfterTargetTransition(state: number) {
+      await runMovingFundsScenario(data, async () => {
+        await bridge.setWallet(targetWalletPubKeyHash, {
+          ecdsaWalletID: targetWalletID,
+          mainUtxoHash: ethers.constants.HashZero,
+          pendingRedemptionsValue: 0,
+          createdAt: 0,
+          movingFundsRequestedAt: 0,
+          closingStartedAt: 0,
+          pendingMovedFundsSweepRequestsCount: 0,
+          state,
+          movingFundsTargetWalletsCommitmentHash: ethers.constants.HashZero,
+        })
+      })
+    }
+
+    beforeEach(async () => {
+      await createSnapshot()
+      walletRegistry.closeWallet.reset()
+      walletRegistry.seize.reset()
+    })
+
+    afterEach(async () => {
+      walletRegistry.closeWallet.reset()
+      walletRegistry.seize.reset()
+      await restoreSnapshot()
+    })
+
+    it("holds a Closing target open until its late request can time out", async () => {
+      await proveAfterTargetTransition(walletState.Closing)
+
+      expect(
+        (await bridge.wallets(targetWalletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(1)
+      await expect(
+        bridge.notifyWalletClosingPeriodElapsed(targetWalletPubKeyHash)
+      ).to.be.revertedWith("Wallet has pending moved funds sweep requests")
+
+      await increaseTime(movedFundsSweepTimeout + 1)
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .notifyMovedFundsSweepTimeout(
+            sweepRequest.txHash,
+            sweepRequest.txOutputIndex,
+            []
+          )
+      )
+        .to.emit(bridge, "MovedFundsSweepTimedOut")
+        .withArgs(
+          targetWalletPubKeyHash,
+          sweepRequest.txHash,
+          sweepRequest.txOutputIndex
+        )
+
+      expect(
+        (await bridge.movedFundsSweepRequests(sweepRequestKey)).state
+      ).to.equal(movedFundsSweepRequestState.TimedOut)
+      const targetWallet = await bridge.wallets(targetWalletPubKeyHash)
+      expect(targetWallet.pendingMovedFundsSweepRequestsCount).to.equal(0)
+      expect(targetWallet.state).to.equal(walletState.Closing)
+      expect(walletRegistry.seize).not.to.have.been.called
+      expect(walletRegistry.closeWallet).not.to.have.been.called
+
+      await expect(
+        bridge.notifyWalletClosingPeriodElapsed(targetWalletPubKeyHash)
+      )
+        .to.emit(bridge, "WalletClosed")
+        .withArgs(targetWalletID, targetWalletPubKeyHash)
+    })
+
+    it("resolves without slashing when the target closed before the late proof", async () => {
+      await proveAfterTargetTransition(walletState.Closed)
+
+      expect(
+        (await bridge.wallets(targetWalletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(1)
+
+      await increaseTime(movedFundsSweepTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyMovedFundsSweepTimeout(
+          sweepRequest.txHash,
+          sweepRequest.txOutputIndex,
+          []
+        )
+
+      expect(
+        (await bridge.movedFundsSweepRequests(sweepRequestKey)).state
+      ).to.equal(movedFundsSweepRequestState.TimedOut)
+      const targetWallet = await bridge.wallets(targetWalletPubKeyHash)
+      expect(targetWallet.pendingMovedFundsSweepRequestsCount).to.equal(0)
+      expect(targetWallet.state).to.equal(walletState.Closed)
+      expect(walletRegistry.seize).not.to.have.been.called
+      expect(walletRegistry.closeWallet).not.to.have.been.called
+    })
+  })
+
   describe("notifyMovingFundsTimeout", () => {
     const walletDraft = {
       ecdsaWalletID: ecdsaWalletTestData.walletID,
@@ -2519,7 +2677,7 @@ describe("Bridge - Moving funds", () => {
         context("when the single output is 20-byte", () => {
           context("when single output is either P2PKH or P2WPKH", () => {
             context(
-              "when sweeping wallet is either in the Live or MovingFunds state",
+              "when sweeping wallet is in the Live, MovingFunds, or Closing state",
               () => {
                 context("when sweeping wallet is in the Live state", () => {
                   context("when main UTXO data are valid", () => {
@@ -3237,71 +3395,120 @@ describe("Bridge - Moving funds", () => {
                       await restoreSnapshot()
                     })
 
-                    it("should succeed", async () => {
-                      // The assertions were already performed for Live wallet
-                      // scenarios. Here we just make sure the transaction
-                      // succeeds for a MovingFunds wallet.
+                    it("should succeed and rearm a completed moving-funds timeout", async () => {
                       await expect(tx).to.not.be.reverted
+
+                      const wallet = await bridge.wallets(
+                        data.wallet.pubKeyHash
+                      )
+                      expect(wallet.state).to.equal(walletState.MovingFunds)
+                      expect(wallet.movingFundsRequestedAt).to.equal(
+                        await lastBlockTime()
+                      )
                     })
                   }
                 )
-              }
-            )
 
-            context(
-              "when sweeping wallet is neither in the Live nor MovingFunds state",
-              () => {
-                const testData = [
-                  {
-                    testName: "when sweeping wallet is in the Unknown state",
-                    walletState: walletState.Unknown,
-                  },
-                  {
-                    testName: "when sweeping wallet is in the Closing state",
-                    walletState: walletState.Closing,
-                  },
-                  {
-                    testName: "when sweeping wallet is in the Closed state",
-                    walletState: walletState.Closed,
-                  },
-                  {
-                    testName: "when sweeping wallet is in the Terminated state",
-                    walletState: walletState.Terminated,
-                  },
-                ]
+                context("when sweeping wallet is in the Closing state", () => {
+                  const data: MovedFundsSweepTestData =
+                    MovedFundsSweepWithoutMainUtxo
 
-                testData.forEach((test) => {
-                  context(test.testName, () => {
-                    const data: MovedFundsSweepTestData =
-                      MovedFundsSweepWithoutMainUtxo
+                  let tx: Promise<ContractTransaction>
 
-                    let tx: Promise<ContractTransaction>
+                  before(async () => {
+                    await createSnapshot()
 
-                    before(async () => {
-                      await createSnapshot()
-
-                      tx = runMovedFundsSweepScenario({
+                    tx = runMovedFundsSweepScenario(
+                      {
                         ...data,
                         wallet: {
                           ...data.wallet,
-                          state: test.walletState,
+                          state: walletState.Closing,
                         },
-                      })
-                    })
+                      },
+                      async () => {
+                        await bridge.setWallet(data.wallet.pubKeyHash, {
+                          ...(await bridge.wallets(data.wallet.pubKeyHash)),
+                          movingFundsTargetWalletsCommitmentHash:
+                            ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+                        })
+                      }
+                    )
+                  })
 
-                    after(async () => {
-                      await restoreSnapshot()
-                    })
+                  after(async () => {
+                    await restoreSnapshot()
+                  })
 
-                    it("should revert", async () => {
-                      await expect(tx).to.be.revertedWith(
-                        "Wallet must be in Live or MovingFunds state"
+                  it("should reactivate the wallet and start a fresh moving-funds timeout", async () => {
+                    await expect(tx)
+                      .to.emit(bridge, "WalletMovingFunds")
+                      .withArgs(
+                        data.wallet.ecdsaWalletID,
+                        data.wallet.pubKeyHash
                       )
-                    })
+
+                    const wallet = await bridge.wallets(data.wallet.pubKeyHash)
+                    expect(wallet.state).to.equal(walletState.MovingFunds)
+                    expect(wallet.movingFundsRequestedAt).to.equal(
+                      await lastBlockTime()
+                    )
+                    expect(wallet.closingStartedAt).to.equal(0)
+                    expect(
+                      wallet.movingFundsTargetWalletsCommitmentHash
+                    ).to.equal(ethers.constants.HashZero)
                   })
                 })
               }
             )
+
+            context("when sweeping wallet is not in a sweepable state", () => {
+              const testData = [
+                {
+                  testName: "when sweeping wallet is in the Unknown state",
+                  walletState: walletState.Unknown,
+                },
+                {
+                  testName: "when sweeping wallet is in the Closed state",
+                  walletState: walletState.Closed,
+                },
+                {
+                  testName: "when sweeping wallet is in the Terminated state",
+                  walletState: walletState.Terminated,
+                },
+              ]
+
+              testData.forEach((test) => {
+                context(test.testName, () => {
+                  const data: MovedFundsSweepTestData =
+                    MovedFundsSweepWithoutMainUtxo
+
+                  let tx: Promise<ContractTransaction>
+
+                  before(async () => {
+                    await createSnapshot()
+
+                    tx = runMovedFundsSweepScenario({
+                      ...data,
+                      wallet: {
+                        ...data.wallet,
+                        state: test.walletState,
+                      },
+                    })
+                  })
+
+                  after(async () => {
+                    await restoreSnapshot()
+                  })
+
+                  it("should revert", async () => {
+                    await expect(tx).to.be.revertedWith(
+                      "Wallet must be in Live or MovingFunds or Closing state"
+                    )
+                  })
+                })
+              })
+            })
           })
 
           context("when single output is neither P2PKH nor P2WPKH", () => {
@@ -3993,59 +4200,48 @@ describe("Bridge - Moving funds", () => {
           })
         })
 
-        context(
-          "when the wallet is neither in the Live nor MovingFunds nor Terminated state",
-          () => {
-            const testData = [
-              {
-                testName: "when the wallet is in the Unknown state",
-                walletState: walletState.Unknown,
-              },
-              {
-                testName: "when the wallet is in the Closing state",
-                walletState: walletState.Closing,
-              },
-              {
-                testName: "when the wallet is in the Closed state",
-                walletState: walletState.Closed,
-              },
-            ]
+        context("when the wallet is not in a resolvable state", () => {
+          const testData = [
+            {
+              testName: "when the wallet is in the Unknown state",
+              walletState: walletState.Unknown,
+            },
+          ]
 
-            testData.forEach((test) => {
-              context(test.testName, async () => {
-                before(async () => {
-                  await createSnapshot()
+          testData.forEach((test) => {
+            context(test.testName, async () => {
+              before(async () => {
+                await createSnapshot()
 
-                  await bridge.setWallet(
-                    movedFundsSweepRequest.walletPubKeyHash,
-                    {
-                      ...(await bridge.wallets(
-                        movedFundsSweepRequest.walletPubKeyHash
-                      )),
-                      state: test.walletState,
-                    }
+                await bridge.setWallet(
+                  movedFundsSweepRequest.walletPubKeyHash,
+                  {
+                    ...(await bridge.wallets(
+                      movedFundsSweepRequest.walletPubKeyHash
+                    )),
+                    state: test.walletState,
+                  }
+                )
+              })
+
+              after(async () => {
+                await restoreSnapshot()
+              })
+
+              it("should revert", async () => {
+                await expect(
+                  bridge.notifyMovedFundsSweepTimeout(
+                    movedFundsSweepRequest.txHash,
+                    movedFundsSweepRequest.txOutputIndex,
+                    walletMembersIDs
                   )
-                })
-
-                after(async () => {
-                  await restoreSnapshot()
-                })
-
-                it("should revert", async () => {
-                  await expect(
-                    bridge.notifyMovedFundsSweepTimeout(
-                      movedFundsSweepRequest.txHash,
-                      movedFundsSweepRequest.txOutputIndex,
-                      walletMembersIDs
-                    )
-                  ).to.be.revertedWith(
-                    "Wallet must be in Live or MovingFunds or Terminated state"
-                  )
-                })
+                ).to.be.revertedWith(
+                  "Wallet must be in Live or MovingFunds or Closing or Closed or Terminated state"
+                )
               })
             })
-          }
-        )
+          })
+        })
       })
 
       context("when moved funds sweep request has not timed out yet", () => {

--- a/solidity/test/bridge/Bridge.RebateRecovery.test.ts
+++ b/solidity/test/bridge/Bridge.RebateRecovery.test.ts
@@ -46,7 +46,6 @@ describe("Bridge - Rebate staking recovery upgrade", () => {
       Wallets: (await helpers.contracts.getContract("Wallets")).address,
       Fraud: (await helpers.contracts.getContract("Fraud")).address,
       MovingFunds: (await helpers.contracts.getContract("MovingFunds")).address,
-      Reservation: (await helpers.contracts.getContract("Reservation")).address,
     }
 
     const bridgeFactory = await ethers.getContractFactory("BridgeStub", {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -2133,6 +2133,85 @@ describe("Bridge - Reservation", () => {
       expect(reservation.state).to.equal(ReservationState.Active)
     })
 
+    it("rejects a terminated re-anchor target at signing but still settles an already-built transaction", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const validator = await helpers.contracts.getContract(
+        "WalletProposalValidator"
+      )
+      const proposal = {
+        sourceWalletPubKeyHash: walletPubKeyHash,
+        reservationKey,
+        requestNonce: 2,
+        targetWalletPubKeyHash: secondWalletPubKeyHash,
+        reanchorTxFee: 1000,
+      }
+
+      // A transaction authorized while the target is Live may already have
+      // been signed and broadcast before the target's registry state changes.
+      expect(await validator.validateReservationReanchorProposal(proposal)).to
+        .be.true
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(proposal.reanchorTxFee),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await bridge.setWallet(secondWalletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      // The wallet must not sign a fresh transaction to a target that is no
+      // longer Live.
+      await expect(
+        validator.validateReservationReanchorProposal(proposal)
+      ).to.be.revertedWith("Target wallet must be in Live state")
+
+      // Proof settlement deliberately remains state-independent: rejecting a
+      // transaction that was already broadcast would drop its BTC from the
+      // reservation accounting.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationReanchored")
+        .withArgs(
+          reservationKey,
+          2,
+          secondWalletPubKeyHash,
+          reanchorTx.txHash,
+          anchorAmount.sub(proposal.reanchorTxFee)
+        )
+      expect(
+        (await bridge.reservations(reservationKey)).walletPubKeyHash
+      ).to.equal(secondWalletPubKeyHash)
+    })
+
     it("rejects a re-anchor paying a wallet other than the authorized target", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
 

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1010,7 +1010,7 @@ describe("Bridge - Reservation", () => {
     })
 
     it("stages the parameters and applies them after the governance delay", async () => {
-      await bridgeGovernance
+      const beginTx = await bridgeGovernance
         .connect(governance)
         .beginReservationParametersUpdate(
           reservationVault.address,
@@ -1021,6 +1021,24 @@ describe("Bridge - Reservation", () => {
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
           RESERVATION_ACTION_TIMEOUT
+        )
+      const beginReceipt = await beginTx.wait()
+      const beginTimestamp = (
+        await ethers.provider.getBlock(beginReceipt.blockNumber)
+      ).timestamp
+
+      await expect(beginTx)
+        .to.emit(bridgeGovernance, "ReservationParametersUpdateStarted")
+        .withArgs(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT,
+          beginTimestamp
         )
 
       await expect(
@@ -1673,6 +1691,102 @@ describe("Bridge - Reservation", () => {
       ).to.be.revertedWith("Action type mismatch")
     })
 
+    it("uses the exact reveal-time refund deadline after parameter updates", async () => {
+      const revealAhead = 3 * 24 * 60 * 60
+      const refundDeadline = (await lastBlockTime()) + 5 * 24 * 60 * 60
+      const exactRefundLocktime = `0x${toLE(refundDeadline, 4)}`
+      await bridge.setDepositRevealAheadPeriod(revealAhead)
+
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                exactRefundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime: exactRefundLocktime,
+        vault: reservationVault.address,
+      })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      await liveWallet(secondWalletPubKeyHash)
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Wallet is not the deposit's designated wallet")
+
+      // Raising the live reveal-ahead period must not manufacture a later
+      // deadline for this already-revealed deposit. A six-day authorization
+      // overlaps its exact five-day Bitcoin refund locktime.
+      await bridge.setDepositRevealAheadPeriod(30 * 24 * 60 * 60)
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          6 * 24 * 60 * 60
+        )
+
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith(
+        "Authorization window would overlap the deposit refund window"
+      )
+
+      // A window that still fits the immutable Bitcoin deadline remains
+      // valid even though the live ahead period is now much larger.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          4 * 24 * 60 * 60
+        )
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.emit(bridge, "ReservationAcceptanceRequested")
+    })
+
     it("accepts a proven anchor and credits the gross amount", async () => {
       const { anchorTx, acceptTx, reservationKey } =
         await makeAcceptedReservation()
@@ -2049,6 +2163,36 @@ describe("Bridge - Reservation", () => {
             2
           )
       ).to.be.revertedWith("Output must pay the authorized target wallet")
+    })
+
+    it("rejects permissionless re-anchors once dissolution is due", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: await lastBlockTime(),
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.MovingFunds,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Reservation past grace period")
+
+      // The terminal cleanup path is available instead of another
+      // non-slashing re-anchor generation.
+      await expect(
+        bridge.connect(thirdParty).requestReservationDissolution(reservationKey)
+      ).to.emit(bridge, "ReservationDissolutionRequested")
     })
 
     it("dissolves an expired reservation into the wallet main UTXO", async () => {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -3099,6 +3099,39 @@ describe("Bridge - Reservation", () => {
       expect(reservation.state).to.equal(ReservationState.Active)
     })
 
+    it("rejects a re-anchor target equal to the source wallet", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      await expect(
+        bridge
+          .connect(bridgeGovernanceSigner)
+          .requestReservationReanchor(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Target wallet must differ from the source wallet")
+    })
+
+    it("rejects a re-anchor target that is not in Live state", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      // secondWalletPubKeyHash is registered but never brought to Live.
+      await bridge.setWallet(secondWalletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.MovingFunds,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      await expect(
+        bridge
+          .connect(bridgeGovernanceSigner)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Target wallet must be in Live state")
+    })
+
     it("rejects a terminated re-anchor target at signing but still settles an already-built transaction", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
       await liveWallet(secondWalletPubKeyHash)

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1787,7 +1787,7 @@ describe("Bridge - Reservation", () => {
     const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
     const blindingFactor = "0xf9f0c90d00039523"
     const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
-    const refundLocktime = "0x60bcea61"
+    let refundLocktime: string
     const NO_MAIN_UTXO_PARAM = {
       txHash: ZERO_BYTES32,
       txOutputIndex: 0,
@@ -1818,6 +1818,84 @@ describe("Bridge - Reservation", () => {
         state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
+    }
+
+    async function revealReservedDeposit(refundDeadline: number) {
+      const exactRefundLocktime = `0x${toLE(refundDeadline, 4)}`
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                exactRefundLocktime
+              )
+            ),
+          },
+        ]
+      )
+
+      const revealTx = await bridge
+        .connect(thirdParty)
+        .revealDeposit(fundingTx.info, {
+          fundingOutputIndex: 0,
+          blindingFactor,
+          walletPubKeyHash,
+          refundPubKeyHash,
+          refundLocktime: exactRefundLocktime,
+          vault: reservationVault.address,
+        })
+      const revealReceipt = await revealTx.wait()
+      const revealBlock = await ethers.provider.getBlock(
+        revealReceipt.blockNumber
+      )
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      return {
+        depositKey: {
+          fundingTxHash: fundingTx.txHash,
+          fundingOutputIndex: 0,
+        },
+        depositExtraInfo: {
+          fundingTx: fundingTx.info,
+          blindingFactor,
+          walletPubKeyHash,
+          refundPubKeyHash,
+          refundLocktime: exactRefundLocktime,
+        },
+        reservationKey,
+        revealedAt: revealBlock.timestamp,
+      }
+    }
+
+    async function setReservationActionTimeout(actionTimeout: number) {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          actionTimeout
+        )
     }
 
     // Reveals a fresh reserved deposit, requests its acceptance and proves
@@ -1893,6 +1971,11 @@ describe("Bridge - Reservation", () => {
     before(async () => {
       await createSnapshot()
       await wireReservations()
+
+      refundLocktime = `0x${toLE(
+        (await lastBlockTime()) + 4000 * 24 * 60 * 60,
+        4
+      )}`
 
       relay.getCurrentEpochDifficulty.returns(0)
       relay.getPrevEpochDifficulty.returns(0)
@@ -1972,6 +2055,158 @@ describe("Bridge - Reservation", () => {
             1
           )
       ).to.be.revertedWith("Action type mismatch")
+    })
+
+    it("rejects repeat acceptance requests when deposit age and action margins leave no signing window", async () => {
+      const actionTimeout = 3 * 60 * 60
+      await setReservationActionTimeout(actionTimeout)
+      await bridge.setDepositRevealAheadPeriod(24 * 60 * 60)
+
+      const { reservationKey } = await revealReservedDeposit(
+        (await lastBlockTime()) + 30 * 24 * 60 * 60
+      )
+
+      for (let i = 0; i < 2; i++) {
+        await expect(
+          bridge
+            .connect(thirdParty)
+            .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+        ).to.be.revertedWith("Acceptance authorization has no signing window")
+      }
+
+      expect(
+        (await bridge.reservationParameters()).reservationTotalAmount
+      ).to.equal(0)
+      expect(
+        await bridge.getWalletReservationsCount(walletPubKeyHash)
+      ).to.equal(0)
+      expect((await bridge.reservations(reservationKey)).requestNonce).to.equal(
+        0
+      )
+    })
+
+    it("accepts the first exact deposit-age/action-margin boundary with an integer signing timestamp", async () => {
+      const actionTimeout = 3 * 60 * 60
+      const depositMinAge = 2 * 60 * 60
+      const actionSafetyMargin = 2 * 60 * 60
+      await setReservationActionTimeout(actionTimeout)
+      await bridge.setDepositRevealAheadPeriod(24 * 60 * 60)
+      const ValidatorFactory = await ethers.getContractFactory(
+        "WalletProposalValidator"
+      )
+      const acceptanceValidator = await ValidatorFactory.deploy(bridge.address)
+
+      const { depositKey, depositExtraInfo, reservationKey, revealedAt } =
+        await revealReservedDeposit((await lastBlockTime()) + 30 * 24 * 60 * 60)
+      const earliestSigningAt = revealedAt + depositMinAge + 1
+      const requestAtEmptyBoundary =
+        earliestSigningAt - (actionTimeout - actionSafetyMargin)
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        requestAtEmptyBoundary,
+      ])
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Acceptance authorization has no signing window")
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        requestAtEmptyBoundary + 1,
+      ])
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.emit(bridge, "ReservationAcceptanceRequested")
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        earliestSigningAt,
+      ])
+      await ethers.provider.send("evm_mine", [])
+      expect(
+        await acceptanceValidator.validateReservationAnchorProposal(
+          {
+            walletPubKeyHash,
+            depositKey,
+            requestNonce: 1,
+            anchorTxFee: anchorFee,
+          },
+          depositExtraInfo
+        )
+      ).to.be.true
+    })
+
+    it("uses the exact refund-safety boundary when reveal-ahead validation is disabled", async () => {
+      const actionTimeout = 3 * 60 * 60
+      const depositMinAge = 2 * 60 * 60
+      const actionSafetyMargin = 2 * 60 * 60
+      const refundSafetyMargin = 24 * 60 * 60
+      await setReservationActionTimeout(actionTimeout)
+      await bridge.setDepositRevealAheadPeriod(0)
+      const ValidatorFactory = await ethers.getContractFactory(
+        "WalletProposalValidator"
+      )
+      const acceptanceValidator = await ValidatorFactory.deploy(bridge.address)
+
+      const firstRevealAt = (await lastBlockTime()) + 10
+      await ethers.provider.send("evm_setNextBlockTimestamp", [firstRevealAt])
+      const emptyRefundDeadline =
+        firstRevealAt + refundSafetyMargin + depositMinAge + 1
+      const firstDeposit = await revealReservedDeposit(emptyRefundDeadline)
+      expect(firstDeposit.revealedAt).to.equal(firstRevealAt)
+
+      const firstRequestAt =
+        firstRevealAt +
+        depositMinAge +
+        1 -
+        (actionTimeout - actionSafetyMargin) +
+        1
+      await ethers.provider.send("evm_setNextBlockTimestamp", [firstRequestAt])
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            firstDeposit.reservationKey,
+            walletPubKeyHash
+          )
+      ).to.be.revertedWith("Acceptance authorization has no signing window")
+
+      const secondRevealAt = (await lastBlockTime()) + 10
+      await ethers.provider.send("evm_setNextBlockTimestamp", [secondRevealAt])
+      const oneSecondRefundDeadline =
+        secondRevealAt + refundSafetyMargin + depositMinAge + 2
+      const secondDeposit = await revealReservedDeposit(oneSecondRefundDeadline)
+      expect(secondDeposit.revealedAt).to.equal(secondRevealAt)
+
+      const earliestSigningAt = secondRevealAt + depositMinAge + 1
+      const secondRequestAt =
+        earliestSigningAt - (actionTimeout - actionSafetyMargin) + 1
+      await ethers.provider.send("evm_setNextBlockTimestamp", [secondRequestAt])
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            secondDeposit.reservationKey,
+            walletPubKeyHash
+          )
+      ).to.emit(bridge, "ReservationAcceptanceRequested")
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        earliestSigningAt,
+      ])
+      await ethers.provider.send("evm_mine", [])
+      expect(
+        await acceptanceValidator.validateReservationAnchorProposal(
+          {
+            walletPubKeyHash,
+            depositKey: secondDeposit.depositKey,
+            requestNonce: 1,
+            anchorTxFee: anchorFee,
+          },
+          secondDeposit.depositExtraInfo
+        )
+      ).to.be.true
     })
 
     it("uses the exact reveal-time refund deadline after parameter updates", async () => {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -389,7 +389,7 @@ describe("Bridge - Reservation", () => {
         )
       })
 
-      it("should revert for a zero action timeout", async () => {
+      it("should reject an action timeout equal to the safety margin", async () => {
         await expect(
           bridge
             .connect(bridgeGovernanceSigner)
@@ -401,11 +401,28 @@ describe("Bridge - Reservation", () => {
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
               MAX_RESERVATIONS_PER_WALLET,
-              0
+              2 * 60 * 60
             )
         ).to.be.revertedWith(
-          "Reservation action timeout must be greater than zero"
+          "Reservation action timeout must exceed the safety margin"
         )
+      })
+
+      it("should accept an action timeout one second above the safety margin", async () => {
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET,
+              2 * 60 * 60 + 1
+            )
+        ).to.emit(bridge, "ReservationParametersUpdated")
       })
 
       it("should revert when changing the vault with active reservations", async () => {
@@ -2237,13 +2254,16 @@ describe("Bridge - Reservation", () => {
         (await lastBlockTime()) + 30 * 24 * 60 * 60
       )
 
-      for (let i = 0; i < 2; i++) {
-        await expect(
-          bridge
-            .connect(thirdParty)
-            .requestReservationAcceptance(reservationKey, walletPubKeyHash)
-        ).to.be.revertedWith("Acceptance authorization has no signing window")
-      }
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Acceptance authorization has no signing window")
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Acceptance authorization has no signing window")
 
       expect(
         (await bridge.reservationParameters()).reservationTotalAmount
@@ -2583,6 +2603,14 @@ describe("Bridge - Reservation", () => {
           [fundingTx.txHash, 0]
         )
       )
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Deposit was not revealed as reserved")
+
+      // Build an otherwise settleable generation to exercise the proof-side
+      // classification defense independently of the request-side guard.
       await bridge.setPendingReservationAcceptanceAction(reservationKey, 1)
 
       const anchorTx = buildTx(

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -12,6 +12,7 @@ import type {
   BridgeGovernance,
   BridgeStub,
   IRelay,
+  ReservationRouter,
   ReservationVault,
   TBTCVault,
   TBTC,
@@ -35,8 +36,37 @@ const RESERVATION_MIN_AMOUNT = 10000
 const RESERVATION_TX_MAX_FEE = 2000
 const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
 const MAX_RESERVATIONS_PER_WALLET = 10
+const RESERVATION_ACTION_TIMEOUT = 172800 // 48 hours
 
 const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
+
+// Reservation.ReservationState
+const ReservationState = {
+  Unknown: 0,
+  Active: 1,
+  ActionPending: 2,
+  Closed: 3,
+  Stranded: 4,
+}
+
+// Reservation.ActionType
+const ActionType = {
+  None: 0,
+  Acceptance: 1,
+  Redemption: 2,
+  Reanchor: 3,
+  Dissolution: 4,
+}
+
+// Reservation.ActionState
+const ActionState = {
+  Unknown: 0,
+  Pending: 1,
+  Settled: 2,
+  TimedOut: 3,
+  Vetoed: 4,
+  Superseded: 5,
+}
 
 describe("Bridge - Reservation", () => {
   let governance: SignerWithAddress
@@ -47,7 +77,7 @@ describe("Bridge - Reservation", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
-  let bridge: Bridge & BridgeStub
+  let bridge: Bridge & BridgeStub & ReservationRouter
   let tbtc: TBTC & Contract
   let tbtcVault: TBTCVault & Contract
   let bridgeGovernance: BridgeGovernance
@@ -109,12 +139,13 @@ describe("Bridge - Reservation", () => {
         RESERVATION_TERM,
         RESERVATION_GRACE,
         RESERVATION_MAX_TOTAL,
-        MAX_RESERVATIONS_PER_WALLET
+        MAX_RESERVATIONS_PER_WALLET,
+        RESERVATION_ACTION_TIMEOUT
       )
   }
 
-  // Builds an active reservation record owned by `owner`, custodied by the
-  // wallet identified by `walletPubKeyHash`.
+  // Builds an active reservation position owned by `owner`, custodied by
+  // the wallet identified by `walletPubKeyHash`.
   async function activeReservation(
     owner: string,
     walletPubKeyHash: string,
@@ -129,12 +160,38 @@ describe("Bridge - Reservation", () => {
       expiresAt: (await lastBlockTime()) + RESERVATION_TERM,
       anchorTxHash: ethers.utils.randomBytes(32),
       anchorTxOutputIndex: 0,
-      state: 1, // Active
-      redemptionRequestedAt: 0,
-      redemptionTxMaxFee: 0,
-      redeemer: ZERO_ADDRESS,
-      redeemerOutputScriptHash: ZERO_BYTES32,
+      state: ReservationState.Active,
+      requestNonce: 0,
+      retryCredit: false,
+      termSeconds: RESERVATION_TERM,
+      gracePeriod: RESERVATION_GRACE,
     }
+  }
+
+  // Requests a reserved redemption through the impersonated vault, funding
+  // and approving the gross Bank balance surrender.
+  async function requestRedemptionViaVault(
+    reservationKey: BigNumber | number,
+    amountSat: BigNumber,
+    redeemer: string,
+    redeemerOutputScript: string,
+    options: { feePaid?: boolean; useRetryCredit?: boolean } = {}
+  ) {
+    const bridgeSigner = await impersonateContract(bridge.address)
+    await bank
+      .connect(bridgeSigner)
+      .increaseBalance(reservationVault.address, amountSat)
+    const vaultSigner = await impersonateContract(reservationVault.address)
+    await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+    return bridge
+      .connect(vaultSigner)
+      .requestReservedRedemption(
+        reservationKey,
+        redeemer,
+        redeemerOutputScript,
+        options.feePaid ?? true,
+        options.useRetryCredit ?? false
+      )
   }
 
   // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
@@ -275,7 +332,8 @@ describe("Bridge - Reservation", () => {
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              RESERVATION_ACTION_TIMEOUT
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -292,7 +350,8 @@ describe("Bridge - Reservation", () => {
             RESERVATION_TERM,
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET
+            MAX_RESERVATIONS_PER_WALLET,
+            RESERVATION_ACTION_TIMEOUT
           )
 
         await expect(tx)
@@ -306,7 +365,8 @@ describe("Bridge - Reservation", () => {
             RESERVATION_TERM,
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET
+            MAX_RESERVATIONS_PER_WALLET,
+            RESERVATION_ACTION_TIMEOUT
           )
       })
 
@@ -321,10 +381,30 @@ describe("Bridge - Reservation", () => {
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              RESERVATION_ACTION_TIMEOUT
             )
         ).to.be.revertedWith(
           "Reservation transaction max fee must be greater than zero"
+        )
+      })
+
+      it("should revert for a zero action timeout", async () => {
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET,
+              0
+            )
+        ).to.be.revertedWith(
+          "Reservation action timeout must be greater than zero"
         )
       })
 
@@ -349,7 +429,8 @@ describe("Bridge - Reservation", () => {
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              RESERVATION_ACTION_TIMEOUT
             )
         ).to.be.revertedWith("Active reservations exist")
       })
@@ -443,8 +524,23 @@ describe("Bridge - Reservation", () => {
     })
 
     context("when called by the reservation vault", () => {
-      it("should extend the reservation term", async () => {
+      it("should extend the reservation term by the snapshotted length", async () => {
         const before_ = await bridge.reservations(reservationKey)
+
+        // Change the live term parameter: the extension must use the
+        // position's snapshot, not the live value.
+        await bridge
+          .connect(bridgeGovernanceSigner)
+          .updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_TERM * 2,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            RESERVATION_ACTION_TIMEOUT
+          )
 
         const vaultSigner = await impersonateContract(reservationVault.address)
         const tx = await bridge
@@ -472,8 +568,6 @@ describe("Bridge - Reservation", () => {
       await createSnapshot()
       await wireReservations()
 
-      // A Terminated wallet lets the timeout path skip slashing and state
-      // transitions, isolating the reservation bookkeeping under test.
       await bridge.setWallet(walletPubKeyHash, {
         ecdsaWalletID: ethers.utils.randomBytes(32),
         mainUtxoHash: ZERO_BYTES32,
@@ -482,21 +576,17 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
+      // The redemption timeout path slashes the wallet and moves it toward
+      // retirement, decrementing the live wallets counter.
+      await bridge.setLiveWalletsCount(1)
 
       await bridge.setReservation(
         reservationKey,
         await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
-
-      // Give the reservation vault the gross Bank balance it must
-      // surrender with the request.
-      const bridgeSigner = await impersonateContract(bridge.address)
-      await bank
-        .connect(bridgeSigner)
-        .increaseBalance(reservationVault.address, amountSat)
     })
 
     after(async () => {
@@ -510,63 +600,91 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             reservationKey,
             thirdParty.address,
-            redeemerOutputScript
+            redeemerOutputScript,
+            true,
+            false
           )
       ).to.be.revertedWith("Caller is not the reservation vault")
     })
 
-    it("should register the redemption, take the balance, and refund on timeout", async () => {
-      const vaultSigner = await impersonateContract(reservationVault.address)
-
-      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
-
-      const tx = await bridge
-        .connect(vaultSigner)
-        .requestReservedRedemption(
-          reservationKey,
-          thirdParty.address,
-          redeemerOutputScript
-        )
+    it("should register the generation, take the balance, and refund on timeout", async () => {
+      const tx = await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
 
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionRequested")
         .withArgs(
           reservationKey,
+          1,
           thirdParty.address,
           redeemerOutputScript,
           amountSat,
-          RESERVATION_TX_MAX_FEE
+          RESERVATION_TX_MAX_FEE,
+          true
         )
 
-      expect((await bridge.reservations(reservationKey)).state).to.equal(2) // RedemptionRequested
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.ActionPending)
+      expect(reservation.requestNonce).to.equal(1)
       expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
 
+      const action = await bridge.reservationActions(reservationKey, 1)
+      expect(action.actionType).to.equal(ActionType.Redemption)
+      expect(action.state).to.equal(ActionState.Pending)
+      expect(action.redeemer).to.equal(thirdParty.address)
+      expect(action.amount).to.equal(amountSat)
+      expect(action.feePaid).to.be.true
+
       // Re-requesting while one is pending must fail.
+      const vaultSigner = await impersonateContract(reservationVault.address)
       await expect(
         bridge
           .connect(vaultSigner)
           .requestReservedRedemption(
             reservationKey,
             thirdParty.address,
-            redeemerOutputScript
+            redeemerOutputScript,
+            true,
+            false
           )
       ).to.be.revertedWith("Reservation is not active")
 
-      // Timeout: the redeemer gets the balance back and the reservation
-      // survives as Active.
+      // Timeout: the redeemer gets the balance back, the terminal record
+      // persists, the fee-paid generation mints the retry entitlement and
+      // the reservation survives as Active.
       const { redemptionTimeout } = await bridge.redemptionParameters()
       await increaseTime(redemptionTimeout + 1)
 
       const timeoutTx = await bridge
         .connect(thirdParty)
-        .notifyReservedRedemptionTimeout(reservationKey, [])
+        .notifyReservationActionTimeout(reservationKey, [])
 
       await expect(timeoutTx)
-        .to.emit(bridge, "ReservedRedemptionTimedOut")
-        .withArgs(reservationKey, walletPubKeyHash)
+        .to.emit(bridge, "ReservationActionTimedOut")
+        .withArgs(reservationKey, 1, ActionType.Redemption)
+      await expect(timeoutTx)
+        .to.emit(bridge, "ReservationRetryCreditMinted")
+        .withArgs(reservationKey)
 
       expect(await bank.balanceOf(thirdParty.address)).to.equal(amountSat)
-      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      const reservationAfter = await bridge.reservations(reservationKey)
+      expect(reservationAfter.state).to.equal(ReservationState.Active)
+      expect(reservationAfter.retryCredit).to.be.true
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 1)).state
+      ).to.equal(ActionState.TimedOut)
+
+      // The wallet was pushed toward retirement (it holds a reservation
+      // and no main UTXO, so it enters MovingFunds rather than Closing).
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.MovingFunds
+      )
     })
   })
 
@@ -625,6 +743,17 @@ describe("Bridge - Reservation", () => {
         "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
 
       before(async () => {
+        await bridge.setWallet(walletPubKeyHash, {
+          ecdsaWalletID: ethers.utils.randomBytes(32),
+          mainUtxoHash: ZERO_BYTES32,
+          pendingRedemptionsValue: 0,
+          createdAt: await lastBlockTime(),
+          movingFundsRequestedAt: 0,
+          closingStartedAt: 0,
+          pendingMovedFundsSweepRequestsCount: 0,
+          state: walletState.Live,
+          movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+        })
         await bridge.setReservation(
           reservationKey,
           await activeReservation(
@@ -674,7 +803,11 @@ describe("Bridge - Reservation", () => {
         expect(await tbtc.balanceOf(treasury.address)).to.equal(
           treasuryBalanceBefore.add(fee)
         )
-        expect((await bridge.reservations(reservationKey)).state).to.equal(2)
+        expect((await bridge.reservations(reservationKey)).state).to.equal(
+          ReservationState.ActionPending
+        )
+        expect((await bridge.reservationActions(reservationKey, 1)).feePaid).to
+          .be.true
         expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
       })
     })
@@ -699,7 +832,7 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
       await bridge.setReservation(
@@ -707,22 +840,15 @@ describe("Bridge - Reservation", () => {
         await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
 
-      const bridgeSigner = await impersonateContract(bridge.address)
-      await bank
-        .connect(bridgeSigner)
-        .increaseBalance(reservationVault.address, amountSat)
-      const vaultSigner = await impersonateContract(reservationVault.address)
-      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
-      await bridge
-        .connect(vaultSigner)
-        .requestReservedRedemption(
-          reservationKey,
-          thirdParty.address,
-          redeemerOutputScript
-        )
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
 
-      // Wire the watchtower only after the request so the
-      // isSafeRedemption gate does not call an EOA.
+      // Wire the watchtower only after the request so the safety gate
+      // does not call an EOA.
       await bridge
         .connect(bridgeGovernanceSigner)
         .setRedemptionWatchtower(deployer.address)
@@ -734,21 +860,37 @@ describe("Bridge - Reservation", () => {
 
     it("should revert when called by a third party", async () => {
       await expect(
-        bridge.connect(thirdParty).notifyReservedRedemptionVeto(reservationKey)
+        bridge
+          .connect(thirdParty)
+          .notifyReservedRedemptionVeto(reservationKey, 1)
       ).to.be.revertedWith("Caller is not the redemption watchtower")
     })
 
-    it("should detain the balance and reactivate the reservation", async () => {
+    it("should revert for a non-current generation", async () => {
+      await expect(
+        bridge.connect(deployer).notifyReservedRedemptionVeto(reservationKey, 2)
+      ).to.be.revertedWith("Not the current generation")
+    })
+
+    it("should detain the balance, void the generation, and reactivate the reservation", async () => {
       const tx = await bridge
         .connect(deployer)
-        .notifyReservedRedemptionVeto(reservationKey)
+        .notifyReservedRedemptionVeto(reservationKey, 1)
 
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionVetoed")
-        .withArgs(reservationKey)
+        .withArgs(reservationKey, 1)
 
       expect(await bank.balanceOf(deployer.address)).to.equal(amountSat)
-      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      // A veto is owner-fault: no retry entitlement is minted.
+      expect(reservation.retryCredit).to.be.false
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 1)).state
+      ).to.equal(ActionState.Vetoed)
     })
   })
 
@@ -775,28 +917,29 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
+      await bridge.setLiveWalletsCount(1)
       await bridge.setReservation(
         reservationKey,
         await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
 
-      // Simulate the state a redemption timeout leaves the owner in: the
-      // gross amount refunded as Bank balance. The fee is paid in TBTC,
-      // funded here through an ordinary reservation credit.
-      const bridgeSigner = await impersonateContract(bridge.address)
-      await bank
-        .connect(bridgeSigner)
-        .increaseBalance(thirdParty.address, amountSat)
-      await bank
-        .connect(bridgeSigner)
-        .increaseBalanceAndCall(
-          reservationVault.address,
-          [thirdParty.address],
-          [amountSat]
-        )
+      // A fee-paid request that times out mints the retry entitlement and
+      // refunds the gross amount to the owner as Bank balance -- exactly
+      // the state the retry path is designed for.
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
     })
 
     after(async () => {
@@ -813,13 +956,47 @@ describe("Bridge - Reservation", () => {
         .connect(thirdParty)
         .retryRedeemReservation(reservationKey, redeemerOutputScript)
 
-      await expect(tx).to.emit(bridge, "ReservedRedemptionRequested")
-      expect((await bridge.reservations(reservationKey)).state).to.equal(2) // RedemptionRequested
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionRequested")
+        .withArgs(
+          reservationKey,
+          2,
+          thirdParty.address,
+          redeemerOutputScript,
+          amountSat,
+          RESERVATION_TX_MAX_FEE,
+          false
+        )
+
       expect(await bank.balanceOf(bridge.address)).to.equal(amountSat)
       // The redemption fee is not re-charged on retry.
       expect(await tbtc.balanceOf(treasury.address)).to.equal(
         treasuryBalanceBefore
       )
+      // The entitlement is consumed.
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+    })
+
+    it("rejects a second retry without a fresh entitlement", async () => {
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      // The retry generation was not fee-paid, so its timeout mints no
+      // new entitlement.
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, amountSat)
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservation(reservationKey, redeemerOutputScript)
+      ).to.be.revertedWith("No retry entitlement")
     })
   })
 
@@ -842,7 +1019,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT
         )
 
       await expect(
@@ -870,7 +1048,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT
         )
     })
   })
@@ -883,6 +1062,9 @@ describe("Bridge - Reservation", () => {
       "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
     let redemptionWatchtower: Contract
     let guardianSigners: SignerWithAddress[]
+
+    const vetoKeyOf = (key: BigNumber | number, nonce: number): string =>
+      ethers.utils.solidityKeccak256(["uint256", "uint64"], [key, nonce])
 
     before(async () => {
       await createSnapshot()
@@ -932,7 +1114,7 @@ describe("Bridge - Reservation", () => {
         movingFundsRequestedAt: 0,
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Terminated,
+        state: walletState.Live,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
       await bridge.setReservation(
@@ -940,57 +1122,57 @@ describe("Bridge - Reservation", () => {
         await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
 
-      const bridgeSigner = await impersonateContract(bridge.address)
-      await bank
-        .connect(bridgeSigner)
-        .increaseBalance(reservationVault.address, amountSat)
-      const vaultSigner = await impersonateContract(reservationVault.address)
-      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
-      await bridge
-        .connect(vaultSigner)
-        .requestReservedRedemption(
-          reservationKey,
-          thirdParty.address,
-          redeemerOutputScript
-        )
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
     })
 
     after(async () => {
       await restoreSnapshot()
     })
 
-    it("vetoes a reserved redemption after three guardian objections", async () => {
+    it("vetoes a reserved redemption generation after three guardian objections", async () => {
       await redemptionWatchtower
         .connect(guardianSigners[0])
-        .raiseReservedObjection(reservationKey)
+        .raiseReservedObjection(reservationKey, 1)
       await redemptionWatchtower
         .connect(guardianSigners[1])
-        .raiseReservedObjection(reservationKey)
+        .raiseReservedObjection(reservationKey, 1)
 
       const tx = await redemptionWatchtower
         .connect(guardianSigners[2])
-        .raiseReservedObjection(reservationKey)
+        .raiseReservedObjection(reservationKey, 1)
 
+      const vetoKey = vetoKeyOf(reservationKey, 1)
       await expect(tx)
         .to.emit(redemptionWatchtower, "VetoFinalized")
-        .withArgs(reservationKey)
+        .withArgs(vetoKey)
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionVetoed")
-        .withArgs(reservationKey)
+        .withArgs(reservationKey, 1)
       await expect(tx)
         .to.emit(redemptionWatchtower, "Banned")
         .withArgs(thirdParty.address)
 
-      // The reservation survives the veto as Active.
-      expect((await bridge.reservations(reservationKey)).state).to.equal(1)
+      // The reservation survives the veto as Active; the generation is
+      // terminally vetoed.
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Active
+      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 1)).state
+      ).to.equal(ActionState.Vetoed)
 
       // Default penalty is 100%: the whole detained amount is burned.
-      const veto = await redemptionWatchtower.vetoProposals(reservationKey)
+      const veto = await redemptionWatchtower.vetoProposals(vetoKey)
       expect(veto.withdrawableAmount).to.equal(0)
       expect(await bank.balanceOf(redemptionWatchtower.address)).to.equal(0)
 
       // The banned owner cannot re-request through the vault: the
-      // isSafeRedemption gate now rejects them.
+      // reservation-scoped safety gate now rejects them.
       const vaultSigner = await impersonateContract(reservationVault.address)
       await expect(
         bridge
@@ -998,9 +1180,41 @@ describe("Bridge - Reservation", () => {
           .requestReservedRedemption(
             reservationKey,
             thirdParty.address,
-            redeemerOutputScript
+            redeemerOutputScript,
+            true,
+            false
           )
       ).to.be.revertedWith("Redemption request rejected by the watchtower")
+    })
+
+    it("starts every new generation with a clean objection count once unbanned", async () => {
+      // Unban the owner: the position must become processable again --
+      // objection state never accumulates across generations.
+      await redemptionWatchtower.connect(governance).unban(thirdParty.address)
+
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.ActionPending)
+      expect(reservation.requestNonce).to.equal(2)
+
+      // A single objection against the fresh generation works and does
+      // not immediately veto (count starts at zero).
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(reservationKey, 2)
+      const veto = await redemptionWatchtower.vetoProposals(
+        vetoKeyOf(reservationKey, 2)
+      )
+      expect(veto.objectionsCount).to.equal(1)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.ActionPending
+      )
     })
   })
 
@@ -1015,6 +1229,7 @@ describe("Bridge - Reservation", () => {
     let futureRefundLocktime: string
     let fundingTx: { info: any; txHash: string }
     let depositKey: { fundingTxHash: string; fundingOutputIndex: number }
+    let depositKeyUint: BigNumber
     let depositExtraInfo: any
 
     before(async () => {
@@ -1031,6 +1246,17 @@ describe("Bridge - Reservation", () => {
       await bridge.setDepositRevealAheadPeriod(0)
 
       await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setWallet(secondWalletPubKeyHash, {
         ecdsaWalletID: ethers.utils.randomBytes(32),
         mainUtxoHash: ZERO_BYTES32,
         pendingRedemptionsValue: 0,
@@ -1080,6 +1306,12 @@ describe("Bridge - Reservation", () => {
       })
 
       depositKey = { fundingTxHash: fundingTx.txHash, fundingOutputIndex: 0 }
+      depositKeyUint = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
       depositExtraInfo = {
         fundingTx: fundingTx.info,
         blindingFactor,
@@ -1110,87 +1342,128 @@ describe("Bridge - Reservation", () => {
       ).to.be.revertedWith("Reserved deposits must not be swept")
     })
 
-    it("validates a reservation anchor proposal", async () => {
+    it("validates a reservation anchor proposal against the authorization", async () => {
+      // No authorization yet: the proposal is invalid.
+      await expect(
+        validator.validateReservationAnchorProposal(
+          { walletPubKeyHash, depositKey, requestNonce: 1, anchorTxFee: 1500 },
+          depositExtraInfo
+        )
+      ).to.be.revertedWith("No pending action of the expected type")
+
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(depositKeyUint, walletPubKeyHash)
+
       expect(
         await validator.validateReservationAnchorProposal(
-          { walletPubKeyHash, depositKey, anchorTxFee: 1500 },
+          { walletPubKeyHash, depositKey, requestNonce: 1, anchorTxFee: 1500 },
           depositExtraInfo
         )
       ).to.be.true
 
       await expect(
         validator.validateReservationAnchorProposal(
-          { walletPubKeyHash, depositKey, anchorTxFee: 0 },
+          { walletPubKeyHash, depositKey, requestNonce: 1, anchorTxFee: 0 },
           depositExtraInfo
         )
       ).to.be.revertedWith("Proposed transaction fee cannot be zero")
 
       await expect(
         validator.validateReservationAnchorProposal(
-          { walletPubKeyHash, depositKey, anchorTxFee: 2001 },
+          { walletPubKeyHash, depositKey, requestNonce: 1, anchorTxFee: 2001 },
           depositExtraInfo
         )
       ).to.be.revertedWith("Proposed transaction fee is too high")
+
+      await expect(
+        validator.validateReservationAnchorProposal(
+          {
+            walletPubKeyHash: secondWalletPubKeyHash,
+            depositKey,
+            requestNonce: 1,
+            anchorTxFee: 1500,
+          },
+          depositExtraInfo
+        )
+      ).to.be.revertedWith("Acceptance authorized for different wallet")
     })
 
-    it("validates reserved redemption, re-anchor and dissolution proposals", async () => {
+    it("validates reserved redemption and re-anchor proposals against their generations", async () => {
       const reservationKey = 12321
       await bridge.setReservation(
         reservationKey,
         await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
 
-      // Re-anchor: valid toward a Live target wallet.
-      await bridge.setWallet(secondWalletPubKeyHash, {
-        ecdsaWalletID: ethers.utils.randomBytes(32),
-        mainUtxoHash: ZERO_BYTES32,
-        pendingRedemptionsValue: 0,
-        createdAt: await lastBlockTime(),
-        movingFundsRequestedAt: 0,
-        closingStartedAt: 0,
-        pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.Live,
-        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
-      })
+      // Re-anchor: requires an authorization. The source wallet is Live,
+      // so only the governance can authorize a rotation.
+      await expect(
+        validator.validateReservationReanchorProposal({
+          sourceWalletPubKeyHash: walletPubKeyHash,
+          reservationKey,
+          requestNonce: 1,
+          targetWalletPubKeyHash: secondWalletPubKeyHash,
+          reanchorTxFee: 1500,
+        })
+      ).to.be.revertedWith("No pending action of the expected type")
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
       expect(
         await validator.validateReservationReanchorProposal({
           sourceWalletPubKeyHash: walletPubKeyHash,
           reservationKey,
+          requestNonce: 1,
           targetWalletPubKeyHash: secondWalletPubKeyHash,
           reanchorTxFee: 1500,
         })
       ).to.be.true
 
-      // Dissolution: rejected before term + grace elapse.
+      await expect(
+        validator.validateReservationReanchorProposal({
+          sourceWalletPubKeyHash: walletPubKeyHash,
+          reservationKey,
+          requestNonce: 1,
+          targetWalletPubKeyHash: walletPubKeyHash,
+          reanchorTxFee: 1500,
+        })
+      ).to.be.revertedWith("Re-anchor authorized for different target wallet")
+
+      // Dissolution: no pending authorization (term has not elapsed, so
+      // none can be requested).
       await expect(
         validator.validateReservationDissolutionProposal({
           walletPubKeyHash,
           reservationKey,
+          requestNonce: 1,
           dissolutionTxFee: 1500,
         })
-      ).to.be.revertedWith("Reservation term or grace period not elapsed")
+      ).to.be.revertedWith("No pending action of the expected type")
 
-      // Reserved redemption: request through the vault, wait past min age.
-      const bridgeSigner = await impersonateContract(bridge.address)
-      await bank
-        .connect(bridgeSigner)
-        .increaseBalance(reservationVault.address, amountSat)
-      const vaultSigner = await impersonateContract(reservationVault.address)
-      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
-      await bridge
-        .connect(vaultSigner)
-        .requestReservedRedemption(
-          reservationKey,
-          thirdParty.address,
-          "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
-        )
+      // Reserved redemption on a second reservation: request through the
+      // vault, wait past min age.
+      const redemptionReservationKey = 12322
+      await bridge.setReservation(
+        redemptionReservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+      await requestRedemptionViaVault(
+        redemptionReservationKey,
+        amountSat,
+        thirdParty.address,
+        "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+      )
 
       await increaseTime(601)
 
       expect(
         await validator.validateReservedRedemptionProposal({
           walletPubKeyHash,
-          reservationKey,
+          reservationKey: redemptionReservationKey,
+          requestNonce: 1,
           redemptionTxFee: 1500,
         })
       ).to.be.true
@@ -1198,7 +1471,8 @@ describe("Bridge - Reservation", () => {
       await expect(
         validator.validateReservedRedemptionProposal({
           walletPubKeyHash: secondWalletPubKeyHash,
-          reservationKey,
+          reservationKey: redemptionReservationKey,
+          requestNonce: 1,
           redemptionTxFee: 1500,
         })
       ).to.be.revertedWith("Reservation custodied by different wallet")
@@ -1245,7 +1519,8 @@ describe("Bridge - Reservation", () => {
       })
     }
 
-    // Reveals a fresh reserved deposit and proves its anchor transaction.
+    // Reveals a fresh reserved deposit, requests its acceptance and proves
+    // its anchor transaction (settling acceptance generation 1).
     async function makeAcceptedReservation(anchorValue?: BigNumber) {
       const fundingTx = buildTx(
         [
@@ -1279,6 +1554,17 @@ describe("Bridge - Reservation", () => {
         vault: reservationVault.address,
       })
 
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+
       const anchorTx = buildTx(
         [{ txHash: fundingTx.txHash, index: 0 }],
         [
@@ -1296,15 +1582,9 @@ describe("Bridge - Reservation", () => {
           anchorTx.info,
           proofFor(anchorTx.txHash),
           NO_MAIN_UTXO_PARAM,
-          0
+          reservationKey,
+          1
         )
-
-      const reservationKey = BigNumber.from(
-        ethers.utils.solidityKeccak256(
-          ["bytes32", "uint32"],
-          [fundingTx.txHash, 0]
-        )
-      )
 
       return { fundingTx, anchorTx, acceptTx, reservationKey }
     }
@@ -1337,6 +1617,62 @@ describe("Bridge - Reservation", () => {
       await restoreSnapshot()
     })
 
+    it("requires an acceptance authorization before the anchor proof", async () => {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.revertedWith("Action type mismatch")
+    })
+
     it("accepts a proven anchor and credits the gross amount", async () => {
       const { anchorTx, acceptTx, reservationKey } =
         await makeAcceptedReservation()
@@ -1345,6 +1681,7 @@ describe("Bridge - Reservation", () => {
         .to.emit(bridge, "ReservationAccepted")
         .withArgs(
           reservationKey,
+          1,
           walletPubKeyHash,
           thirdParty.address,
           anchorTx.txHash,
@@ -1359,7 +1696,14 @@ describe("Bridge - Reservation", () => {
       expect(reservation.mintedAmount).to.equal(anchorAmount)
       expect(reservation.anchorAmount).to.equal(anchorAmount)
       expect(reservation.anchorTxHash).to.equal(anchorTx.txHash)
-      expect(reservation.state).to.equal(1) // Active
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.termSeconds).to.equal(RESERVATION_TERM)
+      expect(reservation.gracePeriod).to.equal(RESERVATION_GRACE)
+
+      // The capacity reserved at authorization released the miner-fee
+      // delta at settlement: the total tracks the anchor value.
+      const params = await bridge.reservationParameters()
+      expect(params.reservationTotalAmount).to.equal(anchorAmount)
 
       // Gross mint minus the 40 bps initiation fee.
       const fee = grossTbtc.mul(40).div(10000)
@@ -1376,15 +1720,82 @@ describe("Bridge - Reservation", () => {
             anchorTx.info,
             proofFor(anchorTx.txHash),
             NO_MAIN_UTXO_PARAM,
-            0
+            reservationKey,
+            1
           )
-      ).to.be.revertedWith("Deposit already swept")
+      ).to.be.revertedWith("Action is not settleable")
     })
 
     it("rejects an anchor paying an excessive miner fee", async () => {
       await expect(
         makeAcceptedReservation(depositAmount.sub(RESERVATION_TX_MAX_FEE + 1))
       ).to.be.revertedWith("Transaction fee is too high")
+    })
+
+    it("rejects an anchor paying a wallet other than the authorized one", async () => {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+
+      await liveWallet(secondWalletPubKeyHash)
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.revertedWith("Anchor output must pay the authorized wallet")
     })
 
     it("completes an in-kind reserved redemption", async () => {
@@ -1409,6 +1820,7 @@ describe("Bridge - Reservation", () => {
       await reservationVault
         .connect(thirdParty)
         .redeemReservation(reservationKey, redeemerScript)
+
       const redemptionTx = buildTx(
         [{ txHash: anchorTx.txHash, index: 0 }],
         [
@@ -1426,30 +1838,35 @@ describe("Bridge - Reservation", () => {
           redemptionTx.info,
           proofFor(redemptionTx.txHash),
           NO_MAIN_UTXO_PARAM,
-          reservationKey
+          reservationKey,
+          2
         )
 
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionCompleted")
-        .withArgs(reservationKey, redemptionTx.txHash)
+        .withArgs(reservationKey, 2, redemptionTx.txHash)
 
-      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Closed
+      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.Settled)
       // The gross surrendered balance was burned.
       expect(await bank.balanceOf(bridge.address)).to.equal(0)
       expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(grossTbtc))
     })
 
     it("keeps redemption provable when txMaxFee exceeds the anchor (underflow guard)", async () => {
-      // Regression: redemptionTxMaxFee is a governable parameter, not a
-      // tx-derived value, so a governance increase can push it above an
-      // existing anchorAmount. The redemption range check must not underflow
-      // in that case. Fund the owner with two acceptances, then raise the
-      // fee/min parameters above the anchor and prove an in-kind redemption.
+      // Regression: the redemption fee bound is snapshotted at request
+      // time, but a snapshot can still exceed the anchor value. The
+      // redemption range check must not underflow in that case. Raise the
+      // fee/min parameters above the anchor BEFORE requesting so the
+      // snapshot captures them, then prove an in-kind redemption paying
+      // the full anchor value.
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
       await makeAcceptedReservation() // funds the owner with extra TBTC
 
-      // Raise the reservation tx max fee above the anchor amount (and the
-      // minimum above the fee, preserving the invariant).
       await bridge
         .connect(bridgeGovernanceSigner)
         .updateReservationParameters(
@@ -1459,7 +1876,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT
         )
 
       const redeemerScript = `0x16${p2wpkhScript(
@@ -1486,20 +1904,21 @@ describe("Bridge - Reservation", () => {
           redemptionTx.info,
           proofFor(redemptionTx.txHash),
           NO_MAIN_UTXO_PARAM,
-          reservationKey
+          reservationKey,
+          2
         )
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionCompleted")
-        .withArgs(reservationKey, redemptionTx.txHash)
+        .withArgs(reservationKey, 2, redemptionTx.txHash)
     })
 
-    it("allows a minimum-sized reservation to migrate (H-08 regression)", async () => {
+    it("re-anchors via a governance-authorized rotation (H-08 regression)", async () => {
       // A reservation whose anchor sits at the reservation minimum must
       // still be migratable with a positive fee. The earlier
       // `>= reservationMinAmount` re-anchor floor, combined with the
       // proposal validator's positive-fee requirement, left no compliant
       // re-anchor for an exactly-minimum anchor and would have pinned a
-      // retiring wallet. The dust floor (`> reservationTxMaxFee`) fixes it.
+      // retiring wallet. The dust floor (`> txMaxFee` snapshot) fixes it.
       const minAmount = BigNumber.from(RESERVATION_MIN_AMOUNT)
       const depositAmt = minAmount.add(RESERVATION_TX_MAX_FEE)
       const fundingTx = buildTx(
@@ -1532,6 +1951,15 @@ describe("Bridge - Reservation", () => {
         refundLocktime,
         vault: reservationVault.address,
       })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
       const anchorTx = buildTx(
         [{ txHash: fundingTx.txHash, index: 0 }],
         [{ valueSat: minAmount, script: p2wpkhScript(walletPubKeyHash) }]
@@ -1543,16 +1971,22 @@ describe("Bridge - Reservation", () => {
           anchorTx.info,
           proofFor(anchorTx.txHash),
           NO_MAIN_UTXO_PARAM,
-          0
+          reservationKey,
+          1
         )
-      const reservationKey = BigNumber.from(
-        ethers.utils.solidityKeccak256(
-          ["bytes32", "uint32"],
-          [fundingTx.txHash, 0]
-        )
-      )
 
       await liveWallet(secondWalletPubKeyHash)
+
+      // A third party cannot authorize a rotation away from a Live wallet.
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Only governance can rotate a Live wallet's anchor")
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
 
       // Migrate with a 1-sat fee: the anchor stays above the dust floor.
       const migrated = minAmount.sub(1)
@@ -1567,20 +2001,73 @@ describe("Bridge - Reservation", () => {
           reanchorTx.info,
           proofFor(reanchorTx.txHash),
           NO_MAIN_UTXO_PARAM,
-          reservationKey
+          reservationKey,
+          2
         )
       await expect(tx)
         .to.emit(bridge, "ReservationReanchored")
         .withArgs(
           reservationKey,
+          2,
           secondWalletPubKeyHash,
           reanchorTx.txHash,
           migrated
         )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(reservation.state).to.equal(ReservationState.Active)
+    })
+
+    it("rejects a re-anchor paying a wallet other than the authorized target", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      // The transaction pays the source wallet instead of the target.
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Output must pay the authorized target wallet")
     })
 
     it("dissolves an expired reservation into the wallet main UTXO", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      // Not requestable before term + grace.
+      await expect(
+        bridge.connect(thirdParty).requestReservationDissolution(reservationKey)
+      ).to.be.revertedWith("Reservation term or grace period not elapsed")
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+
+      expect(await bridge.walletPendingDissolution(walletPubKeyHash)).to.equal(
+        reservationKey
+      )
 
       const dissolutionFee = 500
       const dissolutionTx = buildTx(
@@ -1593,21 +2080,6 @@ describe("Bridge - Reservation", () => {
         ]
       )
 
-      // Not dissolvable before term + grace.
-      await expect(
-        bridge
-          .connect(spvMaintainer)
-          .submitReservationProof(
-            ProofType.Dissolution,
-            dissolutionTx.info,
-            proofFor(dissolutionTx.txHash),
-            NO_MAIN_UTXO_PARAM,
-            reservationKey
-          )
-      ).to.be.revertedWith("Reservation term or grace period not elapsed")
-
-      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
-
       const tx = await bridge
         .connect(spvMaintainer)
         .submitReservationProof(
@@ -1615,12 +2087,21 @@ describe("Bridge - Reservation", () => {
           dissolutionTx.info,
           proofFor(dissolutionTx.txHash),
           NO_MAIN_UTXO_PARAM,
-          reservationKey
+          reservationKey,
+          2
         )
 
-      await expect(tx).to.emit(bridge, "ReservationDissolved")
+      await expect(tx)
+        .to.emit(bridge, "ReservationDissolved")
+        .withArgs(reservationKey, 2, walletPubKeyHash, dissolutionTx.txHash)
 
-      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Closed
+      )
+      // The lock is released.
+      expect(await bridge.walletPendingDissolution(walletPubKeyHash)).to.equal(
+        0
+      )
 
       // The dissolution output became the wallet's new main UTXO.
       const wallet = await bridge.wallets(walletPubKeyHash)

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1236,6 +1236,212 @@ describe("Bridge - Reservation", () => {
     })
   })
 
+  describe("RedemptionWatchtower reserved delay snapshots", () => {
+    const reservationKey = 667
+    const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const amountSat = BigNumber.from(100000000)
+    const redeemerOutputScript =
+      "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+    let redemptionWatchtower: Contract
+    let guardianSigners: SignerWithAddress[]
+    let watchtowerManager: SignerWithAddress
+
+    async function updateDelayPolicy(
+      defaultDelay: number,
+      levelOneDelay: number,
+      levelTwoDelay: number,
+      waivedAmountLimit: BigNumber | number
+    ) {
+      return redemptionWatchtower
+        .connect(watchtowerManager)
+        .updateWatchtowerParameters(
+          await redemptionWatchtower.watchtowerLifetime(),
+          20,
+          await redemptionWatchtower.vetoFreezePeriod(),
+          defaultDelay,
+          levelOneDelay,
+          levelTwoDelay,
+          waivedAmountLimit
+        )
+    }
+
+    async function requestRedemption() {
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
+    }
+
+    before(async () => {
+      await createSnapshot()
+      await wireReservations()
+
+      redemptionWatchtower = await helpers.contracts.getContract(
+        "RedemptionWatchtower"
+      )
+      guardianSigners = (await ethers.getSigners()).slice(10, 13)
+      const watchtowerOwner = await impersonateContract(
+        await redemptionWatchtower.owner()
+      )
+      await redemptionWatchtower.connect(watchtowerOwner).enableWatchtower(
+        governance.address,
+        guardianSigners.map((guardian) => guardian.address)
+      )
+      watchtowerManager = await impersonateContract(
+        await redemptionWatchtower.manager()
+      )
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(redemptionWatchtower.address)
+
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("keeps every objection-level delay on the old generation and applies updates to the next one", async () => {
+      const defaultDelay = await redemptionWatchtower.defaultDelay()
+      const levelOneDelay = await redemptionWatchtower.levelOneDelay()
+      const levelTwoDelay = await redemptionWatchtower.levelTwoDelay()
+      await requestRedemption()
+
+      const oldAction = await bridge.reservationActions(reservationKey, 1)
+      expect(oldAction.watchtowerDefaultDelay).to.equal(defaultDelay)
+      expect(oldAction.watchtowerLevelOneDelay).to.equal(levelOneDelay)
+      expect(oldAction.watchtowerLevelTwoDelay).to.equal(levelTwoDelay)
+
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 1)
+      ).to.equal(defaultDelay)
+
+      const newDefaultDelay = defaultDelay + 60
+      const newLevelOneDelay = levelOneDelay + 120
+      const newLevelTwoDelay = levelTwoDelay + 180
+      await updateDelayPolicy(
+        newDefaultDelay,
+        newLevelOneDelay,
+        newLevelTwoDelay,
+        0
+      )
+
+      // Policy changes never rewrite the authorization window of an already
+      // requested generation.
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 1)
+      ).to.equal(defaultDelay)
+
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(reservationKey, 1)
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 1)
+      ).to.equal(levelOneDelay)
+
+      await redemptionWatchtower
+        .connect(guardianSigners[1])
+        .raiseReservedObjection(reservationKey, 1)
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 1)
+      ).to.equal(levelTwoDelay)
+
+      await redemptionWatchtower
+        .connect(guardianSigners[2])
+        .raiseReservedObjection(reservationKey, 1)
+      await redemptionWatchtower
+        .connect(watchtowerManager)
+        .unban(thirdParty.address)
+
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        redeemerOutputScript
+      )
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 2)
+      ).to.equal(newDefaultDelay)
+    })
+
+    it("keeps a waived generation objection-free after the waiver policy changes", async () => {
+      const defaultDelay = await redemptionWatchtower.defaultDelay()
+      const levelOneDelay = await redemptionWatchtower.levelOneDelay()
+      const levelTwoDelay = await redemptionWatchtower.levelTwoDelay()
+      await updateDelayPolicy(
+        defaultDelay,
+        levelOneDelay,
+        levelTwoDelay,
+        amountSat.add(1)
+      )
+      await requestRedemption()
+
+      const action = await bridge.reservationActions(reservationKey, 1)
+      expect(action.watchtowerDefaultDelay).to.equal(0)
+      expect(action.watchtowerLevelOneDelay).to.equal(0)
+      expect(action.watchtowerLevelTwoDelay).to.equal(0)
+
+      // Removing the waiver affects future generations only. This generation
+      // retains the zero schedule captured when it was requested.
+      await updateDelayPolicy(defaultDelay, levelOneDelay, levelTwoDelay, 0)
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 1)
+      ).to.equal(0)
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(reservationKey, 1)
+      ).to.be.revertedWith("Redemption veto delay period expired")
+    })
+
+    it("captures a zero schedule after the watchtower is disabled", async () => {
+      const lifetimeExpiresAt =
+        (await redemptionWatchtower.watchtowerEnabledAt()) +
+        (await redemptionWatchtower.watchtowerLifetime())
+      await increaseTime(lifetimeExpiresAt - (await lastBlockTime()))
+      await redemptionWatchtower.connect(thirdParty).disableWatchtower()
+
+      await requestRedemption()
+
+      const action = await bridge.reservationActions(reservationKey, 1)
+      expect(action.watchtowerDefaultDelay).to.equal(0)
+      expect(action.watchtowerLevelOneDelay).to.equal(0)
+      expect(action.watchtowerLevelTwoDelay).to.equal(0)
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 1)
+      ).to.equal(0)
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(reservationKey, 1)
+      ).to.be.revertedWith("Redemption veto delay period expired")
+    })
+  })
+
   describe("WalletProposalValidator", () => {
     const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
     const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
@@ -1969,6 +2175,181 @@ describe("Bridge - Reservation", () => {
       // The gross surrendered balance was burned.
       expect(await bank.balanceOf(bridge.address)).to.equal(0)
       expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(grossTbtc))
+    })
+
+    it("keeps a signed reserved redemption provable after the manager raises delays", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      const redemptionWatchtower = await helpers.contracts.getContract(
+        "RedemptionWatchtower"
+      )
+      const guardian = (await ethers.getSigners())[10]
+      const watchtowerOwner = await impersonateContract(
+        await redemptionWatchtower.owner()
+      )
+      await redemptionWatchtower
+        .connect(watchtowerOwner)
+        .enableWatchtower(governance.address, [guardian.address])
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(redemptionWatchtower.address)
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      await requestRedemptionViaVault(
+        reservationKey,
+        anchorAmount,
+        thirdParty.address,
+        redeemerScript
+      )
+
+      const defaultDelay = await redemptionWatchtower.defaultDelay()
+      const levelOneDelay = await redemptionWatchtower.levelOneDelay()
+      const levelTwoDelay = await redemptionWatchtower.levelTwoDelay()
+      await increaseTime(defaultDelay + 1)
+
+      const watchtowerManager = await impersonateContract(
+        await redemptionWatchtower.manager()
+      )
+      await redemptionWatchtower
+        .connect(watchtowerManager)
+        .updateWatchtowerParameters(
+          await redemptionWatchtower.watchtowerLifetime(),
+          20,
+          await redemptionWatchtower.vetoFreezePeriod(),
+          defaultDelay + 3600,
+          levelOneDelay + 3600,
+          levelTwoDelay + 3600,
+          0
+        )
+
+      // The old signing window is closed permanently. Raising live policy
+      // cannot reopen guardian objections against the already-signed spend.
+      await expect(
+        redemptionWatchtower
+          .connect(guardian)
+          .raiseReservedObjection(reservationKey, 2)
+      ).to.be.revertedWith("Redemption veto delay period expired")
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 2)
+      ).to.equal(defaultDelay)
+
+      const validator = await helpers.contracts.getContract(
+        "WalletProposalValidator"
+      )
+      expect(
+        await validator.validateReservedRedemptionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          requestNonce: 2,
+          redemptionTxFee: 1000,
+        })
+      ).to.be.true
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      )
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, 2, redemptionTx.txHash)
+    })
+
+    it("removes the delay from a pre-existing generation after permanent watchtower shutdown", async () => {
+      const redemptionWatchtower = await helpers.contracts.getContract(
+        "RedemptionWatchtower"
+      )
+      const guardian = (await ethers.getSigners())[10]
+      const watchtowerOwner = await impersonateContract(
+        await redemptionWatchtower.owner()
+      )
+      await redemptionWatchtower
+        .connect(watchtowerOwner)
+        .enableWatchtower(governance.address, [guardian.address])
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(redemptionWatchtower.address)
+
+      // Let the finite watchtower lifetime expire without disabling it yet.
+      // The generation requested after expiry still captures the live policy,
+      // then permanent shutdown must override that snapshot globally.
+      const lifetimeExpiresAt =
+        (await redemptionWatchtower.watchtowerEnabledAt()) +
+        (await redemptionWatchtower.watchtowerLifetime())
+      await increaseTime(lifetimeExpiresAt - (await lastBlockTime()))
+
+      // Create the reservation after the time jump so its redemption window
+      // remains active while the expired-but-not-yet-disabled watchtower still
+      // exposes its nonzero policy.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      await requestRedemptionViaVault(
+        reservationKey,
+        anchorAmount,
+        thirdParty.address,
+        redeemerScript
+      )
+
+      const defaultDelay = await redemptionWatchtower.defaultDelay()
+      const action = await bridge.reservationActions(reservationKey, 2)
+      expect(action.watchtowerDefaultDelay).to.equal(defaultDelay)
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 2)
+      ).to.equal(defaultDelay)
+
+      await redemptionWatchtower.connect(thirdParty).disableWatchtower()
+
+      expect(
+        await redemptionWatchtower.getReservedRedemptionDelay(reservationKey, 2)
+      ).to.equal(0)
+      await expect(
+        redemptionWatchtower
+          .connect(guardian)
+          .raiseReservedObjection(reservationKey, 2)
+      ).to.be.revertedWith("Redemption veto delay period expired")
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      )
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, 2, redemptionTx.txHash)
     })
 
     it("keeps redemption provable when txMaxFee exceeds the anchor (underflow guard)", async () => {

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -424,7 +424,7 @@ describe("Bridge - Reservation settlement", () => {
       .approve(reservationVault.address, grossTbtc.add(redemptionFee))
     await reservationVault
       .connect(thirdParty)
-      .redeemReservation(reservationKey, redeemerScript)
+      .redeemReservation(reservationKey, redeemerScript, redemptionFee)
   }
 
   // Retries via the Bank-balance path after a timeout refund.
@@ -1744,7 +1744,11 @@ describe("Bridge - Reservation settlement", () => {
       await expect(
         reservationVault
           .connect(thirdParty)
-          .redeemReservation(reservationKey, randomRedeemerScript())
+          .redeemReservation(
+            reservationKey,
+            randomRedeemerScript(),
+            redemptionFee
+          )
       ).to.be.revertedWith("Reservation past grace period")
     })
 
@@ -1771,7 +1775,11 @@ describe("Bridge - Reservation settlement", () => {
       await expect(
         reservationVault
           .connect(thirdParty)
-          .redeemReservation(reservationKey, randomRedeemerScript())
+          .redeemReservation(
+            reservationKey,
+            randomRedeemerScript(),
+            redemptionFee
+          )
       ).to.be.revertedWith("Wallet must be in Live or MovingFunds state")
     })
   })

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -1930,6 +1930,358 @@ describe("Bridge - Reservation settlement", () => {
     })
   })
 
+  describe("notifyReservationActionTimeout guards", () => {
+    const makePendingRedemption = async (): Promise<BigNumber> => {
+      const { reservationKey } = await makeAcceptedReservation()
+      // The second acceptance funds the owner with the TBTC needed for the
+      // gross surrender plus fee on the first (mirrors the claim
+      // double-spend regression test).
+      await makeAcceptedReservation()
+      await requestRedemption(reservationKey, randomRedeemerScript())
+      return reservationKey
+    }
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects a timeout notification before the action times out", async () => {
+      const reservationKey = await makePendingRedemption()
+
+      // The redemption generation is pending with its timeout in the
+      // future; notifying the timeout now must revert.
+      await expect(
+        bridge.connect(thirdParty).notifyReservationActionTimeout(
+          reservationKey,
+          []
+        )
+      ).to.be.revertedWith("Action has not timed out")
+
+      // And the pending generation is untouched.
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.Pending)
+    })
+
+    it("rejects a second timeout notification on an already-timed-out action", async () => {
+      const reservationKey = await makePendingRedemption()
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+
+      // The first notification succeeds and times the generation out.
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // A second notification against the same generation must revert:
+      // no double capacity-release / double refund.
+      await expect(
+        bridge.connect(thirdParty).notifyReservationActionTimeout(
+          reservationKey,
+          []
+        )
+      ).to.be.revertedWith("No pending action")
+    })
+  })
+
+  describe("late acceptance settling against a terminated wallet", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("strands the position and mints nothing when the target wallet terminated", async () => {
+      // Request an acceptance (generation 1), then let it time out and
+      // have the target wallet terminate before the late proof lands.
+      const { fundingTx, anchorTx, reservationKey } =
+        await makeRequestedReservation()
+
+      const totalBefore = (await bridge.reservationParameters())
+        .reservationTotalAmount
+      const vaultTbtcBefore = await tbtc.balanceOf(reservationVault.address)
+
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+
+      // Time out the acceptance and, in the same breath, terminate the
+      // target wallet so the late proof arrives against a dead wallet.
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.Terminated,
+      })
+
+      // The anchor -- signed while generation 1 was pending -- confirmed
+      // on Bitcoin. Its late proof must NOT mint unbacked TBTC against the
+      // dissolved wallet: the position is recorded Stranded instead.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          1
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 1, ActionType.Acceptance)
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Stranded
+      )
+      expect((await bridge.reservations(reservationKey)).mintedAmount).to.equal(
+        0
+      )
+
+      // No capacity is re-taken for a stranded position: the late proof
+      // settles into the Stranded state without re-crediting capacity,
+      // leaving the total at its post-timeout value (depositAmount was
+      // released by the timeout and is not re-taken for a dead wallet).
+      expect(
+        (await bridge.reservationParameters()).reservationTotalAmount
+      ).to.equal(totalBefore.sub(depositAmount))
+
+      // Neither does the proof mint TBTC: the reservation vault balance is
+      // unchanged by the settlement (a successful late settle would have
+      // credited grossTbtc via increaseBalanceAndCall).
+      const vaultTbtcAfter = await tbtc.balanceOf(reservationVault.address)
+      expect(vaultTbtcAfter).to.equal(vaultTbtcBefore)
+    })
+  })
+
+  describe("late acceptance superseding a newer pending generation", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("unwinds the newer pending acceptance and releases its capacity", async () => {
+      // Generation 1 acceptance request that will time out (the anchor
+      // confirms late); a generation 2 acceptance is requested before the
+      // late proof lands.
+      const { fundingTx, anchorTx, reservationKey } =
+        await makeRequestedReservation()
+
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // Request a fresh acceptance (generation 2) for the same deposit.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+
+      const totalRequested = (await bridge.reservationParameters())
+        .reservationTotalAmount
+      expect(totalRequested).to.equal(BigNumber.from(depositAmount))
+
+      // The generation-1 anchor, already confirmed on Bitcoin, proves late.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          1
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 1, ActionType.Acceptance)
+
+      // The newer pending acceptance generation was superseded, releasing
+      // its reserved deposit.amount capacity; the late proof re-took only
+      // the actual anchorAmount. In this fixture depositAmount and
+      // anchorAmount differ by the anchorFee, so net total is anchorAmount.
+      expect((await bridge.reservationActions(reservationKey, 2)).state).to.equal(
+        ActionState.Superseded
+      )
+      expect(
+        (await bridge.reservationParameters()).reservationTotalAmount
+      ).to.equal(BigNumber.from(anchorAmount))
+    })
+  })
+
+  describe("late re-anchor settling against a terminated target wallet", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("strands the position without re-taking the target wallet's count", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      // Put the source wallet on its ordinary migration path so a
+      // permissionless (non-governance) re-anchor request is allowed.
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.MovingFunds,
+        movingFundsRequestedAt: await lastBlockTime(),
+      })
+
+      // Generation 2 re-anchors to a second wallet but its proof is
+      // delayed until after the authorization times out (the timeout
+      // already released the target wallet's reserved count).
+      const reanchorTx = await requestAndTimeoutReanchor(
+        reservationKey,
+        (await bridge.reservations(reservationKey)).anchorTxHash
+      )
+
+      // The target wallet terminates before the late proof lands.
+      await bridge.setWallet(secondWalletPubKeyHash, {
+        ...(await bridge.wallets(secondWalletPubKeyHash)),
+        state: walletState.Terminated,
+      })
+
+      const totalBefore = (await bridge.reservationParameters())
+        .reservationTotalAmount
+
+      // The re-anchor transaction -- signed while generation 2 was
+      // pending -- confirmed on Bitcoin. Its late proof must not re-take
+      // a reservation slot on the now-dead target wallet: the position is
+      // recorded Stranded instead.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 2, ActionType.Reanchor)
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Stranded)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+
+      // The source wallet's count was released and the full anchor value
+      // was removed from the tracked reserved amount (the position is no
+      // longer an in-kind claim); the target wallet's count was already
+      // released by the timeout and is not re-taken for a dead wallet.
+      expect(
+        (await bridge.reservationParameters()).reservationTotalAmount
+      ).to.equal(totalBefore.sub(anchorAmount))
+    })
+  })
+
+  describe("late re-anchor against a position with a matching pending generation", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("forces settlement against the matching pending re-anchor", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      // Put the source wallet on its ordinary migration path so
+      // permissionless re-anchor requests are allowed.
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.MovingFunds,
+        movingFundsRequestedAt: await lastBlockTime(),
+      })
+      await liveWallet(secondWalletPubKeyHash)
+
+      // Generation 2 re-anchors to the second wallet; its transaction is
+      // built now (as if signed) but its proof arrives only after the
+      // authorization times out.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      const { anchorTxHash } = await bridge.reservations(reservationKey)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTxHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The owner (unaware generation 2's transaction confirmed) requests
+      // a fresh re-anchor (generation 3) to the SAME second wallet.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      // The transaction satisfies both generation 2 (timed out) and
+      // generation 3 (pending, same target wallet, compatible fee). The
+      // late-settlement path must refuse it: settling the pending
+      // generation attributes the re-taken capacity to the correct
+      // (current) generation.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Must settle the pending generation")
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationReanchored")
+        .withArgs(
+          reservationKey,
+          3,
+          secondWalletPubKeyHash,
+          reanchorTx.txHash,
+          anchorAmount.sub(500)
+        )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).state
+      ).to.equal(ActionState.Settled)
+    })
+  })
+
   describe("capacity reserved before signing (fill-then-prove)", () => {
     before(async () => {
       await createSnapshot()
@@ -2060,6 +2412,111 @@ describe("Bridge - Reservation settlement", () => {
     })
   })
 
+  describe("per-wallet reservation count cap", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects an acceptance request once the wallet's reservation count is at cap", async () => {
+      // Drive walletReservationsCount[walletPubKeyHash] to
+      // MAX_RESERVATIONS_PER_WALLET via distinct deposits to the same
+      // wallet, none of which are settled (the count is reserved at
+      // request time, independent of settlement).
+      for (let i = 0; i < MAX_RESERVATIONS_PER_WALLET; i++) {
+        const fundingTx = buildTx(
+          [
+            {
+              txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+              index: 0,
+            },
+          ],
+          [
+            {
+              valueSat: depositAmount,
+              script: p2wshScript(
+                buildDepositScript(
+                  thirdParty.address,
+                  blindingFactor,
+                  walletPubKeyHash,
+                  refundPubKeyHash,
+                  refundLocktime
+                )
+              ),
+            },
+          ]
+        )
+        await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+          fundingOutputIndex: 0,
+          blindingFactor,
+          walletPubKeyHash,
+          refundPubKeyHash,
+          refundLocktime,
+          vault: reservationVault.address,
+        })
+        await bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            BigNumber.from(
+              ethers.utils.solidityKeccak256(
+                ["bytes32", "uint32"],
+                [fundingTx.txHash, 0]
+              )
+            ),
+            walletPubKeyHash
+          )
+      }
+
+      // The wallet is now at MAX_RESERVATIONS_PER_WALLET; one more request
+      // must revert regardless of remaining global amount capacity.
+      const overflowFundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(overflowFundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            BigNumber.from(
+              ethers.utils.solidityKeccak256(
+                ["bytes32", "uint32"],
+                [overflowFundingTx.txHash, 0]
+              )
+            ),
+            walletPubKeyHash
+          )
+      ).to.be.revertedWith("Wallet reservations cap exceeded")
+    })
+  })
   describe("acceptance authorization timeout", () => {
     before(async () => {
       await createSnapshot()

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -830,6 +830,44 @@ describe("Bridge - Reservation settlement", () => {
         .withArgs(second.reservationKey, 2, walletPubKeyHash, secondTx.txHash)
     })
 
+    it("rearms a completed moving-funds timeout when dissolution creates a main UTXO", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.MovingFunds,
+        movingFundsRequestedAt: 0,
+      })
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.mainUtxoHash).not.to.equal(ZERO_BYTES32)
+      expect(wallet.movingFundsRequestedAt).to.equal(await lastBlockTime())
+    })
+
     it("supersedes a cross-reservation lock when a late dissolution consumes its main UTXO", async () => {
       const first = await makeAcceptedReservation()
       const second = await makeAcceptedReservation()
@@ -1332,7 +1370,7 @@ describe("Bridge - Reservation settlement", () => {
     })
 
     it("records a confirmed main-UTXO move while reservation obligations remain", async () => {
-      await makeAcceptedReservation()
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
       await liveWallet(secondWalletPubKeyHash)
 
       const mainUtxo = {
@@ -1382,6 +1420,10 @@ describe("Bridge - Reservation settlement", () => {
       const sourceWallet = await bridge.wallets(walletPubKeyHash)
       expect(sourceWallet.mainUtxoHash).to.equal(ZERO_BYTES32)
       expect(sourceWallet.state).to.equal(walletState.MovingFunds)
+      expect(sourceWallet.movingFundsRequestedAt).to.equal(0)
+      expect(sourceWallet.movingFundsTargetWalletsCommitmentHash).to.equal(
+        ZERO_BYTES32
+      )
 
       const targetRequest = await bridge.movedFundsSweepRequests(
         BigNumber.from(
@@ -1397,6 +1439,42 @@ describe("Bridge - Reservation settlement", () => {
         (await bridge.wallets(secondWalletPubKeyHash))
           .pendingMovedFundsSweepRequestsCount
       ).to.equal(1)
+
+      // Move the final reservation obligation away from the source wallet.
+      // Its already-proven moving-funds generation must stay completed rather
+      // than becoming slashable again when the retained count reaches zero.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      const { movingFundsTimeout } = await bridge.movingFundsParameters()
+      await increaseTime(movingFundsTimeout + 1)
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .notifyMovingFundsTimeout(walletPubKeyHash, [])
+      ).to.be.revertedWith("Moving funds process already completed")
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.MovingFunds
+      )
     })
   })
 })

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -16,6 +16,7 @@ import type {
   BankStub,
   Bridge,
   BridgeStub,
+  IWalletRegistry,
   IRelay,
   ReservationRouter,
   ReservationVault,
@@ -82,6 +83,7 @@ describe("Bridge - Reservation settlement", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
+  let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub & ReservationRouter
   let tbtc: TBTC & Contract
   let tbtcVault: TBTCVault & Contract
@@ -113,6 +115,7 @@ describe("Bridge - Reservation settlement", () => {
       thirdParty,
       bank,
       relay,
+      walletRegistry,
       bridge,
       tbtc,
       tbtcVault,
@@ -175,6 +178,21 @@ describe("Bridge - Reservation settlement", () => {
       state: walletState.Live,
       movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
     })
+  }
+
+  async function expectWalletSeized(ecdsaWalletID: string) {
+    const {
+      redemptionTimeoutSlashingAmount,
+      redemptionTimeoutNotifierRewardMultiplier,
+    } = await bridge.redemptionParameters()
+
+    expect(walletRegistry.seize).to.have.been.calledWith(
+      redemptionTimeoutSlashingAmount,
+      redemptionTimeoutNotifierRewardMultiplier,
+      await thirdParty.getAddress(),
+      ecdsaWalletID,
+      []
+    )
   }
 
   // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
@@ -346,6 +364,52 @@ describe("Bridge - Reservation settlement", () => {
       )
 
     return { fundingTx, anchorTx, reservationKey }
+  }
+
+  async function completeMovingFundsWhileReservationsRemain() {
+    await liveWallet(secondWalletPubKeyHash)
+
+    const mainUtxo = {
+      txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+      txOutputIndex: 0,
+      txOutputValue: 7000000,
+    }
+    const ecdsaWalletID = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+    await bridge.setWallet(walletPubKeyHash, {
+      ecdsaWalletID,
+      mainUtxoHash: ZERO_BYTES32,
+      pendingRedemptionsValue: 0,
+      createdAt: await lastBlockTime(),
+      movingFundsRequestedAt: await lastBlockTime(),
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.MovingFunds,
+      movingFundsTargetWalletsCommitmentHash: ethers.utils.solidityKeccak256(
+        ["bytes20[]"],
+        [[secondWalletPubKeyHash]]
+      ),
+    })
+    await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+
+    const movingFundsTx = buildTx(
+      [{ txHash: mainUtxo.txHash, index: mainUtxo.txOutputIndex }],
+      [
+        {
+          valueSat: BigNumber.from(mainUtxo.txOutputValue).sub(500),
+          script: p2wpkhScript(secondWalletPubKeyHash),
+        },
+      ]
+    )
+    const tx = await bridge
+      .connect(spvMaintainer)
+      .submitMovingFundsProof(
+        movingFundsTx.info,
+        proofFor(movingFundsTx.txHash),
+        mainUtxo,
+        walletPubKeyHash
+      )
+
+    return { ecdsaWalletID, movingFundsTx, tx }
   }
 
   // Requests an in-kind redemption of the given accepted reservation via
@@ -1534,49 +1598,10 @@ describe("Bridge - Reservation settlement", () => {
 
     it("records a confirmed main-UTXO move while reservation obligations remain", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
-      await liveWallet(secondWalletPubKeyHash)
+      const { movingFundsTx, tx } =
+        await completeMovingFundsWhileReservationsRemain()
 
-      const mainUtxo = {
-        txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
-        txOutputIndex: 0,
-        txOutputValue: 7000000,
-      }
-      await bridge.setWallet(walletPubKeyHash, {
-        ecdsaWalletID: ethers.utils.randomBytes(32),
-        mainUtxoHash: ZERO_BYTES32,
-        pendingRedemptionsValue: 0,
-        createdAt: await lastBlockTime(),
-        movingFundsRequestedAt: await lastBlockTime(),
-        closingStartedAt: 0,
-        pendingMovedFundsSweepRequestsCount: 0,
-        state: walletState.MovingFunds,
-        movingFundsTargetWalletsCommitmentHash: ethers.utils.solidityKeccak256(
-          ["bytes20[]"],
-          [[secondWalletPubKeyHash]]
-        ),
-      })
-      await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
-
-      const movingFundsTx = buildTx(
-        [{ txHash: mainUtxo.txHash, index: mainUtxo.txOutputIndex }],
-        [
-          {
-            valueSat: BigNumber.from(mainUtxo.txOutputValue).sub(500),
-            script: p2wpkhScript(secondWalletPubKeyHash),
-          },
-        ]
-      )
-
-      await expect(
-        bridge
-          .connect(spvMaintainer)
-          .submitMovingFundsProof(
-            movingFundsTx.info,
-            proofFor(movingFundsTx.txHash),
-            mainUtxo,
-            walletPubKeyHash
-          )
-      )
+      await expect(tx)
         .to.emit(bridge, "MovingFundsCompleted")
         .withArgs(walletPubKeyHash, movingFundsTx.txHash)
 
@@ -1638,6 +1663,148 @@ describe("Bridge - Reservation settlement", () => {
       expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
         walletState.MovingFunds
       )
+    })
+
+    it("terminates a completed MovingFunds wallet that refuses residual reservation dissolution", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      const { ecdsaWalletID } =
+        await completeMovingFundsWhileReservationsRemain()
+
+      const completedWallet = await bridge.wallets(walletPubKeyHash)
+      expect(completedWallet.state).to.equal(walletState.MovingFunds)
+      expect(completedWallet.movingFundsRequestedAt).to.equal(0)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await walletRegistry.closeWallet.reset()
+      await walletRegistry.seize.reset()
+      const timeoutTx = await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      await expect(timeoutTx)
+        .to.emit(bridge, "WalletTerminated")
+        .withArgs(ecdsaWalletID, walletPubKeyHash)
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.Terminated
+      )
+      await expectWalletSeized(ecdsaWalletID)
+      expect(walletRegistry.closeWallet).to.have.been.calledWith(ecdsaWalletID)
+
+      // A dissolution transaction that was already confirmed remains
+      // late-settleable and supplies the evidence to strand the position.
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Stranded
+      )
+    })
+
+    it("keeps the existing moving-funds path for a Live wallet after dissolution timeout", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+
+      await walletRegistry.closeWallet.reset()
+      await walletRegistry.seize.reset()
+      const tx = await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      await expect(tx).to.emit(bridge, "WalletMovingFunds")
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.state).to.equal(walletState.MovingFunds)
+      expect(wallet.movingFundsRequestedAt).to.equal(await lastBlockTime())
+      await expectWalletSeized(wallet.ecdsaWalletID)
+      expect(walletRegistry.closeWallet).not.to.have.been.called
+    })
+
+    it("terminates an active MovingFunds wallet despite a reset deadline", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      const movingFundsRequestedAt = await lastBlockTime()
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.MovingFunds,
+        movingFundsRequestedAt,
+      })
+      await bridge.setLiveWalletsCount(0)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge.resetMovingFundsTimeout(walletPubKeyHash)
+      const resetRequestedAt = (await bridge.wallets(walletPubKeyHash))
+        .movingFundsRequestedAt
+      expect(resetRequestedAt).to.be.greaterThan(movingFundsRequestedAt)
+
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+
+      await walletRegistry.closeWallet.reset()
+      await walletRegistry.seize.reset()
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.state).to.equal(walletState.Terminated)
+      expect(wallet.movingFundsRequestedAt).to.equal(resetRequestedAt)
+      await expectWalletSeized(wallet.ecdsaWalletID)
+      expect(walletRegistry.closeWallet).to.have.been.calledWith(
+        wallet.ecdsaWalletID
+      )
+    })
+
+    it("does not slash or terminate an already-Terminated wallet again", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.Terminated,
+      })
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+
+      await walletRegistry.closeWallet.reset()
+      await walletRegistry.seize.reset()
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.Terminated
+      )
+      expect(walletRegistry.seize).not.to.have.been.called
+      expect(walletRegistry.closeWallet).not.to.have.been.called
     })
   })
 })

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -18,6 +18,9 @@ import type {
   BridgeStub,
   IWalletRegistry,
   IRelay,
+  MaintainerProxy,
+  MaintainerProxyV2,
+  ReimbursementPool,
   ReservationRouter,
   ReservationVault,
   TBTCVault,
@@ -85,6 +88,9 @@ describe("Bridge - Reservation settlement", () => {
   let relay: FakeContract<IRelay>
   let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub & ReservationRouter
+  let maintainerProxy: MaintainerProxy
+  let maintainerProxyV2: MaintainerProxyV2
+  let reimbursementPool: ReimbursementPool
   let tbtc: TBTC & Contract
   let tbtcVault: TBTCVault & Contract
   let reservationVault: ReservationVault
@@ -117,9 +123,13 @@ describe("Bridge - Reservation settlement", () => {
       relay,
       walletRegistry,
       bridge,
+      reimbursementPool,
       tbtc,
       tbtcVault,
     } = await waffle.loadFixture(bridgeFixture))
+
+    maintainerProxy = await helpers.contracts.getContract("MaintainerProxy")
+    maintainerProxyV2 = await helpers.contracts.getContract("MaintainerProxyV2")
 
     reservationVault = await helpers.contracts.getContract("ReservationVault")
     bridgeGovernanceSigner = await impersonateContract(
@@ -301,9 +311,8 @@ describe("Bridge - Reservation settlement", () => {
   const randomRedeemerScript = (): string =>
     `0x16${p2wpkhScript(ethers.utils.hexlify(ethers.utils.randomBytes(20)))}`
 
-  // Reveals a fresh reserved deposit, requests acceptance (generation 1)
-  // and proves the anchor.
-  async function makeAcceptedReservation(custodian = walletPubKeyHash) {
+  // Reveals a fresh reserved deposit and requests acceptance (generation 1).
+  async function makeRequestedReservation(custodian = walletPubKeyHash) {
     const fundingTx = buildTx(
       [
         {
@@ -351,6 +360,15 @@ describe("Bridge - Reservation settlement", () => {
       [{ txHash: fundingTx.txHash, index: 0 }],
       [{ valueSat: anchorAmount, script: p2wpkhScript(custodian) }]
     )
+
+    return { fundingTx, anchorTx, reservationKey }
+  }
+
+  // Reveals a fresh reserved deposit, requests acceptance (generation 1)
+  // and proves the anchor.
+  async function makeAcceptedReservation(custodian = walletPubKeyHash) {
+    const { fundingTx, anchorTx, reservationKey } =
+      await makeRequestedReservation(custodian)
 
     await bridge
       .connect(spvMaintainer)
@@ -466,6 +484,191 @@ describe("Bridge - Reservation settlement", () => {
 
     return reanchorTx
   }
+
+  describe("production MaintainerProxy reservation proof route", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("settles and reimburses a real proof when only the proxy is authorized in Bridge", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setSpvMaintainerStatus(spvMaintainer.address, false)
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setSpvMaintainerStatus(maintainerProxyV2.address, false)
+      await maintainerProxyV2
+        .connect(governance)
+        .authorizeSpvMaintainer(spvMaintainer.address)
+      await deployer.sendTransaction({
+        to: reimbursementPool.address,
+        value: ethers.utils.parseEther("1"),
+      })
+
+      const { anchorTx, reservationKey } = await makeRequestedReservation()
+      const proof = proofFor(anchorTx.txHash)
+
+      // The immutable production proxy does not have this selector, so it
+      // cannot provide an authorized route even though it knows the caller.
+      await maintainerProxy
+        .connect(governance)
+        .authorizeSpvMaintainer(spvMaintainer.address)
+      expect(
+        await maintainerProxy.isSpvMaintainer(spvMaintainer.address)
+      ).to.not.equal(0)
+      const legacyProxyReservationBridge = await ethers.getContractAt(
+        "IReservationBridge",
+        maintainerProxy.address
+      )
+      await expect(
+        legacyProxyReservationBridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proof,
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.reverted
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proof,
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.revertedWith("Caller is not SPV maintainer")
+
+      const proxyReservationBridge = await ethers.getContractAt(
+        "IReservationBridge",
+        maintainerProxyV2.address
+      )
+      await expect(
+        proxyReservationBridge
+          .connect(thirdParty)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proof,
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.revertedWith("Caller is not authorized")
+
+      await expect(
+        proxyReservationBridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proof,
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.revertedWith("Caller is not SPV maintainer")
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setSpvMaintainerStatus(maintainerProxyV2.address, true)
+
+      expect(await reimbursementPool.isAuthorized(maintainerProxyV2.address)).to
+        .be.false
+      await expect(
+        proxyReservationBridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proof,
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+      ).to.be.revertedWith("Contract is not authorized for a refund")
+
+      // The strict refund failure rolls the external Bridge settlement back.
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Unknown
+      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 1)).state
+      ).to.equal(ActionState.Pending)
+
+      await reimbursementPool
+        .connect(governance)
+        .authorize(maintainerProxyV2.address)
+
+      const balanceBefore = await ethers.provider.getBalance(
+        spvMaintainer.address
+      )
+      const tx = await proxyReservationBridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proof,
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          1
+        )
+
+      const reservation = await bridge.reservations(reservationKey)
+      await expect(tx)
+        .to.emit(bridge, "ReservationAccepted")
+        .withArgs(
+          reservationKey,
+          1,
+          walletPubKeyHash,
+          thirdParty.address,
+          anchorTx.txHash,
+          anchorAmount,
+          reservation.expiresAt
+        )
+
+      const balanceAfter = await ethers.provider.getBalance(
+        spvMaintainer.address
+      )
+      expect(balanceAfter).to.be.gt(balanceBefore)
+      expect(reservation.state).to.equal(ReservationState.Active)
+    })
+
+    it("keeps the proof offset owner-configurable", async () => {
+      expect(
+        await maintainerProxyV2.submitReservationProofGasOffset()
+      ).to.equal(30000)
+
+      await expect(
+        maintainerProxyV2
+          .connect(thirdParty)
+          .updateReservationProofGasOffset(31000)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
+
+      await expect(
+        maintainerProxyV2
+          .connect(governance)
+          .updateReservationProofGasOffset(31000)
+      )
+        .to.emit(maintainerProxyV2, "ReservationProofGasOffsetUpdated")
+        .withArgs(31000)
+
+      expect(
+        await maintainerProxyV2.submitReservationProofGasOffset()
+      ).to.equal(31000)
+    })
+  })
 
   describe("claim double-spend regression (timeout racing a confirmed redemption)", () => {
     before(async () => {

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -440,6 +440,33 @@ describe("Bridge - Reservation settlement", () => {
       .retryRedeemReservation(reservationKey, redeemerScript)
   }
 
+  async function requestAndTimeoutReanchor(
+    reservationKey: BigNumber,
+    anchorTxHash: string
+  ) {
+    await liveWallet(secondWalletPubKeyHash)
+    await bridge
+      .connect(thirdParty)
+      .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+    const reanchorTx = buildTx(
+      [{ txHash: anchorTxHash, index: 0 }],
+      [
+        {
+          valueSat: anchorAmount.sub(500),
+          script: p2wpkhScript(secondWalletPubKeyHash),
+        },
+      ]
+    )
+
+    await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+    await bridge
+      .connect(thirdParty)
+      .notifyReservationActionTimeout(reservationKey, [])
+
+    return reanchorTx
+  }
+
   describe("claim double-spend regression (timeout racing a confirmed redemption)", () => {
     before(async () => {
       await createSnapshot()
@@ -665,6 +692,11 @@ describe("Bridge - Reservation settlement", () => {
       expect(
         (await bridge.reservationActions(reservationKey, 3)).state
       ).to.equal(ActionState.Superseded)
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).usedRetryCredit
+      ).to.be.true
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
       // Generation 3's escrow returned to its redeemer. (The generation 2
       // timeout refund was re-spent on the retry, so the redeemer's net
       // Bank balance is exactly the unwound escrow.)
@@ -673,6 +705,183 @@ describe("Bridge - Reservation settlement", () => {
       expect((await bridge.reservations(reservationKey)).state).to.equal(
         ReservationState.Closed
       )
+    })
+  })
+
+  describe("retry-credit restoration after a late re-anchor", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("restores a retry credit when the late re-anchor supersedes the retry", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      // Generation 2 is fee-paid. Its timeout refunds the escrow, mints the
+      // one-shot retry credit, and naturally moves the custody wallet into
+      // MovingFunds so anyone can request the migration below.
+      await requestRedemption(reservationKey, randomRedeemerScript())
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+
+      // Generation 3 re-anchors the original reservation output but its
+      // proof is delayed until after the authorization times out.
+      const reanchorTx = await requestAndTimeoutReanchor(
+        reservationKey,
+        anchorTx.txHash
+      )
+
+      // Generation 4 consumes the one-shot credit and escrows the timeout
+      // refund for a fee-free retry against the still-current old anchor.
+      const retryScript = randomRedeemerScript()
+      await retryRedemption(reservationKey, retryScript)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(0)
+      expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
+
+      const retryTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: retryScript.slice(4),
+          },
+        ]
+      )
+
+      // The already-confirmed generation 3 transaction consumes the old
+      // anchor. Generation 4 can never settle, so it is superseded and its
+      // escrow is refunded. The consumed retry entitlement must return to
+      // the now-Active position.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 4)
+      await expect(tx)
+        .to.emit(bridge, "ReservationRetryCreditMinted")
+        .withArgs(reservationKey)
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.retryCredit).to.be.true
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(
+        (await bridge.reservationActions(reservationKey, 4)).state
+      ).to.equal(ActionState.Superseded)
+      expect(
+        (await bridge.reservationActions(reservationKey, 4)).usedRetryCredit
+      ).to.be.true
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(anchorAmount)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      // Supersession is terminal and the escrow was refunded exactly once.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            retryTx.info,
+            proofFor(retryTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            4
+          )
+      ).to.be.revertedWith("Action is not settleable")
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(anchorAmount)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      // The restored entitlement is usable again and is consumed exactly
+      // once by a new fee-free retry against the re-anchored position.
+      await retryRedemption(reservationKey, randomRedeemerScript())
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.ActionPending
+      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 5)).usedRetryCredit
+      ).to.be.true
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(0)
+      expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
+    })
+
+    it("does not mint credit when the superseded redemption paid a fee", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      // Put the source wallet on its ordinary migration path without first
+      // creating a retry entitlement.
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.MovingFunds,
+        movingFundsRequestedAt: await lastBlockTime(),
+      })
+
+      const reanchorTx = await requestAndTimeoutReanchor(
+        reservationKey,
+        anchorTx.txHash
+      )
+
+      // Generation 3 is a fresh fee-paid redemption, not a retry.
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+      expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 3)
+      await expect(tx).not.to.emit(bridge, "ReservationRetryCreditMinted")
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.retryCredit).to.be.false
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).state
+      ).to.equal(ActionState.Superseded)
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).usedRetryCredit
+      ).to.be.false
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(anchorAmount)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, anchorAmount)
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservation(reservationKey, randomRedeemerScript())
+      ).to.be.revertedWith("No retry entitlement")
     })
   })
 

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -830,8 +830,90 @@ describe("Bridge - Reservation settlement", () => {
         .withArgs(second.reservationKey, 2, walletPubKeyHash, secondTx.txHash)
     })
 
+    it("supersedes a cross-reservation lock when a late dissolution consumes its main UTXO", async () => {
+      const first = await makeAcceptedReservation()
+      const second = await makeAcceptedReservation()
+      const mainUtxo = {
+        txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+        txOutputIndex: 0,
+        txOutputValue: 7000000,
+      }
+      await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(first.reservationKey)
+
+      // Generation A times out and releases the wallet lock, but its
+      // confirmed Bitcoin transaction remains late-settleable.
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(first.reservationKey, [])
+
+      // Generation B acquires the lock against the same registry main UTXO.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(second.reservationKey)
+      expect(await bridge.walletPendingDissolution(walletPubKeyHash)).to.equal(
+        second.reservationKey
+      )
+
+      const dissolutionFee = 500
+      const firstTx = buildTx(
+        [
+          { txHash: first.anchorTx.txHash, index: 0 },
+          { txHash: mainUtxo.txHash, index: mainUtxo.txOutputIndex },
+        ],
+        [
+          {
+            valueSat: anchorAmount
+              .add(mainUtxo.txOutputValue)
+              .sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          firstTx.info,
+          proofFor(firstTx.txHash),
+          mainUtxo,
+          first.reservationKey,
+          2
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(second.reservationKey, 2)
+      expect(
+        (await bridge.reservationActions(second.reservationKey, 2)).state
+      ).to.equal(ActionState.Superseded)
+      expect((await bridge.reservations(second.reservationKey)).state).to.equal(
+        ReservationState.Active
+      )
+      expect(await bridge.walletPendingDissolution(walletPubKeyHash)).to.equal(
+        0
+      )
+    })
+
     it("re-registers a drifted dissolution output for the sweep machinery", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: await lastBlockTime(),
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.MovingFunds,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
 
       await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
       await bridge
@@ -854,7 +936,7 @@ describe("Bridge - Reservation settlement", () => {
       const sweepUtxo = {
         txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
         txOutputIndex: 0,
-        txOutputValue: 7777777,
+        txOutputValue: 1,
       }
       await bridge.setWalletMainUtxo(walletPubKeyHash, sweepUtxo)
       const driftedMainUtxoHash = (await bridge.wallets(walletPubKeyHash))
@@ -887,6 +969,60 @@ describe("Bridge - Reservation settlement", () => {
       )
       expect(sweepRequest.walletPubKeyHash).to.equal(walletPubKeyHash)
       expect(sweepRequest.value).to.equal(anchorAmount.sub(dissolutionFee))
+      expect(
+        (await bridge.wallets(walletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(1)
+
+      // The drifted output remains a tracked obligation after the last
+      // reservation closes, so even the below-dust path cannot put the
+      // wallet in Closing and strand the sweep.
+      await expect(
+        bridge.notifyMovingFundsBelowDust(walletPubKeyHash, sweepUtxo)
+      ).to.be.revertedWith("Wallet has pending moved funds sweep requests")
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.MovingFunds
+      )
+
+      // The normal sweep proof path remains available and balances the
+      // counter created by the dissolution settlement.
+      await bridge.setMovedFundsSweepTxMaxTotalFee(2000)
+      const movedFundsSweepTx = buildTx(
+        [
+          { txHash: dissolutionTx.txHash, index: 0 },
+          { txHash: sweepUtxo.txHash, index: sweepUtxo.txOutputIndex },
+        ],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee).sub(500).add(1),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitMovedFundsSweepProof(
+          movedFundsSweepTx.info,
+          proofFor(movedFundsSweepTx.txHash),
+          sweepUtxo
+        )
+
+      expect(
+        (await bridge.wallets(walletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(0)
+      expect(
+        (
+          await bridge.movedFundsSweepRequests(
+            BigNumber.from(
+              ethers.utils.solidityKeccak256(
+                ["bytes32", "uint32"],
+                [dissolutionTx.txHash, 0]
+              )
+            )
+          )
+        ).state
+      ).to.equal(2) // Processed
     })
   })
 
@@ -1193,6 +1329,74 @@ describe("Bridge - Reservation settlement", () => {
       expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
         walletState.MovingFunds
       )
+    })
+
+    it("records a confirmed main-UTXO move while reservation obligations remain", async () => {
+      await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      const mainUtxo = {
+        txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+        txOutputIndex: 0,
+        txOutputValue: 7000000,
+      }
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: await lastBlockTime(),
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.MovingFunds,
+        movingFundsTargetWalletsCommitmentHash: ethers.utils.solidityKeccak256(
+          ["bytes20[]"],
+          [[secondWalletPubKeyHash]]
+        ),
+      })
+      await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+
+      const movingFundsTx = buildTx(
+        [{ txHash: mainUtxo.txHash, index: mainUtxo.txOutputIndex }],
+        [
+          {
+            valueSat: BigNumber.from(mainUtxo.txOutputValue).sub(500),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitMovingFundsProof(
+            movingFundsTx.info,
+            proofFor(movingFundsTx.txHash),
+            mainUtxo,
+            walletPubKeyHash
+          )
+      )
+        .to.emit(bridge, "MovingFundsCompleted")
+        .withArgs(walletPubKeyHash, movingFundsTx.txHash)
+
+      const sourceWallet = await bridge.wallets(walletPubKeyHash)
+      expect(sourceWallet.mainUtxoHash).to.equal(ZERO_BYTES32)
+      expect(sourceWallet.state).to.equal(walletState.MovingFunds)
+
+      const targetRequest = await bridge.movedFundsSweepRequests(
+        BigNumber.from(
+          ethers.utils.solidityKeccak256(
+            ["bytes32", "uint32"],
+            [movingFundsTx.txHash, 0]
+          )
+        )
+      )
+      expect(targetRequest.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(targetRequest.state).to.equal(1) // Pending
+      expect(
+        (await bridge.wallets(secondWalletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(1)
     })
   })
 })

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -1955,10 +1955,9 @@ describe("Bridge - Reservation settlement", () => {
       // The redemption generation is pending with its timeout in the
       // future; notifying the timeout now must revert.
       await expect(
-        bridge.connect(thirdParty).notifyReservationActionTimeout(
-          reservationKey,
-          []
-        )
+        bridge
+          .connect(thirdParty)
+          .notifyReservationActionTimeout(reservationKey, [])
       ).to.be.revertedWith("Action has not timed out")
 
       // And the pending generation is untouched.
@@ -1981,10 +1980,9 @@ describe("Bridge - Reservation settlement", () => {
       // A second notification against the same generation must revert:
       // no double capacity-release / double refund.
       await expect(
-        bridge.connect(thirdParty).notifyReservationActionTimeout(
-          reservationKey,
-          []
-        )
+        bridge
+          .connect(thirdParty)
+          .notifyReservationActionTimeout(reservationKey, [])
       ).to.be.revertedWith("No pending action")
     })
   })
@@ -2109,9 +2107,9 @@ describe("Bridge - Reservation settlement", () => {
       // its reserved deposit.amount capacity; the late proof re-took only
       // the actual anchorAmount. In this fixture depositAmount and
       // anchorAmount differ by the anchorFee, so net total is anchorAmount.
-      expect((await bridge.reservationActions(reservationKey, 2)).state).to.equal(
-        ActionState.Superseded
-      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.Superseded)
       expect(
         (await bridge.reservationParameters()).reservationTotalAmount
       ).to.equal(BigNumber.from(anchorAmount))
@@ -2143,7 +2141,9 @@ describe("Bridge - Reservation settlement", () => {
       // already released the target wallet's reserved count).
       const reanchorTx = await requestAndTimeoutReanchor(
         reservationKey,
-        (await bridge.reservations(reservationKey)).anchorTxHash
+        (
+          await bridge.reservations(reservationKey)
+        ).anchorTxHash
       )
 
       // The target wallet terminates before the late proof lands.
@@ -2449,6 +2449,7 @@ describe("Bridge - Reservation settlement", () => {
             },
           ]
         )
+        // eslint-disable-next-line no-await-in-loop
         await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
           fundingOutputIndex: 0,
           blindingFactor,
@@ -2457,6 +2458,7 @@ describe("Bridge - Reservation settlement", () => {
           refundLocktime,
           vault: reservationVault.address,
         })
+        // eslint-disable-next-line no-await-in-loop
         await bridge
           .connect(thirdParty)
           .requestReservationAcceptance(

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -94,7 +94,7 @@ describe("Bridge - Reservation settlement", () => {
   const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
   const blindingFactor = "0xf9f0c90d00039523"
   const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
-  const refundLocktime = "0x60bcea61"
+  let refundLocktime: string
   const NO_MAIN_UTXO_PARAM = {
     txHash: ZERO_BYTES32,
     txOutputIndex: 0,
@@ -125,6 +125,10 @@ describe("Bridge - Reservation settlement", () => {
     bridgeGovernanceSigner = await impersonateContract(
       await bridge.governance()
     )
+    refundLocktime = `0x${toLE(
+      (await lastBlockTime()) + 4000 * 24 * 60 * 60,
+      4
+    )}`
 
     await bridge
       .connect(bridgeGovernanceSigner)

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -868,6 +868,169 @@ describe("Bridge - Reservation settlement", () => {
       expect(wallet.movingFundsRequestedAt).to.equal(await lastBlockTime())
     })
 
+    it("strands a late dissolution output after the source wallet terminates", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+
+      // The dissolution generation times out and moves the source wallet
+      // into MovingFunds. A subsequent moving-funds timeout terminates the
+      // wallet before the already-confirmed dissolution proof reaches the
+      // Bridge.
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      const { movingFundsTimeout } = await bridge.movingFundsParameters()
+      await increaseTime(movingFundsTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyMovingFundsTimeout(walletPubKeyHash, [])
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.Terminated
+      )
+
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 2, ActionType.Dissolution)
+      await expect(tx)
+        .to.emit(bridge, "ReservationDissolved")
+        .withArgs(reservationKey, 2, walletPubKeyHash, dissolutionTx.txHash)
+
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.state).to.equal(walletState.Terminated)
+      expect(wallet.mainUtxoHash).to.equal(ZERO_BYTES32)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Stranded
+      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.Settled)
+      expect(
+        (await bridge.reservationParameters()).reservationTotalAmount
+      ).to.equal(0)
+      expect(await bridge.walletPendingDissolution(walletPubKeyHash)).to.equal(
+        0
+      )
+
+      const outputKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [dissolutionTx.txHash, 0]
+        )
+      )
+      expect((await bridge.movedFundsSweepRequests(outputKey)).state).to.equal(
+        0
+      )
+      const anchorKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [anchorTx.txHash, 0]
+        )
+      )
+      expect(await bridge.spentMainUTXOs(anchorKey)).to.equal(true)
+    })
+
+    it("clears a consumed main UTXO when a late dissolution settles after termination", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      const mainUtxo = {
+        txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+        txOutputIndex: 1,
+        txOutputValue: 7000000,
+      }
+      await bridge.setWalletMainUtxo(walletPubKeyHash, mainUtxo)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      const { movingFundsTimeout } = await bridge.movingFundsParameters()
+      await increaseTime(movingFundsTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyMovingFundsTimeout(walletPubKeyHash, [])
+
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [
+          { txHash: anchorTx.txHash, index: 0 },
+          { txHash: mainUtxo.txHash, index: mainUtxo.txOutputIndex },
+        ],
+        [
+          {
+            valueSat: anchorAmount
+              .add(mainUtxo.txOutputValue)
+              .sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          mainUtxo,
+          reservationKey,
+          2
+        )
+
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.state).to.equal(walletState.Terminated)
+      expect(wallet.mainUtxoHash).to.equal(ZERO_BYTES32)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Stranded
+      )
+      expect(await bridge.walletPendingDissolution(walletPubKeyHash)).to.equal(
+        0
+      )
+
+      const mainUtxoKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [mainUtxo.txHash, mainUtxo.txOutputIndex]
+        )
+      )
+      expect(await bridge.spentMainUTXOs(mainUtxoKey)).to.equal(true)
+      const outputKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [dissolutionTx.txHash, 0]
+        )
+      )
+      expect((await bridge.movedFundsSweepRequests(outputKey)).state).to.equal(
+        0
+      )
+    })
+
     it("supersedes a cross-reservation lock when a late dissolution consumes its main UTXO", async () => {
       const first = await makeAcceptedReservation()
       const second = await makeAcceptedReservation()
@@ -1341,11 +1504,11 @@ describe("Bridge - Reservation settlement", () => {
   })
 
   describe("wallet lifecycle integration", () => {
-    before(async () => {
+    beforeEach(async () => {
       await createSnapshot()
     })
 
-    after(async () => {
+    afterEach(async () => {
       await restoreSnapshot()
     })
 

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -708,6 +708,229 @@ describe("Bridge - Reservation settlement", () => {
     })
   })
 
+  describe("action source-anchor binding", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects a timed-out re-anchor replay against a later anchor", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      const thirdWalletPubKeyHash = ethers.utils.hexlify(
+        ethers.utils.randomBytes(20)
+      )
+      await liveWallet(secondWalletPubKeyHash)
+      await liveWallet(thirdWalletPubKeyHash)
+      await bridge.setWallet(walletPubKeyHash, {
+        ...(await bridge.wallets(walletPubKeyHash)),
+        state: walletState.MovingFunds,
+        movingFundsRequestedAt: await lastBlockTime(),
+      })
+
+      // Generation 2 authorizes A -> B and times out while its already-
+      // confirmed transaction awaits an SPV proof.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      const firstReanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // Generation 3 authorizes the same source A -> C and also times out.
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, thirdWalletPubKeyHash)
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      const originalAnchorHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTx.txHash, 0]
+      )
+      expect(
+        (await bridge.reservationActions(reservationKey, 2))
+          .sourceAnchorUtxoHash
+      ).to.equal(originalAnchorHash)
+      expect(
+        (await bridge.reservationActions(reservationKey, 3))
+          .sourceAnchorUtxoHash
+      ).to.equal(originalAnchorHash)
+
+      // The genuine, already-confirmed generation-2 transaction remains
+      // late-settleable and advances the tracked anchor from A to B.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            firstReanchorTx.info,
+            proofFor(firstReanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      )
+        .to.emit(bridge, "ReservationReanchored")
+        .withArgs(
+          reservationKey,
+          2,
+          secondWalletPubKeyHash,
+          firstReanchorTx.txHash,
+          anchorAmount.sub(500)
+        )
+
+      // A freshly crafted B -> C transaction has generation 3's shape but
+      // spends an anchor that generation never authorized. Without the
+      // source snapshot it would settle as a valid late generation-3 proof.
+      const replayTx = buildTx(
+        [{ txHash: firstReanchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: p2wpkhScript(thirdWalletPubKeyHash),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            replayTx.info,
+            proofFor(replayTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            3
+          )
+      ).to.be.revertedWith("Action source anchor is no longer current")
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(reservation.anchorTxHash).to.equal(firstReanchorTx.txHash)
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).state
+      ).to.equal(ActionState.TimedOut)
+      expect(
+        await bridge.spentMainUTXOs(
+          BigNumber.from(
+            ethers.utils.solidityKeccak256(
+              ["bytes32", "uint32"],
+              [firstReanchorTx.txHash, 0]
+            )
+          )
+        )
+      ).to.be.false
+    })
+
+    it("rejects an old redemption authorization against a re-anchored output", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      const refundedBalance = await bank.balanceOf(thirdParty.address)
+      const redemptionAction = await bridge.reservationActions(
+        reservationKey,
+        2
+      )
+      expect(redemptionAction.actionDataHash).to.equal(
+        ethers.utils.keccak256(redeemerScript)
+      )
+      expect(redemptionAction.sourceAnchorUtxoHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [anchorTx.txHash, 0]
+        )
+      )
+
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+
+      // This transaction spends the new B anchor and pays the old
+      // redemption script. It must not inherit generation 2's authority.
+      const replayTx = buildTx(
+        [{ txHash: reanchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1500),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            replayTx.info,
+            proofFor(replayTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Action source anchor is no longer current")
+
+      const currentAnchorKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [reanchorTx.txHash, 0]
+        )
+      )
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(reservation.anchorTxHash).to.equal(reanchorTx.txHash)
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.TimedOut)
+      expect(await bridge.spentMainUTXOs(currentAnchorKey)).to.be.false
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(refundedBalance)
+    })
+  })
+
   describe("retry-credit restoration after a late re-anchor", () => {
     beforeEach(async () => {
       await createSnapshot()

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -1,0 +1,1198 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+// Adversarial settlement tests for the two-phase reservation state machine:
+// the claim double-spend regression (timeout racing a confirmed redemption),
+// the late-proof settlement matrix, the on-chain watchtower-delay
+// enforcement, the per-wallet dissolution lock, and the
+// capacity-reserved-before-signing guarantee.
+
+import { ethers, helpers, waffle } from "hardhat"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber, Contract } from "ethers"
+import chai, { expect } from "chai"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+import type {
+  Bank,
+  BankStub,
+  Bridge,
+  BridgeStub,
+  IRelay,
+  ReservationRouter,
+  ReservationVault,
+  TBTCVault,
+  TBTC,
+} from "../../typechain"
+import bridgeFixture from "../fixtures/bridge"
+import { walletState } from "../fixtures"
+
+chai.use(smock.matchers)
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime, increaseTime } = helpers.time
+
+const ZERO_BYTES32 = ethers.constants.HashZero
+
+const RESERVATION_TERM = 31536000 // 365 days
+const RESERVATION_GRACE = 2592000 // 30 days
+const RESERVATION_MIN_AMOUNT = 10000
+const RESERVATION_TX_MAX_FEE = 2000
+const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
+const MAX_RESERVATIONS_PER_WALLET = 10
+const RESERVATION_ACTION_TIMEOUT = 172800 // 48 hours
+
+const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
+
+const ReservationState = {
+  Unknown: 0,
+  Active: 1,
+  ActionPending: 2,
+  Closed: 3,
+  Stranded: 4,
+}
+
+const ActionType = {
+  None: 0,
+  Acceptance: 1,
+  Redemption: 2,
+  Reanchor: 3,
+  Dissolution: 4,
+}
+
+const ActionState = {
+  Unknown: 0,
+  Pending: 1,
+  Settled: 2,
+  TimedOut: 3,
+  Vetoed: 4,
+  Superseded: 5,
+}
+
+const ProofType = {
+  Acceptance: 0,
+  Redemption: 1,
+  Reanchor: 2,
+  Dissolution: 3,
+}
+
+describe("Bridge - Reservation settlement", () => {
+  let governance: SignerWithAddress
+  let spvMaintainer: SignerWithAddress
+  let thirdParty: SignerWithAddress
+  let deployer: SignerWithAddress
+
+  let bank: Bank & BankStub
+  let relay: FakeContract<IRelay>
+  let bridge: Bridge & BridgeStub & ReservationRouter
+  let tbtc: TBTC & Contract
+  let tbtcVault: TBTCVault & Contract
+  let reservationVault: ReservationVault
+  let bridgeGovernanceSigner: SignerWithAddress
+
+  const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+  const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
+  const blindingFactor = "0xf9f0c90d00039523"
+  const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
+  const refundLocktime = "0x60bcea61"
+  const NO_MAIN_UTXO_PARAM = {
+    txHash: ZERO_BYTES32,
+    txOutputIndex: 0,
+    txOutputValue: 0,
+  }
+
+  const depositAmount = BigNumber.from(3000000)
+  const anchorFee = 1500
+  const anchorAmount = depositAmount.sub(anchorFee)
+  const grossTbtc = anchorAmount.mul(SATOSHI_MULTIPLIER)
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      deployer,
+      governance,
+      spvMaintainer,
+      thirdParty,
+      bank,
+      relay,
+      bridge,
+      tbtc,
+      tbtcVault,
+    } = await waffle.loadFixture(bridgeFixture))
+
+    reservationVault = await helpers.contracts.getContract("ReservationVault")
+    bridgeGovernanceSigner = await impersonateContract(
+      await bridge.governance()
+    )
+
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .setVaultStatus(reservationVault.address, true)
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        RESERVATION_ACTION_TIMEOUT
+      )
+
+    relay.getCurrentEpochDifficulty.returns(0)
+    relay.getPrevEpochDifficulty.returns(0)
+
+    await bridge.setDepositDustThreshold(10000)
+    await bridge.setDepositTxMaxFee(2000)
+    await bridge.setDepositRevealAheadPeriod(0)
+    await liveWallet(walletPubKeyHash)
+    await bridge.setLiveWalletsCount(10)
+
+    const tbtcOwner = await impersonateContract(await tbtc.owner())
+    await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+  })
+
+  async function impersonateContract(
+    address: string
+  ): Promise<SignerWithAddress> {
+    await ethers.provider.send("hardhat_impersonateAccount", [address])
+    await ethers.provider.send("hardhat_setBalance", [
+      address,
+      "0x8AC7230489E80000",
+    ])
+    return ethers.getSigner(address)
+  }
+
+  async function liveWallet(pkh: string) {
+    await bridge.setWallet(pkh, {
+      ecdsaWalletID: ethers.utils.randomBytes(32),
+      mainUtxoHash: ZERO_BYTES32,
+      pendingRedemptionsValue: 0,
+      createdAt: await lastBlockTime(),
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+    })
+  }
+
+  // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
+
+  const REGTEST_BITS_LE = "ffff7f20"
+  const REGTEST_TARGET = BigNumber.from("0x7fffff").mul(
+    BigNumber.from(2).pow(8 * (0x20 - 3))
+  )
+
+  const reverseHex = (hex: string): string =>
+    hex.replace(/^0x/, "").match(/../g)!.reverse().join("")
+
+  const hash256 = (hexData: string): string =>
+    ethers.utils.sha256(ethers.utils.sha256(hexData))
+
+  const toLE = (value: number | BigNumber, byteLength: number): string =>
+    reverseHex(
+      BigNumber.from(value)
+        .toHexString()
+        .slice(2)
+        .padStart(byteLength * 2, "0")
+    )
+
+  const compactSize = (n: number): string => {
+    if (n >= 0xfd) {
+      throw new Error("compactSize > 252 not supported in fixtures")
+    }
+    return n.toString(16).padStart(2, "0")
+  }
+
+  function buildTx(
+    inputs: { txHash: string; index: number }[],
+    outputs: { valueSat: BigNumber | number; script: string }[]
+  ) {
+    const inputVector = `0x${compactSize(inputs.length)}${inputs
+      .map((i) => `${i.txHash.slice(2)}${toLE(i.index, 4)}00ffffffff`)
+      .join("")}`
+    const outputVector = `0x${compactSize(outputs.length)}${outputs
+      .map(
+        (o) =>
+          `${toLE(BigNumber.from(o.valueSat), 8)}${compactSize(
+            o.script.length / 2
+          )}${o.script}`
+      )
+      .join("")}`
+    const info = {
+      version: "0x01000000",
+      inputVector,
+      outputVector,
+      locktime: "0x00000000",
+    }
+    const txHash = hash256(
+      `0x01000000${inputVector.slice(2)}${outputVector.slice(2)}00000000`
+    )
+    return { info, txHash }
+  }
+
+  function mineHeader(merkleRoot: string): string {
+    const prevBlock = ethers.utils
+      .hexlify(ethers.utils.randomBytes(32))
+      .slice(2)
+    const base = `20000000${prevBlock}${merkleRoot.slice(
+      2
+    )}662a2c68${REGTEST_BITS_LE}`
+    for (let nonce = 0; ; nonce++) {
+      const header = `0x${base}${toLE(nonce, 4)}`
+      if (
+        BigNumber.from(`0x${reverseHex(hash256(header))}`).lte(REGTEST_TARGET)
+      ) {
+        return header
+      }
+    }
+  }
+
+  function proofFor(txHash: string) {
+    const coinbasePreimage = ethers.utils.sha256(ethers.utils.randomBytes(32))
+    const coinbaseTxId = ethers.utils.sha256(coinbasePreimage)
+    const merkleRoot = hash256(`0x${coinbaseTxId.slice(2)}${txHash.slice(2)}`)
+    return {
+      merkleProof: coinbaseTxId,
+      txIndexInBlock: 1,
+      bitcoinHeaders: mineHeader(merkleRoot),
+      coinbasePreimage,
+      coinbaseProof: txHash,
+    }
+  }
+
+  const buildDepositScript = (
+    depositor: string,
+    blinding: string,
+    walletPkh: string,
+    refundPkh: string,
+    locktime: string
+  ): string =>
+    `14${depositor.slice(2)}7508${blinding.slice(2)}7576a914${walletPkh
+      .slice(2)
+      .toLowerCase()}8763ac6776a914${refundPkh.slice(2)}8804${locktime.slice(
+      2
+    )}b175ac68`
+
+  const p2wshScript = (script: string): string =>
+    `0020${ethers.utils.sha256(`0x${script}`).slice(2)}`
+
+  const p2wpkhScript = (pkh: string): string => `0014${pkh.slice(2)}`
+
+  const randomRedeemerScript = (): string =>
+    `0x16${p2wpkhScript(ethers.utils.hexlify(ethers.utils.randomBytes(20)))}`
+
+  // Reveals a fresh reserved deposit, requests acceptance (generation 1)
+  // and proves the anchor.
+  async function makeAcceptedReservation(custodian = walletPubKeyHash) {
+    const fundingTx = buildTx(
+      [
+        {
+          txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+          index: 0,
+        },
+      ],
+      [
+        {
+          valueSat: depositAmount,
+          script: p2wshScript(
+            buildDepositScript(
+              thirdParty.address,
+              blindingFactor,
+              custodian,
+              refundPubKeyHash,
+              refundLocktime
+            )
+          ),
+        },
+      ]
+    )
+
+    await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+      fundingOutputIndex: 0,
+      blindingFactor,
+      walletPubKeyHash: custodian,
+      refundPubKeyHash,
+      refundLocktime,
+      vault: reservationVault.address,
+    })
+
+    const reservationKey = BigNumber.from(
+      ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.txHash, 0]
+      )
+    )
+
+    await bridge
+      .connect(thirdParty)
+      .requestReservationAcceptance(reservationKey, custodian)
+
+    const anchorTx = buildTx(
+      [{ txHash: fundingTx.txHash, index: 0 }],
+      [{ valueSat: anchorAmount, script: p2wpkhScript(custodian) }]
+    )
+
+    await bridge
+      .connect(spvMaintainer)
+      .submitReservationProof(
+        ProofType.Acceptance,
+        anchorTx.info,
+        proofFor(anchorTx.txHash),
+        NO_MAIN_UTXO_PARAM,
+        reservationKey,
+        1
+      )
+
+    return { fundingTx, anchorTx, reservationKey }
+  }
+
+  // Requests an in-kind redemption of the given accepted reservation via
+  // the real vault flow (fee paid in TBTC).
+  async function requestRedemption(
+    reservationKey: BigNumber,
+    redeemerScript: string
+  ) {
+    const redemptionFee = grossTbtc.mul(20).div(10000)
+    await tbtc
+      .connect(thirdParty)
+      .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+    await reservationVault
+      .connect(thirdParty)
+      .redeemReservation(reservationKey, redeemerScript)
+  }
+
+  // Retries via the Bank-balance path after a timeout refund.
+  async function retryRedemption(
+    reservationKey: BigNumber,
+    redeemerScript: string
+  ) {
+    await bank
+      .connect(thirdParty)
+      .approveBalance(reservationVault.address, anchorAmount)
+    await reservationVault
+      .connect(thirdParty)
+      .retryRedeemReservation(reservationKey, redeemerScript)
+  }
+
+  describe("claim double-spend regression (timeout racing a confirmed redemption)", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("settles the late proof without a second refund and defeats fraud exposure", async () => {
+      // Two acceptances: the second funds the owner with the TBTC needed
+      // for the gross surrender plus fee on the first.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+
+      // The wallet signs and broadcasts; the transaction confirms on
+      // Bitcoin (crafted below) but its proof does not reach the Bridge
+      // before the timeout.
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The timeout refunded the escrowed claim to the redeemer.
+      const redeemerBankBalance = await bank.balanceOf(thirdParty.address)
+      expect(redeemerBankBalance).to.equal(anchorAmount)
+      const bridgeBankBalance = await bank.balanceOf(bridge.address)
+
+      // The late proof settles against the terminal TimedOut record.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 2, ActionType.Redemption)
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, 2, redemptionTx.txHash)
+
+      // No second refund and no burn: the Bank moved nothing during the
+      // late settlement.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        redeemerBankBalance
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(bridgeBankBalance)
+
+      // The lineage is closed and the consumed anchor is registered as
+      // honestly spent, so the wallet's signature defeats any fraud
+      // challenge.
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Closed
+      )
+      expect(
+        await bridge.spentMainUTXOs(
+          BigNumber.from(
+            ethers.utils.solidityKeccak256(
+              ["bytes32", "uint32"],
+              [anchorTx.txHash, 0]
+            )
+          )
+        )
+      ).to.be.true
+
+      // The settled generation cannot be settled twice.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Action is not settleable")
+    })
+  })
+
+  describe("late proof against a position with a newer pending generation", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("forces settlement against a matching pending generation", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The owner retries with the SAME redeemer script (generation 3).
+      await retryRedemption(reservationKey, redeemerScript)
+
+      // The transaction satisfies both generation 2 (timed out) and
+      // generation 3 (pending). The late-settlement path must refuse it:
+      // settling the pending generation burns the escrow, which is the
+      // correct accounting.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Must settle the pending generation")
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, 3, redemptionTx.txHash)
+
+      // The pending settlement burned the escrow.
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+    })
+
+    it("unwinds a non-matching pending generation and refunds its escrow", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+
+      // Generation 2's transaction confirms on Bitcoin.
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The owner retries toward a DIFFERENT redeemer script
+      // (generation 3) -- unaware the old transaction confirmed.
+      const otherScript = randomRedeemerScript()
+      await retryRedemption(reservationKey, otherScript)
+      expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
+
+      // The late proof of generation 2 settles; generation 3 can never
+      // settle (its anchor is gone), so it is unwound and its escrow
+      // refunded.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 3)
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 2, ActionType.Redemption)
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).state
+      ).to.equal(ActionState.Superseded)
+      // Generation 3's escrow returned to its redeemer. (The generation 2
+      // timeout refund was re-spent on the retry, so the redeemer's net
+      // Bank balance is exactly the unwound escrow.)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(anchorAmount)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Closed
+      )
+    })
+  })
+
+  describe("watchtower authorization enforcement in the proof path", () => {
+    let redemptionWatchtower: Contract
+
+    before(async () => {
+      await createSnapshot()
+
+      redemptionWatchtower = await helpers.contracts.getContract(
+        "RedemptionWatchtower"
+      )
+      const watchtowerOwner = await impersonateContract(
+        await redemptionWatchtower.owner()
+      )
+      const guardians = (await ethers.getSigners()).slice(10, 13)
+      await redemptionWatchtower.connect(watchtowerOwner).enableWatchtower(
+        governance.address,
+        guardians.map((g) => g.address)
+      )
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(redemptionWatchtower.address)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects a proof before the delay elapses and accepts it afterwards", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+
+      // A Byzantine wallet signs and broadcasts immediately; the
+      // transaction confirms on Bitcoin. The Bridge must not let it
+      // finalize before the guardians' window closes.
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Watchtower delay has not elapsed")
+
+      // Default delay is 2 hours.
+      await increaseTime(7300)
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, 2, redemptionTx.txHash)
+    })
+
+    it("never settles a vetoed generation", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(reservationKey, redeemerScript)
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const guardians = (await ethers.getSigners()).slice(10, 13)
+      await redemptionWatchtower
+        .connect(guardians[0])
+        .raiseReservedObjection(reservationKey, 2)
+      await redemptionWatchtower
+        .connect(guardians[1])
+        .raiseReservedObjection(reservationKey, 2)
+      await redemptionWatchtower
+        .connect(guardians[2])
+        .raiseReservedObjection(reservationKey, 2)
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.Vetoed)
+
+      // The early-signed transaction is unprovable forever: the signature
+      // stays exposed to the fraud machinery, which is the intended
+      // consequence of signing before authorization.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+      ).to.be.revertedWith("Action is not settleable")
+    })
+  })
+
+  describe("per-wallet dissolution lock (concurrent dissolutions)", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("serializes no-main-UTXO dissolutions of the same wallet", async () => {
+      const first = await makeAcceptedReservation()
+      const second = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(first.reservationKey)
+
+      // The second dissolution of the same wallet is locked out while the
+      // first is in flight.
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationDissolution(second.reservationKey)
+      ).to.be.revertedWith("Another dissolution is pending for the wallet")
+
+      // Settle the first dissolution; its output becomes the main UTXO.
+      const dissolutionFee = 500
+      const firstTx = buildTx(
+        [{ txHash: first.anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          firstTx.info,
+          proofFor(firstTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          first.reservationKey,
+          2
+        )
+
+      // The lock released; the second dissolution can now be requested,
+      // and its snapshot records the new main UTXO -- the second
+      // transaction must spend it (2-in-1-out).
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(second.reservationKey)
+
+      const mainUtxo = {
+        txHash: firstTx.txHash,
+        txOutputIndex: 0,
+        txOutputValue: anchorAmount.sub(dissolutionFee),
+      }
+      const secondTx = buildTx(
+        [
+          { txHash: second.anchorTx.txHash, index: 0 },
+          { txHash: firstTx.txHash, index: 0 },
+        ],
+        [
+          {
+            valueSat: anchorAmount
+              .sub(dissolutionFee)
+              .add(anchorAmount)
+              .sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          secondTx.info,
+          proofFor(secondTx.txHash),
+          mainUtxo,
+          second.reservationKey,
+          2
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationDissolved")
+        .withArgs(second.reservationKey, 2, walletPubKeyHash, secondTx.txHash)
+    })
+
+    it("re-registers a drifted dissolution output for the sweep machinery", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+
+      // The authorized 1-input dissolution confirms on Bitcoin, but before
+      // its proof lands a deposit sweep registers a new main UTXO.
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      const sweepUtxo = {
+        txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+        txOutputIndex: 0,
+        txOutputValue: 7777777,
+      }
+      await bridge.setWalletMainUtxo(walletPubKeyHash, sweepUtxo)
+      const driftedMainUtxoHash = (await bridge.wallets(walletPubKeyHash))
+        .mainUtxoHash
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      await expect(tx).to.emit(bridge, "ReservationDissolved")
+
+      // The wallet's main UTXO is untouched; the dissolution output is
+      // registered as a moved-funds sweep request instead.
+      expect((await bridge.wallets(walletPubKeyHash)).mainUtxoHash).to.equal(
+        driftedMainUtxoHash
+      )
+      const sweepRequest = await bridge.movedFundsSweepRequests(
+        BigNumber.from(
+          ethers.utils.solidityKeccak256(
+            ["bytes32", "uint32"],
+            [dissolutionTx.txHash, 0]
+          )
+        )
+      )
+      expect(sweepRequest.walletPubKeyHash).to.equal(walletPubKeyHash)
+      expect(sweepRequest.value).to.equal(anchorAmount.sub(dissolutionFee))
+    })
+  })
+
+  describe("capacity reserved before signing (fill-then-prove)", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("settles an authorized acceptance even after the caps fill up", async () => {
+      // Authorize an acceptance while capacity is available.
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+
+      // The caps fill up after the authorization (a governance tightening
+      // to the current usage level models any competing fill).
+      const params = await bridge.reservationParameters()
+      await bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        params.reservationTotalAmount, // no room beyond what is reserved
+        MAX_RESERVATIONS_PER_WALLET,
+        RESERVATION_ACTION_TIMEOUT
+      )
+
+      // A new authorization cannot be created any more...
+      const otherFundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(otherFundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            BigNumber.from(
+              ethers.utils.solidityKeccak256(
+                ["bytes32", "uint32"],
+                [otherFundingTx.txHash, 0]
+              )
+            ),
+            walletPubKeyHash
+          )
+      ).to.be.revertedWith("Total reserved amount cap exceeded")
+
+      // ...but the already-authorized (and, on Bitcoin, already signed)
+      // anchor still settles: capacity was reserved before signing.
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          1
+        )
+      await expect(tx).to.emit(bridge, "ReservationAccepted")
+    })
+  })
+
+  describe("acceptance authorization timeout", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("releases capacity, allows re-authorization, and still settles the late anchor", async () => {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+      await bridge
+        .connect(thirdParty)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+
+      const totalBefore = (await bridge.reservationParameters())
+        .reservationTotalAmount
+
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      const timeoutTx = await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      await expect(timeoutTx)
+        .to.emit(bridge, "ReservationActionTimedOut")
+        .withArgs(reservationKey, 1, ActionType.Acceptance)
+
+      // The reserved capacity was released.
+      expect(
+        (await bridge.reservationParameters()).reservationTotalAmount
+      ).to.equal(totalBefore.sub(depositAmount))
+
+      // The anchor -- signed while generation 1 was pending -- confirmed
+      // on Bitcoin anyway. Its late proof still settles and re-takes the
+      // capacity.
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          1
+        )
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 1, ActionType.Acceptance)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Active
+      )
+    })
+  })
+
+  describe("reserved redemption gating", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects requests after the grace period (stranding bound)", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .redeemReservation(reservationKey, randomRedeemerScript())
+      ).to.be.revertedWith("Reservation past grace period")
+    })
+
+    it("rejects requests while the wallet is not Live or MovingFunds", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Terminated,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .redeemReservation(reservationKey, randomRedeemerScript())
+      ).to.be.revertedWith("Wallet must be in Live or MovingFunds state")
+    })
+  })
+
+  describe("wallet lifecycle integration", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("keeps a reservation-holding wallet out of the Closing state", async () => {
+      await makeAcceptedReservation()
+
+      // A redemption-timeout-style transition of the (main-UTXO-less)
+      // wallet must land in MovingFunds, not Closing: the wallet still
+      // custodies an anchor.
+      const secondReservation = await makeAcceptedReservation()
+      const redeemerScript = randomRedeemerScript()
+      await requestRedemption(secondReservation.reservationKey, redeemerScript)
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(secondReservation.reservationKey, [])
+
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.MovingFunds
+      )
+    })
+  })
+})

--- a/solidity/test/bridge/Bridge.Wallets.test.ts
+++ b/solidity/test/bridge/Bridge.Wallets.test.ts
@@ -648,6 +648,43 @@ describe("Bridge - Wallets", () => {
         })
 
         context("when wallet balance is zero", () => {
+          context("when a moved-funds sweep request is pending", () => {
+            const movedFundsUtxo = {
+              txHash:
+                "0x8a5d799af0f9872f435eb49750c953b4257c37df69502b7f38f6367db62034cb",
+              txOutputIndex: 0,
+              txOutputValue: 100000,
+            }
+
+            before(async () => {
+              await createSnapshot()
+              await bridge.setPendingMovedFundsSweepRequest(
+                ecdsaWalletTestData.pubKeyHash160,
+                movedFundsUtxo
+              )
+
+              await bridge
+                .connect(walletRegistry.wallet)
+                .__ecdsaWalletHeartbeatFailedCallback(
+                  ecdsaWalletTestData.walletID,
+                  ecdsaWalletTestData.publicKeyX,
+                  ecdsaWalletTestData.publicKeyY
+                )
+            })
+
+            after(async () => {
+              await restoreSnapshot()
+            })
+
+            it("should retain MovingFunds until the sweep is handled", async () => {
+              const wallet = await bridge.wallets(
+                ecdsaWalletTestData.pubKeyHash160
+              )
+              expect(wallet.state).to.equal(walletState.MovingFunds)
+              expect(wallet.pendingMovedFundsSweepRequestsCount).to.equal(1)
+            })
+          })
+
           context("when wallet is the active one", () => {
             let tx: ContractTransaction
 

--- a/solidity/test/bridge/Bridge.Wallets.test.ts
+++ b/solidity/test/bridge/Bridge.Wallets.test.ts
@@ -1497,6 +1497,7 @@ describe("Bridge - Wallets", () => {
 
         before(async () => {
           await createSnapshot()
+          walletRegistry.closeWallet.reset()
 
           await increaseTime(
             (

--- a/solidity/test/bridge/Deployment.test.ts
+++ b/solidity/test/bridge/Deployment.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
-import { deployments, ethers, helpers, upgrades } from "hardhat"
+import hre, { deployments, ethers, helpers, upgrades } from "hardhat"
 import chai, { expect } from "chai"
 import chaiAsPromised from "chai-as-promised"
 
@@ -12,15 +12,18 @@ import type {
   TBTCVault,
   TBTC,
   MaintainerProxy,
+  MaintainerProxyV2,
   ReimbursementPool,
   WalletRegistry,
   VendingMachine,
 } from "../../typechain"
 import type { TransparentUpgradeableProxy } from "../../typechain/TransparentUpgradeableProxy"
+import deployMaintainerProxyV2 from "../../deploy/96_deploy_maintainer_proxy_v2"
 
 chai.use(chaiAsPromised)
 
 const { AddressZero } = ethers.constants
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
 describe("Deployment", async () => {
   let deployer: SignerWithAddress
@@ -37,6 +40,7 @@ describe("Deployment", async () => {
   let tbtcVault: TBTCVault
   let tbtc: TBTC
   let maintainerProxy: MaintainerProxy
+  let maintainerProxyV2: MaintainerProxyV2
   let reimbursementPool: ReimbursementPool
   let walletRegistry: WalletRegistry
   let vendingMachine: VendingMachine
@@ -70,6 +74,7 @@ describe("Deployment", async () => {
     tbtcVault = await helpers.contracts.getContract("TBTCVault")
     tbtc = await helpers.contracts.getContract("TBTC")
     maintainerProxy = await helpers.contracts.getContract("MaintainerProxy")
+    maintainerProxyV2 = await helpers.contracts.getContract("MaintainerProxyV2")
     reimbursementPool = await helpers.contracts.getContract("ReimbursementPool")
     walletRegistry = await helpers.contracts.getContract("WalletRegistry")
     vendingMachine = await helpers.contracts.getContract("VendingMachine")
@@ -235,6 +240,72 @@ describe("Deployment", async () => {
         await maintainerProxy.owner(),
         "invalid MaintainerProxy owner"
       ).equal(governance.address)
+    })
+  })
+
+  describe("MaintainerProxyV2", () => {
+    it("should set Bridge reference", async () => {
+      expect(await maintainerProxyV2.bridge(), "invalid Bridge address").equal(
+        bridge.address
+      )
+    })
+
+    it("should set ReimbursementPool reference", async () => {
+      expect(
+        await maintainerProxyV2.reimbursementPool(),
+        "invalid ReimbursementPool address"
+      ).equal(reimbursementPool.address)
+    })
+
+    it("should set owner", async () => {
+      expect(await maintainerProxyV2.owner(), "invalid owner").equal(
+        governance.address
+      )
+    })
+
+    it("should set reservation proof gas offset", async () => {
+      expect(
+        await maintainerProxyV2.submitReservationProofGasOffset(),
+        "invalid reservation proof gas offset"
+      ).equal(30000)
+    })
+
+    describe("deployment resume", () => {
+      before(async () => {
+        await createSnapshot()
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should idempotently migrate SPV maintainers before handing ownership off", async () => {
+        expect(await maintainerProxy.isSpvMaintainer(esdm.address)).to.equal(0)
+        await maintainerProxy
+          .connect(governance)
+          .authorizeSpvMaintainer(esdm.address)
+
+        await maintainerProxyV2
+          .connect(governance)
+          .transferOwnership(deployer.address)
+
+        await deployMaintainerProxyV2(hre)
+
+        expect(
+          await maintainerProxyV2.isSpvMaintainer(esdm.address)
+        ).to.not.equal(0)
+        expect(await maintainerProxyV2.owner()).to.equal(governance.address)
+
+        const maintainersCount = (await maintainerProxyV2.allSpvMaintainers())
+          .length
+
+        await deployMaintainerProxyV2(hre)
+
+        expect((await maintainerProxyV2.allSpvMaintainers()).length).to.equal(
+          maintainersCount
+        )
+        expect(await maintainerProxyV2.owner()).to.equal(governance.address)
+      })
     })
   })
 

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -51,7 +51,7 @@ async function getStorageLayout(
   if (!layout) {
     throw new Error(
       `No storage layout for ${sourceName}:${contractName}; ` +
-        `is the storageLayout output selection enabled?`
+        "is the storageLayout output selection enabled?"
     )
   }
   return layout

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -1,0 +1,363 @@
+import { artifacts, ethers, helpers, waffle } from "hardhat"
+import { expect } from "chai"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+
+import bridgeFixture from "../fixtures/bridge"
+import type { Bridge, BridgeStub, ReservationRouter } from "../../typechain"
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+
+/**
+ * Storage layout entry as reported by solc's `storageLayout` output.
+ */
+type StorageEntry = {
+  label: string
+  offset: number
+  slot: string
+  type: string
+}
+
+type StorageLayout = {
+  storage: StorageEntry[]
+  types: Record<
+    string,
+    {
+      label: string
+      encoding: string
+      numberOfBytes: string
+      members?: StorageEntry[]
+      key?: string
+      value?: string
+      base?: string
+    }
+  >
+}
+
+async function getStorageLayout(
+  sourceName: string,
+  contractName: string
+): Promise<StorageLayout> {
+  const buildInfo = await artifacts.getBuildInfo(
+    `${sourceName}:${contractName}`
+  )
+  if (!buildInfo) {
+    throw new Error(`No build info for ${sourceName}:${contractName}`)
+  }
+  const layout = (
+    buildInfo.output.contracts[sourceName][contractName] as {
+      storageLayout?: StorageLayout
+    }
+  ).storageLayout
+  if (!layout) {
+    throw new Error(
+      `No storage layout for ${sourceName}:${contractName}; ` +
+        `is the storageLayout output selection enabled?`
+    )
+  }
+  return layout
+}
+
+/**
+ * Produces a compilation-independent canonical description of a storage
+ * type: solc type identifiers embed AST ids (e.g.
+ * `t_struct(Storage)12345_storage`) that differ between compilation units,
+ * so the identifiers are normalized and struct members are expanded
+ * recursively.
+ */
+function canonicalType(
+  typeId: string,
+  types: StorageLayout["types"],
+  seen: Set<string> = new Set()
+): unknown {
+  const normalized = typeId.replace(/\)\d+/g, ")")
+  if (seen.has(typeId)) {
+    return normalized
+  }
+  seen.add(typeId)
+
+  const type = types[typeId]
+  if (!type) {
+    return normalized
+  }
+
+  const result: Record<string, unknown> = {
+    id: normalized,
+    encoding: type.encoding,
+    numberOfBytes: type.numberOfBytes,
+  }
+  if (type.members) {
+    result.members = type.members.map((member) => ({
+      label: member.label,
+      slot: member.slot,
+      offset: member.offset,
+      type: canonicalType(member.type, types, seen),
+    }))
+  }
+  if (type.key) {
+    result.key = canonicalType(type.key, types, seen)
+  }
+  if (type.value) {
+    result.value = canonicalType(type.value, types, seen)
+  }
+  if (type.base) {
+    result.base = canonicalType(type.base, types, seen)
+  }
+  return result
+}
+
+function canonicalLayout(layout: StorageLayout): unknown {
+  return layout.storage.map((entry) => ({
+    label: entry.label,
+    slot: entry.slot,
+    offset: entry.offset,
+    type: canonicalType(entry.type, layout.types),
+  }))
+}
+
+describe("ReservationRouter", () => {
+  let governance: SignerWithAddress
+  let thirdParty: SignerWithAddress
+  let deployer: SignerWithAddress
+  let bridge: Bridge & BridgeStub & ReservationRouter
+  let deployBridge: (
+    txProofDifficultyFactor: number,
+    wireReservationRouter?: boolean
+  ) => Promise<any>
+  let routerAddress: string
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ governance, thirdParty, deployer, bridge, deployBridge } =
+      await waffle.loadFixture(bridgeFixture))
+
+    routerAddress = (await helpers.contracts.getContract("ReservationRouter"))
+      .address
+  })
+
+  describe("storage layout parity", () => {
+    it("should give the router the exact storage layout of the Bridge", async () => {
+      const bridgeLayout = await getStorageLayout(
+        "contracts/bridge/Bridge.sol",
+        "Bridge"
+      )
+      const routerLayout = await getStorageLayout(
+        "contracts/bridge/ReservationRouter.sol",
+        "ReservationRouter"
+      )
+
+      // Every storage variable reachable by router code must live at the
+      // same slot/offset and have the same canonical type as in the Bridge.
+      // The Bridge and the router are compiled in different compilation
+      // units, hence the comparison of canonicalized layouts rather than
+      // raw solc output.
+      expect(canonicalLayout(routerLayout)).to.deep.equal(
+        canonicalLayout(bridgeLayout)
+      )
+    })
+
+    it("should keep the BridgeStub used in tests layout-compatible", async () => {
+      const bridgeLayout = await getStorageLayout(
+        "contracts/bridge/Bridge.sol",
+        "Bridge"
+      )
+      const stubLayout = await getStorageLayout(
+        "contracts/test/BridgeStub.sol",
+        "BridgeStub"
+      )
+
+      // The stub may append storage after the Bridge's own variables but
+      // must never alter the shared prefix.
+      const prefix = stubLayout.storage.slice(0, bridgeLayout.storage.length)
+      expect(
+        canonicalLayout({ storage: prefix, types: stubLayout.types })
+      ).to.deep.equal(canonicalLayout(bridgeLayout))
+    })
+  })
+
+  describe("selector disjointness", () => {
+    it("should not shadow any router function with a Bridge function", async () => {
+      const bridgeArtifact = await artifacts.readArtifact("Bridge")
+      const routerArtifact = await artifacts.readArtifact("ReservationRouter")
+
+      const bridgeInterface = new ethers.utils.Interface(bridgeArtifact.abi)
+      const routerInterface = new ethers.utils.Interface(routerArtifact.abi)
+
+      const bridgeSelectors = new Set(
+        Object.values(bridgeInterface.functions).map((fragment) =>
+          bridgeInterface.getSighash(fragment)
+        )
+      )
+
+      const shadowed = Object.values(routerInterface.functions).filter(
+        (fragment) => bridgeSelectors.has(routerInterface.getSighash(fragment))
+      )
+
+      // The `Governable` base is inherited by both contracts for storage
+      // parity, so its two members are declared on both sides with
+      // identical semantics. The Bridge's own copies win and the router's
+      // are unreachable, which is exactly the intent. Anything else
+      // overlapping means a router function is silently unreachable.
+      const knownIdenticalInherited = new Set([
+        "governance()",
+        "transferGovernance(address)",
+      ])
+
+      expect(
+        shadowed
+          .map((fragment) => fragment.format())
+          .filter((signature) => !knownIdenticalInherited.has(signature)),
+        "router functions unreachable behind identical Bridge selectors"
+      ).to.be.empty
+    })
+  })
+
+  describe("setReservationRouter", () => {
+    context("when called on a bridge with the router already set", () => {
+      it("should revert", async () => {
+        // A fresh bridge is governed by the deployer (the main bridge's
+        // governance was transferred to the BridgeGovernance contract by
+        // the deployment scripts).
+        const [freshBridge] = await deployBridge(1)
+        await expect(
+          freshBridge.connect(deployer).setReservationRouter(routerAddress)
+        ).to.be.revertedWith("Reservation router already set")
+      })
+    })
+
+    context("when called by a third party on a fresh bridge", () => {
+      it("should revert", async () => {
+        const [freshBridge] = await deployBridge(1, false)
+        await expect(
+          freshBridge.connect(thirdParty).setReservationRouter(routerAddress)
+        ).to.be.revertedWith("Caller is not the governance")
+      })
+    })
+
+    context("when called with the zero address", () => {
+      it("should revert", async () => {
+        const [freshBridge] = await deployBridge(1, false)
+        await expect(
+          freshBridge
+            .connect(deployer)
+            .setReservationRouter(ethers.constants.AddressZero)
+        ).to.be.revertedWith("Reservation router address must not be 0x0")
+      })
+    })
+
+    context("when called by the governance on a fresh bridge", () => {
+      it("should set the router and emit ReservationRouterSet", async () => {
+        const [freshBridge] = await deployBridge(1, false)
+        const tx = await freshBridge
+          .connect(deployer)
+          .setReservationRouter(routerAddress)
+
+        // The event is declared in the BridgeState library; resolve it
+        // through the router-merged interface of the main bridge handle.
+        await expect(tx)
+          .to.emit(bridge.attach(freshBridge.address), "ReservationRouterSet")
+          .withArgs(routerAddress)
+
+        expect(
+          await bridge.attach(freshBridge.address).reservationRouter()
+        ).to.equal(routerAddress)
+      })
+    })
+  })
+
+  describe("fallback routing", () => {
+    context("before the router is set", () => {
+      it("should revert reservation calls with a clear error", async () => {
+        const [freshBridge] = await deployBridge(1, false)
+        const routed = bridge.attach(freshBridge.address)
+        await expect(routed.reservationParameters()).to.be.revertedWith(
+          "Unknown function"
+        )
+      })
+    })
+
+    context("after the router is set", () => {
+      it("should serve the reservation surface at the Bridge address", async () => {
+        // The fixture wires the router, so the reservation views must
+        // resolve through the fallback and read Bridge storage.
+        expect(await bridge.reservationRouter()).to.equal(routerAddress)
+
+        const params = await bridge.reservationParameters()
+        expect(params.reservationVault).to.be.properAddress
+      })
+
+      it("should revert unknown selectors without executing anything", async () => {
+        await createSnapshot()
+        try {
+          await expect(
+            thirdParty.sendTransaction({
+              to: bridge.address,
+              data: "0xdeadbeef",
+            })
+          ).to.be.reverted
+        } finally {
+          await restoreSnapshot()
+        }
+      })
+
+      it("should not accept plain value transfers", async () => {
+        await expect(
+          thirdParty.sendTransaction({
+            to: bridge.address,
+            value: 1,
+          })
+        ).to.be.reverted
+      })
+    })
+  })
+
+  describe("standalone router hardening", () => {
+    let standaloneRouter: ReservationRouter
+
+    before(async () => {
+      standaloneRouter = (await ethers.getContractAt(
+        "ReservationRouter",
+        routerAddress
+      )) as ReservationRouter
+    })
+
+    it("should have empty storage of its own", async () => {
+      // Direct calls execute on the router's own storage where nothing has
+      // ever been initialized.
+      expect(await standaloneRouter.reservationRouter()).to.equal(
+        ethers.constants.AddressZero
+      )
+      const params = await standaloneRouter.reservationParameters()
+      expect(params.reservationVault).to.equal(ethers.constants.AddressZero)
+    })
+
+    it("should reject state-changing calls made directly", async () => {
+      await expect(
+        standaloneRouter
+          .connect(thirdParty)
+          .updateReservationParameters(
+            ethers.constants.AddressZero,
+            1000000,
+            10000,
+            31536000,
+            2592000,
+            100000000000,
+            10
+          )
+      ).to.be.revertedWith("Caller is not the governance")
+
+      await expect(
+        standaloneRouter.connect(thirdParty).extendReservation(1)
+      ).to.be.revertedWith("Caller is not the reservation vault")
+
+      await expect(
+        standaloneRouter
+          .connect(thirdParty)
+          .requestReservedRedemption(1, thirdParty.address, "0x1600144b47c798")
+      ).to.be.revertedWith("Caller is not the reservation vault")
+
+      await expect(
+        standaloneRouter.connect(thirdParty).notifyReservedRedemptionVeto(1)
+      ).to.be.revertedWith("Caller is not the redemption watchtower")
+    })
+  })
+})

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -165,7 +165,9 @@ describe("ReservationRouter", () => {
           const members = candidate.types[selfEntry.type].members as
             | StorageEntry[]
             | undefined
-          return members?.some((member) => member.label === "reservedDeposits")
+          return members?.some(
+            (member) => member.label === "pendingReservedDeposit"
+          )
             ? candidate
             : matchingLayout
         },

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -341,7 +341,8 @@ describe("ReservationRouter", () => {
             31536000,
             2592000,
             100000000000,
-            10
+            10,
+            172800
           )
       ).to.be.revertedWith("Caller is not the governance")
 
@@ -352,12 +353,27 @@ describe("ReservationRouter", () => {
       await expect(
         standaloneRouter
           .connect(thirdParty)
-          .requestReservedRedemption(1, thirdParty.address, "0x1600144b47c798")
+          .requestReservedRedemption(
+            1,
+            thirdParty.address,
+            "0x1600144b47c798",
+            true,
+            false
+          )
       ).to.be.revertedWith("Caller is not the reservation vault")
 
       await expect(
-        standaloneRouter.connect(thirdParty).notifyReservedRedemptionVeto(1)
+        standaloneRouter.connect(thirdParty).notifyReservedRedemptionVeto(1, 1)
       ).to.be.revertedWith("Caller is not the redemption watchtower")
+
+      await expect(
+        standaloneRouter
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            1,
+            "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+          )
+      ).to.be.revertedWith("Reservations are disabled")
     })
   })
 })

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -241,6 +241,59 @@ describe("ReservationRouter", () => {
             .connect(deployer)
             .setReservationRouter(ethers.constants.AddressZero)
         ).to.be.revertedWith("Reservation router address must not be 0x0")
+
+        await freshBridge.connect(deployer).setReservationRouter(routerAddress)
+        expect(
+          await bridge.attach(freshBridge.address).reservationRouter()
+        ).to.equal(routerAddress)
+      })
+    })
+
+    context("when called with an EOA", () => {
+      it("should revert without consuming the one-time slot", async () => {
+        const [freshBridge] = await deployBridge(1, false)
+
+        await expect(
+          freshBridge.connect(deployer).setReservationRouter(thirdParty.address)
+        ).to.be.revertedWith("Reservation router must be a contract")
+
+        await freshBridge.connect(deployer).setReservationRouter(routerAddress)
+        expect(
+          await bridge.attach(freshBridge.address).reservationRouter()
+        ).to.equal(routerAddress)
+      })
+    })
+
+    context("when called with a not-yet-deployed address", () => {
+      it("should revert without consuming the one-time slot", async () => {
+        const [freshBridge] = await deployBridge(1, false)
+        const notYetDeployedAddress = ethers.utils.getContractAddress({
+          from: thirdParty.address,
+          nonce: await thirdParty.getTransactionCount(),
+        })
+
+        expect(await ethers.provider.getCode(notYetDeployedAddress)).to.equal(
+          "0x"
+        )
+        await expect(
+          freshBridge
+            .connect(deployer)
+            .setReservationRouter(notYetDeployedAddress)
+        ).to.be.revertedWith("Reservation router must be a contract")
+        expect(await ethers.provider.getCode(notYetDeployedAddress)).to.equal(
+          "0x"
+        )
+        expect(
+          ethers.utils.getContractAddress({
+            from: thirdParty.address,
+            nonce: await thirdParty.getTransactionCount(),
+          })
+        ).to.equal(notYetDeployedAddress)
+
+        await freshBridge.connect(deployer).setReservationRouter(routerAddress)
+        expect(
+          await bridge.attach(freshBridge.address).reservationRouter()
+        ).to.equal(routerAddress)
       })
     })
 
@@ -260,6 +313,10 @@ describe("ReservationRouter", () => {
         expect(
           await bridge.attach(freshBridge.address).reservationRouter()
         ).to.equal(routerAddress)
+
+        await expect(
+          freshBridge.connect(deployer).setReservationRouter(routerAddress)
+        ).to.be.revertedWith("Reservation router already set")
       })
     })
   })

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -1,6 +1,13 @@
 import { artifacts, ethers, helpers, waffle } from "hardhat"
 import { expect } from "chai"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import * as fs from "fs"
+import * as path from "path"
+import { getStorageUpgradeErrors } from "@openzeppelin/upgrades-core"
+import { normalizeValidationData } from "@openzeppelin/upgrades-core/dist/validate/data"
+import type { ValidationData } from "@openzeppelin/upgrades-core/dist/validate/data"
+import { unfoldStorageLayout } from "@openzeppelin/upgrades-core/dist/validate/query"
+import type { StorageLayout as OZStorageLayout } from "@openzeppelin/upgrades-core/dist/storage/layout"
 
 import bridgeFixture from "../fixtures/bridge"
 import type { Bridge, BridgeStub, ReservationRouter } from "../../typechain"
@@ -135,6 +142,93 @@ describe("ReservationRouter", () => {
   })
 
   describe("storage layout parity", () => {
+    it("should pass the OpenZeppelin upgrade check from the deployed Bridge gap", () => {
+      const validations = normalizeValidationData(
+        JSON.parse(
+          fs.readFileSync(
+            path.resolve(__dirname, "../../cache/validations.json"),
+            "utf8"
+          )
+        ) as ValidationData
+      )
+
+      const currentLayout = validations.log.reduce<OZStorageLayout | undefined>(
+        (matchingLayout, run) => {
+          if (!run.Bridge) return matchingLayout
+
+          const candidate = unfoldStorageLayout(run, "Bridge")
+          const selfEntry = candidate.storage.find(
+            (entry) => entry.label === "self"
+          )
+          if (!selfEntry) return matchingLayout
+
+          const members = candidate.types[selfEntry.type].members as
+            | StorageEntry[]
+            | undefined
+          return members?.some((member) => member.label === "reservedDeposits")
+            ? candidate
+            : matchingLayout
+        },
+        undefined
+      )
+
+      expect(currentLayout, "compiled Bridge validation layout").not.to.be
+        .undefined
+
+      const selfEntry = currentLayout!.storage.find(
+        (entry) => entry.label === "self"
+      )!
+      const members = currentLayout!.types[selfEntry.type]
+        .members as StorageEntry[]
+      const rebateStakingIndex = members.findIndex(
+        (member) => member.label === "rebateStaking"
+      )
+      expect(rebateStakingIndex).to.be.greaterThan(-1)
+
+      const currentGap = members.find((member) => member.label === "__gap")!
+      expect(currentGap.slot).to.equal("39")
+      expect(currentLayout!.types[currentGap.type].label).to.equal(
+        "uint256[39]"
+      )
+
+      const asStorageItem = (entry: StorageEntry) => ({
+        ...entry,
+        contract: "Bridge",
+        src: "compiled-layout",
+      })
+      const legacyGap = {
+        label: "__gap",
+        slot: "30",
+        offset: 0,
+        type: "t_array(t_uint256)48_storage",
+        contract: "Bridge",
+        src: "deployed-layout",
+      }
+      const legacyTypes = {
+        ...currentLayout!.types,
+        [legacyGap.type]: {
+          label: "uint256[48]",
+          numberOfBytes: "1536",
+        },
+      }
+
+      const errors = getStorageUpgradeErrors(
+        {
+          storage: [
+            ...members.slice(0, rebateStakingIndex + 1).map(asStorageItem),
+            legacyGap,
+          ],
+          types: legacyTypes,
+        },
+        {
+          storage: members.map(asStorageItem),
+          types: currentLayout!.types,
+        }
+      )
+
+      expect(errors).to.deep.equal([])
+    })
+
     it("should give the router the exact storage layout of the Bridge", async () => {
       const bridgeLayout = await getStorageLayout(
         "contracts/bridge/Bridge.sol",

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -1,5 +1,5 @@
 import crypto from "crypto"
-import { ethers, helpers } from "hardhat"
+import { artifacts, ethers, helpers } from "hardhat"
 import chai, { expect } from "chai"
 import { FakeContract, smock } from "@defi-wonderland/smock"
 import { BigNumber, BigNumberish, BytesLike } from "ethers"
@@ -41,7 +41,27 @@ describe("WalletProposalValidator", () => {
   before(async () => {
     const { deployer } = await helpers.signers.getNamedSigners()
 
-    bridge = await smock.fake<Bridge>("Bridge")
+    // The validator consults the UTXO-reservation surface, which lives in
+    // the ReservationRouter and is reached through the Bridge's fallback at
+    // the Bridge address. Build the fake from the merged ABI so those calls
+    // return zeroed defaults (reservations disabled) instead of reverting.
+    const bridgeAbi = (await artifacts.readArtifact("Bridge")).abi
+    const routerAbi = (await artifacts.readArtifact("ReservationRouter")).abi
+    const bridgeInterface = new ethers.utils.Interface(bridgeAbi)
+    const bridgeSignatures = new Set(
+      bridgeInterface.fragments
+        .filter((f) => f.type === "function" || f.type === "event")
+        .map((f) => f.format())
+    )
+    const routerExtras = new ethers.utils.Interface(routerAbi).fragments.filter(
+      (f) =>
+        (f.type === "function" || f.type === "event") &&
+        !bridgeSignatures.has(f.format())
+    )
+    bridge = await smock.fake<Bridge>([
+      ...bridgeInterface.fragments,
+      ...routerExtras,
+    ])
 
     const WalletProposalValidator = await ethers.getContractFactory(
       "WalletProposalValidator"

--- a/solidity/test/bridge/WalletProposalValidator.test.ts
+++ b/solidity/test/bridge/WalletProposalValidator.test.ts
@@ -2620,10 +2620,6 @@ describe("WalletProposalValidator", () => {
           walletState: walletState.Unknown,
         },
         {
-          testName: "when wallet state is Closing",
-          walletState: walletState.Closing,
-        },
-        {
           testName: "when wallet state is Closed",
           walletState: walletState.Closed,
         },
@@ -2666,7 +2662,7 @@ describe("WalletProposalValidator", () => {
                 movedFundsSweepTxFee: 0,
               })
             ).to.be.revertedWith(
-              "Source wallet is not in Live or MovingFunds state"
+              "Sweeping wallet is not in Live or MovingFunds or Closing state"
             )
           })
         })
@@ -2682,6 +2678,10 @@ describe("WalletProposalValidator", () => {
         {
           testName: "when wallet state is MovingFunds",
           walletState: walletState.MovingFunds,
+        },
+        {
+          testName: "when wallet state is Closing",
+          walletState: walletState.Closing,
         },
       ]
 

--- a/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
+++ b/solidity/test/deploy/85_deploy_tip109_governance_upgrade.test.ts
@@ -260,7 +260,7 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(directBridgeCall).to.be.undefined
       })
 
-      it("should define all 7 required libraries for Bridge implementation deployment", async () => {
+      it("should define all 6 required libraries for Bridge implementation deployment", async () => {
         await func(mockHre)
 
         const bridgeCall = deployCalls.find(
@@ -278,10 +278,9 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
           "Wallets",
           "Fraud",
           "MovingFunds",
-          "Reservation",
         ]
         const actualKeys = Object.keys(libraries)
-        expect(actualKeys).to.have.lengthOf(7)
+        expect(actualKeys).to.have.lengthOf(6)
 
         expectedLibKeys.forEach((key) => {
           expect(libraries).to.have.property(key)
@@ -295,7 +294,6 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         expect(libraries.Wallets).to.equal(WALLETS_ADDRESS)
         expect(libraries.Fraud).to.equal(FRAUD_ADDRESS)
         expect(libraries.MovingFunds).to.equal(MOVING_FUNDS_ADDRESS)
-        expect(libraries.Reservation).to.equal(RESERVATION_ADDRESS)
       })
 
       it("should deploy RebateStaking implementation with distinct artifact name", async () => {
@@ -777,11 +775,11 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
       })
     })
 
-    it("should have libraries with all 7 entries", () => {
+    it("should have libraries with all 6 entries", () => {
       expect(summary).to.not.be.null
       const libs = summary.libraries
 
-      expect(Object.keys(libs)).to.have.lengthOf(7)
+      expect(Object.keys(libs)).to.have.lengthOf(6)
 
       const requiredKeys = [
         "Deposit",
@@ -790,7 +788,6 @@ describe("Deploy Script 85: TIP-109 Governance Upgrade", () => {
         "Wallets",
         "Fraud",
         "MovingFunds",
-        "Reservation",
       ]
 
       requiredKeys.forEach((key) => {

--- a/solidity/test/fixtures/bridge.ts
+++ b/solidity/test/fixtures/bridge.ts
@@ -17,8 +17,48 @@ import type {
   IRelay,
   RedemptionWatchtower,
   RebateStaking,
+  ReservationRouter,
   IERC20,
 } from "../../typechain"
+
+/**
+ * The UTXO-reservation surface lives in the ReservationRouter and is reached
+ * through the Bridge's fallback via delegatecall, so it is callable at the
+ * Bridge address but absent from the Bridge artifact ABI. This helper
+ * overlays the router ABI on a Bridge contract handle so tests can keep
+ * calling the full surface on a single object.
+ */
+export async function attachReservationRouter<T>(
+  bridgeContract: T & { address: string }
+): Promise<T & ReservationRouter> {
+  const routerArtifact = await deployments.getArtifact("ReservationRouter")
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const bridgeAbi = (bridgeContract as any).interface.fragments
+  const bridgeSignatures = new Set(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    bridgeAbi.map((f: any) => f.format())
+  )
+  const routerFragments = new ethers.utils.Interface(
+    routerArtifact.abi
+  ).fragments.filter(
+    (f) =>
+      (f.type === "function" || f.type === "event") &&
+      // Fragments both sides declare (`Initialized`, `governance()`, ...)
+      // are dropped from the router side to avoid ethers' duplicate
+      // definition warnings.
+      !bridgeSignatures.has(f.format())
+  )
+  const mergedInterface = new ethers.utils.Interface([
+    ...bridgeAbi,
+    ...routerFragments,
+  ])
+  return new ethers.Contract(
+    bridgeContract.address,
+    mergedInterface,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (bridgeContract as any).signer ?? (bridgeContract as any).provider
+  ) as T & ReservationRouter
+}
 
 /**
  * Common fixture for tests suites targeting the Bridge contract.
@@ -37,12 +77,15 @@ export default async function bridgeFixture(): Promise<{
   bank: Bank & BankStub
   relay: FakeContract<IRelay>
   walletRegistry: FakeContract<IWalletRegistry>
-  bridge: Bridge & BridgeStub
+  bridge: Bridge & BridgeStub & ReservationRouter
   reimbursementPool: ReimbursementPool
   maintainerProxy: MaintainerProxy
   bridgeGovernance: BridgeGovernance
   redemptionWatchtower: RedemptionWatchtower
-  deployBridge: (txProofDifficultyFactor: number) => Promise<any>
+  deployBridge: (
+    txProofDifficultyFactor: number,
+    wireReservationRouter?: boolean
+  ) => Promise<any>
 }> {
   await deployments.fixture()
 
@@ -75,9 +118,10 @@ export default async function bridgeFixture(): Promise<{
     "RebateStaking"
   )
 
-  const bridge: Bridge & BridgeStub = await helpers.contracts.getContract(
-    "Bridge"
-  )
+  const bridge: Bridge & BridgeStub & ReservationRouter =
+    await attachReservationRouter<Bridge & BridgeStub>(
+      await helpers.contracts.getContract("Bridge")
+    )
 
   const bridgeGovernance: BridgeGovernance =
     await helpers.contracts.getContract("BridgeGovernance")
@@ -112,42 +156,70 @@ export default async function bridgeFixture(): Promise<{
   // specify txProofDifficultyFactor. The new instance is deployed with
   // a random name to do not conflict with the main deployed instance.
   // Same parameters as in `05_deploy_bridge.ts` deployment script are used.
-  const deployBridge = async (txProofDifficultyFactor: number) =>
-    helpers.upgrades.deployProxy(`Bridge_${randomBytes(8).toString("hex")}`, {
-      contractName: "BridgeStub",
-      initializerArgs: [
-        bank.address,
-        relay.address,
-        treasury.address,
-        walletRegistry.address,
-        reimbursementPool.address,
-        txProofDifficultyFactor,
-      ],
-      factoryOpts: {
-        signer: deployer,
-        libraries: {
-          Deposit: (await helpers.contracts.getContract("Deposit")).address,
-          DepositSweep: (await helpers.contracts.getContract("DepositSweep"))
-            .address,
-          Redemption: (await helpers.contracts.getContract("Redemption"))
-            .address,
-          Wallets: (await helpers.contracts.getContract("Wallets")).address,
-          Fraud: (await helpers.contracts.getContract("Fraud")).address,
-          MovingFunds: (await helpers.contracts.getContract("MovingFunds"))
-            .address,
-          Reservation: (await helpers.contracts.getContract("Reservation"))
-            .address,
+  const deployBridge = async (
+    txProofDifficultyFactor: number,
+    wireReservationRouter = true
+  ) => {
+    const [newBridge, newBridgeDeployment] = await helpers.upgrades.deployProxy(
+      `Bridge_${randomBytes(8).toString("hex")}`,
+      {
+        contractName: "BridgeStub",
+        initializerArgs: [
+          bank.address,
+          relay.address,
+          treasury.address,
+          walletRegistry.address,
+          reimbursementPool.address,
+          txProofDifficultyFactor,
+        ],
+        factoryOpts: {
+          signer: deployer,
+          libraries: {
+            Deposit: (await helpers.contracts.getContract("Deposit")).address,
+            DepositSweep: (
+              await helpers.contracts.getContract("DepositSweep")
+            ).address,
+            Redemption: (
+              await helpers.contracts.getContract("Redemption")
+            ).address,
+            Wallets: (await helpers.contracts.getContract("Wallets")).address,
+            Fraud: (await helpers.contracts.getContract("Fraud")).address,
+            MovingFunds: (
+              await helpers.contracts.getContract("MovingFunds")
+            ).address,
+          },
         },
-      },
-      proxyOpts: {
-        kind: "transparent",
-        // Allow external libraries linking. We need to ensure manually that the
-        // external  libraries we link are upgrade safe, as the OpenZeppelin plugin
-        // doesn't perform such a validation yet.
-        // See: https://docs.openzeppelin.com/upgrades-plugins/1.x/faq#why-cant-i-use-external-libraries
-        unsafeAllow: ["external-library-linking"],
-      },
-    })
+        proxyOpts: {
+          kind: "transparent",
+          // Allow external libraries linking. We need to ensure manually that the
+          // external  libraries we link are upgrade safe, as the OpenZeppelin plugin
+          // doesn't perform such a validation yet.
+          // See: https://docs.openzeppelin.com/upgrades-plugins/1.x/faq#why-cant-i-use-external-libraries
+          unsafeAllow: ["external-library-linking"],
+        },
+      }
+    )
+
+    // Wire the reservation router the same way the deployment scripts do.
+    // The router is stateless code, so the instance deployed by the fixture
+    // deployments can serve this fresh Bridge as well.
+    if (wireReservationRouter) {
+      await (newBridge as Bridge & BridgeStub)
+        .connect(deployer)
+        .setReservationRouter(
+          (
+            await helpers.contracts.getContract("ReservationRouter")
+          ).address
+        )
+    }
+
+    return [
+      await attachReservationRouter<Bridge & BridgeStub>(
+        newBridge as Bridge & BridgeStub
+      ),
+      newBridgeDeployment,
+    ]
+  }
 
   return {
     deployer,

--- a/solidity/test/maintainer/MaintainerProxy.test.ts
+++ b/solidity/test/maintainer/MaintainerProxy.test.ts
@@ -2057,7 +2057,7 @@ describe("MaintainerProxy", () => {
 
             expect(diff).to.be.gt(0)
             expect(diff).to.be.lt(
-              ethers.utils.parseUnits("2000000", "gwei") // 0,002 ETH
+              ethers.utils.parseUnits("2300000", "gwei") // 0,0023 ETH
             )
           })
         })


### PR DESCRIPTION
Stacked on #1090 (router). Implements the settlement state machine of RFC 13 — the shared fix for the review's Critical and most High findings, whose root cause was a single-phase lifecycle racing timeout/veto against confirmed Bitcoin spends.

## The machine

Every reservation Bitcoin action (acceptance anchor, in-kind redemption, re-anchor, dissolution) is now an explicitly requested **generation** keyed by `(reservationKey, requestNonce)`:

- **Request** = authorize + reserve + snapshot. All capacity/lifecycle checks happen here and are *reserved* (global total, per-wallet count, target liveness, per-wallet dissolution lock); every proof-critical parameter (fee bound, redeemer script, target wallet, expected main UTXO, timeout) is snapshotted into the generation's `ReservationAction` record. A signed authorized action can never become unprovable because state moved later (**H-02**).
- **Proof** names its generation and validates only against the record. Reserved-redemption proofs enforce the generation's watchtower delay **in the Bridge proof path** (**H-03**); a vetoed generation never settles — the early signature stays fraud-exposed by design.
- **Timeout** writes a terminal, late-proof-accepting record (mirror of `timedOutRedemptions`). A late proof settles: consumed outpoints are marked in `spentMainUTXOs` (honest-but-late signature defeats fraud challenges), the lineage closes, and **no Bank movement repeats** — no double refund, no double burn (**C-01**). If the current pending redemption also matches the tx, the proof must settle *it* (escrow burned — the correct accounting); a non-matching pending generation is unwound (`Superseded`, escrow refunded) since its anchor provably no longer exists.
- **Re-anchor/dissolution authorization** (**H-01**): explicit requests with nonce, source-state rules (MovingFunds permissionless / Live governance-only), distinct capacity-reserved target; proof requires the output to pay the *recorded* target. Same-wallet re-anchors no longer exist — the byte-ambiguity with dissolution is gone.
- **Dissolution lock** (**H-07**): one in-flight dissolution per wallet + snapshotted expected main UTXO; registry drift (a sweep landing first against a no-main-UTXO snapshot) re-registers the confirmed output as a moved-funds sweep request.
- **Lifecycle gating** (**H-05** + part of H-06): requests need a Live/MovingFunds wallet; post-grace only dissolution is requestable (request/timeout cycling can't defeat the stranding bound); a wallet holding anchors cannot begin closing — with no main UTXO it enters MovingFunds to drain them; redemption *and* dissolution timeouts slash like pooled redemption timeouts.
- **Retry entitlement** (**M-02**): minted only when a fee-paid generation times out, single-use, consumed by the fee-free retry. **Per-generation veto keying** (**M-03**): objections never accumulate across generations; reservation-scoped safety check is ban-state only.
- **Snapshots** (**M-01**): per-position term/grace at acceptance; per-generation fee bounds/timeouts at request. Governance changes are prospective only.

## Closes

C-01, H-01, H-02, H-03, H-05 (request side), H-07, M-01, M-02, M-03. (H-06 termination stranding, M-04/M-05 reveal-side guards, and the H-04/M-06 backing model land in the next PRs of the stack.)

## Shape

The settlement side is a new external library `ReservationProofs`, reached through `Reservation` so the router links exactly one library. Storage appends: `reservationActionTimeout`, `reservationActions`, `walletPendingDissolution` (gap 42→39, append-only). Sizes: router 6,007 B / Reservation 14,760 B / ReservationProofs 19,416 B / Bridge unchanged 22,403 B — all with ≥5 KB EIP-170 margin.

Includes a config-time backport of the upstream `@openzeppelin/upgrades-core` fix for foreign link-reference splices crashing unrelated proxy validations (droppable on plugin upgrade).

## Tests

Full suite **3068 passing / 0 failing**. New adversarial settlement suite: C-01 late-proof regression (no second refund, fraud-defeat registration, no double-settle), late-proof matrix vs newer pending generations, H-03 delay + vetoed-generation permanence, H-07 serialized dissolutions + drift fallback, H-02 fill-then-prove, acceptance-authorization timeout with late anchor settlement, post-grace stranding bound, wallet retirement through MovingFunds.

## keep-core follow-up (flagged)

Proposal structs gained `requestNonce` and proofs now name their generation — threshold-network/keep-core#4238's coordination/assemblers must carry the authorized nonce and consult action records (gated on this ABI publishing), including the new `requestReservationAcceptance`/`requestReservationDissolution`/`notifyReservationActionTimeout` entry points.