### PR TITLE
feat(bridge): bounded permissionless renewal and strict expiry semantics

### DIFF
--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -270,17 +270,44 @@ at most one dissolution per wallet may be in flight, which (with the
 snapshot of the expected main-UTXO hash) removes the concurrent-dissolution
 race entirely. Snapshots the fee bound and expected main UTXO.
 
-=== Precedence and the stranding bound
+=== Renewal, expiry and the stranding bound
 
-Reserved redemption requests are accepted only while
-`now <= expiresAt + gracePeriod` (and the position is Active, the wallet is
-Live or MovingFunds, and the owner passes the reservation-scoped watchtower
-safety check). After grace, only dissolution may be requested — so an owner
-cannot cycle request/timeout to hold a wallet hostage past the custody
-term: *term + grace + one action timeout* is a hard stranding bound. One
-carve-out: a timeout-minted retry entitlement may be used after grace until
-a dissolution is requested; requesting dissolution voids outstanding
-entitlements (the claim simply remains pooled TBTC).
+The custody term is renewable under a *permissionless, default-allow,
+bounded-lookahead* model:
+
+* A renewal adds exactly one current term and is possible only inside the
+  *renewal window* immediately before expiry
+  (`expiresAt - window <= now < expiresAt`, with `0 < window < term`
+  enforced atomically at every parameter change and at execution). Because
+  the window is shorter than the term, a fresh renewal is immediately
+  outside its next window — terms can never be stacked, and the owner's
+  maximum lookahead is one term plus the window.
+* The renewal call is intent-bound: it commits to the observed expiry and
+  to the expected new expiry, so stale transactions and mid-flight term
+  changes revert instead of silently buying a different duration. The
+  vault-side owner call additionally carries a fee bound (`maxFeeTbtc`).
+* The vault enforces an exception-only policy layer: a global renewals
+  pause and per-reservation blocks, applicable immediately by a renewal
+  guardian or governance (restrictive actions are monotonic — they never
+  shorten a purchased term and never touch funds); only governance can
+  unpause, unblock, or replace the guardian. A fresh vault starts paused.
+* Reserved redemption requests are accepted strictly *before expiry*
+  (`now < expiresAt`), for the fee-free retry path as well — no owner
+  action beginning at or after expiry can delay dissolution. The
+  post-expiry *dissolution delay* (the renamed grace period) exists for
+  orderly settlement only; each granted term snapshots
+  `dissolutionEligibleAt = expiresAt + currentDissolutionDelay`, and
+  dissolution becomes requestable at that snapshot. Later parameter
+  changes never move the eligibility of a term already granted.
+
+A pre-expiry pending redemption may still settle after expiry (its
+generation record governs); if it times out or is vetoed at/after expiry
+the position returns to a state where every owner path is expiry-gated —
+dissolution-bound in behavior. The hard stranding bound after the final
+expiry is the dissolution delay plus one action timeout (plus, for a
+governance intervention, one final front-run term: detection-to-block
+latency + window + term + max(delay, redemption timeout) + settlement
+latency).
 
 === Watchtower integration (per-generation)
 
@@ -353,18 +380,21 @@ checked and reserved at request/authorization time, never at proof time.
 Mechanics implemented now; *parameter values are explicit governance
 decisions* surfaced for sign-off:
 
-* term bounds: minimum 3 months, maximum 2 years *(default, flagged)*;
-* extension fee prorated to the extension length (20 bps/yr base);
-* renewal horizon cap: `expiresAt <= now + 2 × term` *(default, flagged)*
-  — prepaid extensions cannot push expiry out indefinitely;
-* grace-period penalty: none *(default 0, flagged — decision pending)*;
+* term bounds: minimum 90 days, maximum 730 days, enforced as protocol
+  constants *(baseline per the renewal design; flagged)*;
+* renewal window: 30 days *(default, flagged)* — the bounded-lookahead
+  window replaces both proration (a renewal is always exactly one term)
+  and any renewal-horizon cap (stacking is impossible by construction);
+* dissolution delay: 30 days *(default, flagged)*; there is no grace
+  penalty — the delay is not an owner window at all;
 * pricing of the embedded senior-liquidity option: financial-modeling task,
   out of scope for the contracts, tracked as an open economics item;
-* `ReservationVault` ownership transferred to governance/timelock at
-  deploy; `updateFees` behind the protocol governance delay; per-position
-  fee terms snapshotted at acceptance; user-supplied fee-slippage bound on
-  mint/redeem paths. Fee schedule stays 40 bps initiation / 20 bps/yr
-  extension / 20 bps redemption.
+* `ReservationVault` ownership transferred to governance at deploy, with
+  renewals paused until governance activates them; the renewal call
+  carries a user fee bound (`maxFeeTbtc`). Fee schedule stays 40 bps
+  initiation / 20 bps/yr renewal / 20 bps redemption. A governance-delay
+  posture for `updateFees` and an initiation-fee snapshot remain open
+  items tracked for the policy PR.
 
 == Storage layout policy
 

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1821,20 +1821,22 @@ contract BridgeGovernance is Ownable {
         uint64 _newReservationMinAmount,
         uint64 _newReservationTxMaxFee,
         uint32 _newReservationTermSeconds,
-        uint32 _newReservationGracePeriod,
+        uint32 _newReservationDissolutionDelay,
         uint64 _newReservationMaxTotalAmount,
         uint32 _newMaxReservationsPerWallet,
-        uint32 _newReservationActionTimeout
+        uint32 _newReservationActionTimeout,
+        uint32 _newReservationRenewalWindowSeconds
     ) external onlyOwner {
         reservationData.beginReservationParametersUpdate(
             _newReservationVault,
             _newReservationMinAmount,
             _newReservationTxMaxFee,
             _newReservationTermSeconds,
-            _newReservationGracePeriod,
+            _newReservationDissolutionDelay,
             _newReservationMaxTotalAmount,
             _newMaxReservationsPerWallet,
-            _newReservationActionTimeout
+            _newReservationActionTimeout,
+            _newReservationRenewalWindowSeconds
         );
     }
 
@@ -1850,10 +1852,11 @@ contract BridgeGovernance is Ownable {
             staged.newReservationMinAmount,
             staged.newReservationTxMaxFee,
             staged.newReservationTermSeconds,
-            staged.newReservationGracePeriod,
+            staged.newReservationDissolutionDelay,
             staged.newReservationMaxTotalAmount,
             staged.newMaxReservationsPerWallet,
-            staged.newReservationActionTimeout
+            staged.newReservationActionTimeout,
+            staged.newReservationRenewalWindowSeconds
         );
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -291,6 +291,22 @@ contract BridgeGovernance is Ownable {
     event TreasuryUpdateStarted(address newTreasury, uint256 timestamp);
     event TreasuryUpdated(address treasury);
 
+    // Emitted by BridgeGovernanceParameters via delegatecall. It must also be
+    // declared here so governance tooling can decode logs at this contract's
+    // address using the BridgeGovernance ABI.
+    event ReservationParametersUpdateStarted(
+        address newReservationVault,
+        uint64 newReservationMinAmount,
+        uint64 newReservationTxMaxFee,
+        uint32 newReservationTermSeconds,
+        uint32 newReservationDissolutionDelay,
+        uint64 newReservationMaxTotalAmount,
+        uint32 newMaxReservationsPerWallet,
+        uint32 newReservationActionTimeout,
+        uint32 newReservationRenewalWindowSeconds,
+        uint256 timestamp
+    );
+
     constructor(Bridge _bridge, uint256 _governanceDelay) {
         bridge = _bridge;
         governanceDelays[0] = _governanceDelay;

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -1577,10 +1577,11 @@ library BridgeGovernanceParameters {
         uint64 newReservationMinAmount;
         uint64 newReservationTxMaxFee;
         uint32 newReservationTermSeconds;
-        uint32 newReservationGracePeriod;
+        uint32 newReservationDissolutionDelay;
         uint64 newReservationMaxTotalAmount;
         uint32 newMaxReservationsPerWallet;
         uint32 newReservationActionTimeout;
+        uint32 newReservationRenewalWindowSeconds;
         uint256 reservationParametersChangeInitiated;
     }
 
@@ -1589,10 +1590,11 @@ library BridgeGovernanceParameters {
         uint64 newReservationMinAmount,
         uint64 newReservationTxMaxFee,
         uint32 newReservationTermSeconds,
-        uint32 newReservationGracePeriod,
+        uint32 newReservationDissolutionDelay,
         uint64 newReservationMaxTotalAmount,
         uint32 newMaxReservationsPerWallet,
         uint32 newReservationActionTimeout,
+        uint32 newReservationRenewalWindowSeconds,
         uint256 timestamp
     );
 
@@ -1605,30 +1607,34 @@ library BridgeGovernanceParameters {
         uint64 _newReservationMinAmount,
         uint64 _newReservationTxMaxFee,
         uint32 _newReservationTermSeconds,
-        uint32 _newReservationGracePeriod,
+        uint32 _newReservationDissolutionDelay,
         uint64 _newReservationMaxTotalAmount,
         uint32 _newMaxReservationsPerWallet,
-        uint32 _newReservationActionTimeout
+        uint32 _newReservationActionTimeout,
+        uint32 _newReservationRenewalWindowSeconds
     ) external {
         /* solhint-disable not-rely-on-time */
         self.newReservationVault = _newReservationVault;
         self.newReservationMinAmount = _newReservationMinAmount;
         self.newReservationTxMaxFee = _newReservationTxMaxFee;
         self.newReservationTermSeconds = _newReservationTermSeconds;
-        self.newReservationGracePeriod = _newReservationGracePeriod;
+        self.newReservationDissolutionDelay = _newReservationDissolutionDelay;
         self.newReservationMaxTotalAmount = _newReservationMaxTotalAmount;
         self.newMaxReservationsPerWallet = _newMaxReservationsPerWallet;
         self.newReservationActionTimeout = _newReservationActionTimeout;
+        self
+            .newReservationRenewalWindowSeconds = _newReservationRenewalWindowSeconds;
         self.reservationParametersChangeInitiated = block.timestamp;
         emit ReservationParametersUpdateStarted(
             _newReservationVault,
             _newReservationMinAmount,
             _newReservationTxMaxFee,
             _newReservationTermSeconds,
-            _newReservationGracePeriod,
+            _newReservationDissolutionDelay,
             _newReservationMaxTotalAmount,
             _newMaxReservationsPerWallet,
             _newReservationActionTimeout,
+            _newReservationRenewalWindowSeconds,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -343,10 +343,13 @@ library BridgeState {
         // incurred by a single reservation lifecycle transaction (anchor,
         // re-anchor, reserved redemption, dissolution).
         uint64 reservationTxMaxFee;
-        // The grace period in seconds after a reservation's custody term
-        // expires during which the reservation can still be extended or
-        // redeemed but not yet dissolved.
-        uint32 reservationGracePeriod;
+        // The dissolution delay in seconds after a reservation's custody
+        // term expires and before the reservation becomes dissolvable. The
+        // delay exists for orderly settlement and dissolution coordination;
+        // it is NOT an owner-action window — renewal and new redemptions
+        // stop strictly at expiry. Snapshotted per position as
+        // `dissolutionEligibleAt` when a term is granted.
+        uint32 reservationDissolutionDelay;
         // Maximum total amount in satoshi that can be locked under active
         // reservations at the same time.
         uint64 reservationMaxTotalAmount;
@@ -379,6 +382,12 @@ library BridgeState {
         // timed out. Reserved redemptions use `redemptionTimeout` instead.
         // Snapshotted into each action record at request time.
         uint32 reservationActionTimeout;
+        // Length in seconds of the renewal window: a reservation owner may
+        // renew (extend by exactly one current term) only while
+        // `expiresAt - window <= now < expiresAt`. Must be strictly
+        // shorter than the term so a fresh renewal is immediately outside
+        // its next window — renewals can never be stacked.
+        uint32 reservationRenewalWindowSeconds;
         // Collection of all reservation action generation records indexed
         // by `keccak256(reservationKey | requestNonce)`. Each record
         // snapshots every proof- and settlement-critical parameter of one
@@ -401,7 +410,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[39] __gap;
+        uint256[38] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -410,7 +410,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[38] __gap;
+        uint256[40] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/IReservationBridge.sol
+++ b/solidity/contracts/bridge/IReservationBridge.sol
@@ -54,7 +54,11 @@ interface IReservationBridge {
     ) external;
 
     /// @notice See `ReservationRouter.extendReservation`.
-    function extendReservation(uint256 reservationKey) external;
+    function extendReservation(
+        uint256 reservationKey,
+        uint32 expectedExpiresAt,
+        uint32 expectedNewExpiresAt
+    ) external;
 
     /// @notice See `ReservationRouter.notifyReservedRedemptionVeto`.
     function notifyReservedRedemptionVeto(
@@ -68,10 +72,11 @@ interface IReservationBridge {
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
         uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
+        uint32 reservationDissolutionDelay,
         uint64 reservationMaxTotalAmount,
         uint32 maxReservationsPerWallet,
-        uint32 reservationActionTimeout
+        uint32 reservationActionTimeout,
+        uint32 reservationRenewalWindowSeconds
     ) external;
 
     /// @notice Bridge treasury address. Declared by the Bridge contract
@@ -101,10 +106,11 @@ interface IReservationBridge {
             uint64 reservationMinAmount,
             uint64 reservationTxMaxFee,
             uint32 reservationTermSeconds,
-            uint32 reservationGracePeriod,
+            uint32 reservationDissolutionDelay,
             uint64 reservationMaxTotalAmount,
             uint64 reservationTotalAmount,
             uint32 maxReservationsPerWallet,
-            uint32 reservationActionTimeout
+            uint32 reservationActionTimeout,
+            uint32 reservationRenewalWindowSeconds
         );
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -67,6 +67,13 @@ library Reservation {
     using BTCUtils for bytes;
     using BytesLib for bytes;
 
+    /// @notice Hard protocol bounds on the custody term length. The
+    ///         governable term must stay within them; they bound the
+    ///         maximum owner lookahead (one term plus the renewal window)
+    ///         and keep the carry economics of a term meaningful.
+    uint32 internal constant MIN_RESERVATION_TERM = 90 days;
+    uint32 internal constant MAX_RESERVATION_TERM = 730 days;
+
     /// @notice Represents the state of a reservation position.
     enum ReservationState {
         /// @dev The reservation is unknown to the Bridge. Acceptance
@@ -165,16 +172,15 @@ library Reservation {
         // True when the owner holds a single-use, fee-free redemption
         // retry entitlement, minted when a fee-paid redemption request
         // times out through the wallet's fault. Consumed by the next
-        // retry request; voided by a dissolution request.
+        // (strictly pre-expiry) retry request.
         bool retryCredit;
-        // Custody term length in seconds, snapshotted at acceptance.
-        // Extensions extend by this value; later governance changes apply
-        // to new reservations only.
-        uint32 termSeconds;
-        // Grace period in seconds, snapshotted at acceptance. After
-        // `expiresAt + gracePeriod` the reservation becomes dissolvable
-        // and can no longer be redeemed in-kind.
-        uint32 gracePeriod;
+        // UNIX timestamp the reservation becomes dissolvable at. Set to
+        // `expiresAt + reservationDissolutionDelay` whenever a term is
+        // granted (acceptance and each renewal), using the delay value
+        // current at that moment — later governance changes never move
+        // the eligibility time of a term already granted.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 dissolutionEligibleAt;
         // This struct doesn't contain `__gap` property as the structure is
         // stored in a mapping, mappings store values in different slots and
         // they are not contiguous with other values.
@@ -232,7 +238,9 @@ library Reservation {
 
     event ReservationExtended(
         uint256 indexed reservationKey,
-        uint32 newExpiresAt
+        uint32 oldExpiresAt,
+        uint32 newExpiresAt,
+        uint32 dissolutionEligibleAt
     );
 
     event ReservedRedemptionRequested(
@@ -278,10 +286,11 @@ library Reservation {
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
         uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
+        uint32 reservationDissolutionDelay,
         uint64 reservationMaxTotalAmount,
         uint32 maxReservationsPerWallet,
-        uint32 reservationActionTimeout
+        uint32 reservationActionTimeout,
+        uint32 reservationRenewalWindowSeconds
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -531,16 +540,19 @@ library Reservation {
             );
         }
 
+        // New redemption generations stop strictly at expiry — for the
+        // retry path as well. The post-expiry dissolution delay exists for
+        // orderly settlement, not as a late owner-action window, so no
+        // owner action beginning at/after expiry can delay dissolution.
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp < reservation.expiresAt,
+            "Reservation expired"
+        );
+
         if (useRetryCredit) {
             require(reservation.retryCredit, "No retry entitlement");
             reservation.retryCredit = false;
-        } else {
-            require(
-                /* solhint-disable-next-line not-rely-on-time */
-                block.timestamp <=
-                    uint256(reservation.expiresAt) + reservation.gracePeriod,
-                "Reservation past grace period"
-            );
         }
 
         if (self.redemptionWatchtower != address(0)) {
@@ -738,9 +750,8 @@ library Reservation {
         );
         require(
             /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp >
-                uint256(reservation.expiresAt) + reservation.gracePeriod,
-            "Reservation term or grace period not elapsed"
+            block.timestamp >= reservation.dissolutionEligibleAt,
+            "Reservation not dissolution-eligible yet"
         );
 
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
@@ -762,7 +773,6 @@ library Reservation {
         );
         self.walletPendingDissolution[walletPubKeyHash] = reservationKey;
 
-        reservation.retryCredit = false;
         reservation.state = ReservationState.ActionPending;
         uint64 requestNonce = ++reservation.requestNonce;
 
@@ -937,19 +947,41 @@ library Reservation {
         self.bank.transferBalance(self.redemptionWatchtower, action.amount);
     }
 
-    /// @notice Extends the custody term of a reservation by its snapshotted
-    ///         term length. The custody fee for the extension is collected
-    ///         by the reservation vault before this call.
-    /// @param reservationKey The key of the reservation to extend.
+    /// @notice Renews the custody term of a reservation: adds exactly one
+    ///         current term to the expiry. Renewal is permissionless for
+    ///         the owner (through the reservation vault, which collects
+    ///         the fee and enforces the exceptional pause/block policy)
+    ///         but strictly bounded: it is possible only inside the
+    ///         renewal window immediately before expiry, and since the
+    ///         window is shorter than the term, a fresh renewal is
+    ///         immediately outside its next window — terms can never be
+    ///         stacked. The maximum owner lookahead is one term plus the
+    ///         window.
+    /// @param reservationKey The key of the reservation to renew.
+    /// @param expectedExpiresAt The expiry the caller observed; rejects
+    ///        stale renewal transactions.
+    /// @param expectedNewExpiresAt The new expiry the caller is paying
+    ///        for; rejects renewals whose term parameter changed between
+    ///        transaction construction and execution.
     /// @dev Requirements:
     ///      - The caller must be the reservation vault,
-    ///      - The reservation must be Active, or awaiting the settlement
-    ///        of a pending redemption,
-    ///      - The reservation must not be past its (snapshotted) grace
-    ///        period.
+    ///      - The reservation must be Active (a pending action blocks
+    ///        renewal),
+    ///      - The stored expiry must equal `expectedExpiresAt`,
+    ///      - The current parameters must satisfy `0 < window < term`,
+    ///      - The execution time must lie in `[expiry - window, expiry)`
+    ///        — at expiry, renewal is closed,
+    ///      - `expiry + term` must equal `expectedNewExpiresAt`.
+    ///
+    ///      On success the expiry advances by exactly one current term and
+    ///      the dissolution eligibility is re-snapshotted for the newly
+    ///      purchased term using the current dissolution delay. No other
+    ///      field changes.
     function extendReservation(
         BridgeState.Storage storage self,
-        uint256 reservationKey
+        uint256 reservationKey,
+        uint32 expectedExpiresAt,
+        uint32 expectedNewExpiresAt
     ) external {
         require(
             msg.sender == self.reservationVault,
@@ -960,29 +992,49 @@ library Reservation {
             reservationKey
         ];
         require(
-            reservation.state == ReservationState.Active ||
-                (reservation.state == ReservationState.ActionPending &&
-                    getAction(self, reservationKey, reservation.requestNonce)
-                        .actionType ==
-                    ActionType.Redemption),
+            reservation.state == ReservationState.Active,
             "Reservation is not active"
         );
+
+        uint32 expiresAt = reservation.expiresAt;
         require(
-            /* solhint-disable-next-line not-rely-on-time */
-            block.timestamp <=
-                uint256(reservation.expiresAt) + reservation.gracePeriod,
-            "Reservation past grace period"
+            expiresAt == expectedExpiresAt,
+            "Stale renewal: unexpected current expiry"
         );
 
-        uint32 base = reservation.expiresAt;
-        /* solhint-disable-next-line not-rely-on-time */
-        if (base < block.timestamp) {
-            /* solhint-disable-next-line not-rely-on-time */
-            base = uint32(block.timestamp);
-        }
-        reservation.expiresAt = base + reservation.termSeconds;
+        uint32 window = self.reservationRenewalWindowSeconds;
+        uint32 term = self.reservationTermSeconds;
+        require(
+            window > 0 && window < term,
+            "Renewal window must be shorter than the term"
+        );
 
-        emit ReservationExtended(reservationKey, reservation.expiresAt);
+        require(
+            /* solhint-disable-next-line not-rely-on-time */
+            block.timestamp >= expiresAt - window &&
+                /* solhint-disable-next-line not-rely-on-time */
+                block.timestamp < expiresAt,
+            "Outside the renewal window"
+        );
+
+        uint32 newExpiresAt = expiresAt + term;
+        require(
+            newExpiresAt == expectedNewExpiresAt,
+            "Stale renewal: unexpected new expiry"
+        );
+
+        uint32 dissolutionEligibleAt = newExpiresAt +
+            self.reservationDissolutionDelay;
+
+        reservation.expiresAt = newExpiresAt;
+        reservation.dissolutionEligibleAt = dissolutionEligibleAt;
+
+        emit ReservationExtended(
+            reservationKey,
+            expiresAt,
+            newExpiresAt,
+            dissolutionEligibleAt
+        );
     }
 
     /// @notice Updates the reservation parameters, including the
@@ -992,24 +1044,30 @@ library Reservation {
     ///      - Reservation transaction max fee must be greater than zero,
     ///      - Reservation minimum amount must be greater than the
     ///        reservation transaction max fee,
-    ///      - Reservation term must be greater than zero,
+    ///      - Reservation term must be within the protocol bounds
+    ///        [MIN_RESERVATION_TERM, MAX_RESERVATION_TERM],
+    ///      - The renewal window must be non-zero and strictly shorter
+    ///        than the term (checked atomically here and re-checked at
+    ///        renewal execution, so neither parameter change can reopen
+    ///        term stacking),
     ///      - Reservation action timeout must be greater than zero,
     ///      - The reservation vault can only be changed while there are no
     ///        active reservations (total reserved amount is zero).
     ///
-    ///      Term, grace period and fee bounds are snapshotted into
-    ///      positions and action records when they are created; updates
-    ///      apply prospectively only.
+    ///      Term, dissolution delay and fee bounds are snapshotted into
+    ///      positions and action records when terms are granted or actions
+    ///      requested; updates apply prospectively only.
     function updateReservationParameters(
         BridgeState.Storage storage self,
         address reservationVault,
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
         uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
+        uint32 reservationDissolutionDelay,
         uint64 reservationMaxTotalAmount,
         uint32 maxReservationsPerWallet,
-        uint32 reservationActionTimeout
+        uint32 reservationActionTimeout,
+        uint32 reservationRenewalWindowSeconds
     ) external {
         require(
             reservationTxMaxFee > 0,
@@ -1020,8 +1078,14 @@ library Reservation {
             "Reservation minimum amount must be greater than the reservation TX max fee"
         );
         require(
-            reservationTermSeconds > 0,
-            "Reservation term must be greater than zero"
+            reservationTermSeconds >= MIN_RESERVATION_TERM &&
+                reservationTermSeconds <= MAX_RESERVATION_TERM,
+            "Reservation term out of protocol bounds"
+        );
+        require(
+            reservationRenewalWindowSeconds > 0 &&
+                reservationRenewalWindowSeconds < reservationTermSeconds,
+            "Renewal window must be shorter than the term"
         );
         require(
             reservationActionTimeout > 0,
@@ -1040,19 +1104,21 @@ library Reservation {
         self.reservationMinAmount = reservationMinAmount;
         self.reservationTxMaxFee = reservationTxMaxFee;
         self.reservationTermSeconds = reservationTermSeconds;
-        self.reservationGracePeriod = reservationGracePeriod;
+        self.reservationDissolutionDelay = reservationDissolutionDelay;
         self.reservationMaxTotalAmount = reservationMaxTotalAmount;
         self.maxReservationsPerWallet = maxReservationsPerWallet;
         self.reservationActionTimeout = reservationActionTimeout;
+        self.reservationRenewalWindowSeconds = reservationRenewalWindowSeconds;
 
         emit ReservationParametersUpdated(
             reservationMinAmount,
             reservationTxMaxFee,
             reservationTermSeconds,
-            reservationGracePeriod,
+            reservationDissolutionDelay,
             reservationMaxTotalAmount,
             maxReservationsPerWallet,
-            reservationActionTimeout
+            reservationActionTimeout,
+            reservationRenewalWindowSeconds
         );
     }
 

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -631,6 +631,7 @@ library Reservation {
     ///        away from Live wallets.
     /// @dev Requirements:
     ///      - The reservation must be Active,
+    ///      - The reservation must not yet be dissolution-eligible,
     ///      - The source wallet must be in the MovingFunds state (anyone
     ///        may then request — migration is the system's duty), or Live
     ///        with the governance as the caller (approved rotation),
@@ -651,6 +652,12 @@ library Reservation {
             reservation.state == ReservationState.Active,
             "Reservation is not active"
         );
+        /* solhint-disable not-rely-on-time */
+        require(
+            block.timestamp < reservation.dissolutionEligibleAt,
+            "Reservation is dissolution-eligible"
+        );
+        /* solhint-enable not-rely-on-time */
 
         {
             Wallets.WalletState sourceState = self

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -373,8 +373,9 @@ library ReservationProofs {
         reservation.anchorTxHash = anchorTxHash;
         reservation.anchorTxOutputIndex = 0;
         reservation.state = Reservation.ReservationState.Active;
-        reservation.termSeconds = self.reservationTermSeconds;
-        reservation.gracePeriod = self.reservationGracePeriod;
+        reservation.dissolutionEligibleAt =
+            expiresAt +
+            self.reservationDissolutionDelay;
 
         self.reservationsByAnchorUtxo[
             uint256(keccak256(abi.encodePacked(anchorTxHash, uint32(0))))

--- a/solidity/contracts/bridge/ReservationRouter.sol
+++ b/solidity/contracts/bridge/ReservationRouter.sol
@@ -112,7 +112,9 @@ contract ReservationRouter is Governable, Initializable {
 
     event ReservationExtended(
         uint256 indexed reservationKey,
-        uint32 newExpiresAt
+        uint32 oldExpiresAt,
+        uint32 newExpiresAt,
+        uint32 dissolutionEligibleAt
     );
 
     event ReservedRedemptionRequested(
@@ -190,10 +192,11 @@ contract ReservationRouter is Governable, Initializable {
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
         uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
+        uint32 reservationDissolutionDelay,
         uint64 reservationMaxTotalAmount,
         uint32 maxReservationsPerWallet,
-        uint32 reservationActionTimeout
+        uint32 reservationActionTimeout,
+        uint32 reservationRenewalWindowSeconds
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -354,14 +357,25 @@ contract ReservationRouter is Governable, Initializable {
         self.notifyReservedRedemptionVeto(reservationKey, requestNonce);
     }
 
-    /// @notice Extends the custody term of a reservation by its snapshotted
-    ///         term length. Can only be called by the reservation vault,
-    ///         which collects the custody fee for the extension. See
-    ///         `Reservation.extendReservation`.
-    /// @param reservationKey The key of the reservation to extend.
-    function extendReservation(uint256 reservationKey) external {
+    /// @notice Renews the custody term of a reservation by exactly one
+    ///         current term, inside the renewal window immediately before
+    ///         expiry. Can only be called by the reservation vault, which
+    ///         collects the custody fee and enforces the exceptional
+    ///         pause/block policy. See `Reservation.extendReservation`.
+    /// @param reservationKey The key of the reservation to renew.
+    /// @param expectedExpiresAt The expiry the caller observed.
+    /// @param expectedNewExpiresAt The new expiry the caller is paying for.
+    function extendReservation(
+        uint256 reservationKey,
+        uint32 expectedExpiresAt,
+        uint32 expectedNewExpiresAt
+    ) external {
         // The caller is checked in the library function.
-        self.extendReservation(reservationKey);
+        self.extendReservation(
+            reservationKey,
+            expectedExpiresAt,
+            expectedNewExpiresAt
+        );
     }
 
     /// @notice Updates parameters of reservations, including the
@@ -374,15 +388,18 @@ contract ReservationRouter is Governable, Initializable {
     /// @param reservationTxMaxFee New value of the reservation transaction
     ///        max fee in satoshis.
     /// @param reservationTermSeconds New value of the reservation custody
-    ///        term length in seconds. Snapshotted into new positions.
-    /// @param reservationGracePeriod New value of the reservation grace
-    ///        period in seconds. Snapshotted into new positions.
+    ///        term length in seconds, within the protocol bounds. Applies
+    ///        to future term grants; never alters an existing expiry.
+    /// @param reservationDissolutionDelay New value of the post-expiry
+    ///        dissolution delay in seconds. Snapshotted per granted term.
     /// @param reservationMaxTotalAmount New cap on the total amount in
     ///        satoshi locked under active reservations.
     /// @param maxReservationsPerWallet New cap on the number of active
     ///        reservations a single wallet can custody.
     /// @param reservationActionTimeout New value of the reservation action
     ///        timeout in seconds.
+    /// @param reservationRenewalWindowSeconds New length of the renewal
+    ///        window; must stay strictly shorter than the term.
     /// @dev Requirements:
     ///      - The caller must be the governance,
     ///      - See `Reservation.updateReservationParameters` for parameter
@@ -392,20 +409,22 @@ contract ReservationRouter is Governable, Initializable {
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
         uint32 reservationTermSeconds,
-        uint32 reservationGracePeriod,
+        uint32 reservationDissolutionDelay,
         uint64 reservationMaxTotalAmount,
         uint32 maxReservationsPerWallet,
-        uint32 reservationActionTimeout
+        uint32 reservationActionTimeout,
+        uint32 reservationRenewalWindowSeconds
     ) external onlyGovernance {
         self.updateReservationParameters(
             reservationVault,
             reservationMinAmount,
             reservationTxMaxFee,
             reservationTermSeconds,
-            reservationGracePeriod,
+            reservationDissolutionDelay,
             reservationMaxTotalAmount,
             maxReservationsPerWallet,
-            reservationActionTimeout
+            reservationActionTimeout,
+            reservationRenewalWindowSeconds
         );
     }
 
@@ -457,22 +476,24 @@ contract ReservationRouter is Governable, Initializable {
             uint64 reservationMinAmount,
             uint64 reservationTxMaxFee,
             uint32 reservationTermSeconds,
-            uint32 reservationGracePeriod,
+            uint32 reservationDissolutionDelay,
             uint64 reservationMaxTotalAmount,
             uint64 reservationTotalAmount,
             uint32 maxReservationsPerWallet,
-            uint32 reservationActionTimeout
+            uint32 reservationActionTimeout,
+            uint32 reservationRenewalWindowSeconds
         )
     {
         reservationVault = self.reservationVault;
         reservationMinAmount = self.reservationMinAmount;
         reservationTxMaxFee = self.reservationTxMaxFee;
         reservationTermSeconds = self.reservationTermSeconds;
-        reservationGracePeriod = self.reservationGracePeriod;
+        reservationDissolutionDelay = self.reservationDissolutionDelay;
         reservationMaxTotalAmount = self.reservationMaxTotalAmount;
         reservationTotalAmount = self.reservationTotalAmount;
         maxReservationsPerWallet = self.maxReservationsPerWallet;
         reservationActionTimeout = self.reservationActionTimeout;
+        reservationRenewalWindowSeconds = self.reservationRenewalWindowSeconds;
     }
 
     /// @notice Returns the address of the reservation router the Bridge

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -270,7 +270,7 @@ contract WalletProposalValidator {
 
         address proposalVault = address(0);
 
-        (address reservationVault, , , , , , , , ) = IReservationBridge(
+        (address reservationVault, , , , , , , , , ) = IReservationBridge(
             address(bridge)
         ).reservationParameters();
 

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -82,6 +82,27 @@ contract ReservationVault is IVault, Ownable {
     ///         after wallet-fault timeouts.
     uint16 public redemptionFeeBps;
 
+    /// @notice True while all renewals are paused. A fresh vault starts
+    ///         paused; governance unpauses as part of activation. Pausing
+    ///         only removes future renewal opportunities — it never
+    ///         shortens a term already purchased and has no effect on
+    ///         redemption, re-anchoring or dissolution.
+    bool public renewalsPaused;
+
+    /// @notice Per-reservation renewal blocks, keyed by the stable
+    ///         reservation key (derived from the original deposit outpoint;
+    ///         preserved through re-anchors and wallet migration). A block
+    ///         prevents future renewals of the reservation only.
+    mapping(uint256 => bool) public renewalBlocked;
+
+    /// @notice Address allowed to apply the restrictive policy actions
+    ///         (pause renewals, block a reservation) besides the owner.
+    ///         Guardian actions are monotonic — they cannot disturb an
+    ///         already-paid term or move funds — so they are safe to make
+    ///         immediate. Only the owner (governance) can relax policy:
+    ///         unpause, unblock, or replace the guardian.
+    address public renewalGuardian;
+
     event ReservationCreditProcessed(
         address indexed owner,
         uint256 satAmount,
@@ -107,8 +128,29 @@ contract ReservationVault is IVault, Ownable {
         uint16 redemptionFeeBps
     );
 
+    event ReservationRenewalBlocked(uint256 indexed reservationKey);
+
+    event ReservationRenewalUnblocked(uint256 indexed reservationKey);
+
+    event ReservationRenewalsPaused(address indexed caller);
+
+    event ReservationRenewalsUnpaused(address indexed caller);
+
+    event RenewalGuardianUpdated(
+        address indexed oldGuardian,
+        address indexed newGuardian
+    );
+
     modifier onlyBank() {
         require(msg.sender == address(bank), "Caller is not the Bank");
+        _;
+    }
+
+    modifier onlyGuardianOrOwner() {
+        require(
+            msg.sender == renewalGuardian || msg.sender == owner(),
+            "Caller is not the renewal guardian or owner"
+        );
         _;
     }
 
@@ -147,6 +189,11 @@ contract ReservationVault is IVault, Ownable {
         initiationFeeBps = 40;
         extensionFeeBps = 20;
         redemptionFeeBps = 20;
+
+        // A fresh vault starts with renewals paused; governance unpauses
+        // as part of the activation ceremony, after ownership has been
+        // transferred out of the deployer's hands.
+        renewalsPaused = true;
     }
 
     /// @notice Called by the Bank when the Bridge proves a reservation's
@@ -262,14 +309,37 @@ contract ReservationVault is IVault, Ownable {
         );
     }
 
-    /// @notice Extends the custody term of the caller's reservation by one
-    ///         term length, charging the extension fee in TBTC.
-    /// @param reservationKey The key of the reservation to extend.
+    /// @notice Renews the custody term of the caller's reservation by
+    ///         exactly one current term, charging the extension fee in
+    ///         TBTC. Renewal is possible only inside the renewal window
+    ///         immediately before expiry (enforced independently by the
+    ///         Bridge) and only while neither the global renewal pause nor
+    ///         a per-reservation block is in effect.
+    /// @param reservationKey The key of the reservation to renew.
+    /// @param expectedExpiresAt The expiry the caller observed; rejects
+    ///        stale renewal transactions.
+    /// @param expectedNewExpiresAt The new expiry the caller is paying
+    ///        for; rejects renewals whose term parameter changed between
+    ///        transaction construction and execution.
+    /// @param maxFeeTbtc Upper bound on the TBTC fee the caller accepts;
+    ///        an unexpected fee update reverts instead of overcharging.
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
-    ///      - The caller must have approved this vault for the extension
-    ///        fee in TBTC.
-    function extendCustody(uint256 reservationKey) external {
+    ///      - Renewals must not be paused and the reservation not blocked,
+    ///      - The fee must not exceed `maxFeeTbtc`,
+    ///      - The caller must have approved this vault for the fee in TBTC,
+    ///      - The Bridge-side renewal window, expiry-intent and one-term
+    ///        checks must pass.
+    ///
+    ///      The Bridge renewal executes before the fee transfer; if either
+    ///      fails the whole transaction reverts, so no expiry change or
+    ///      fee payment survives without the other.
+    function extendCustody(
+        uint256 reservationKey,
+        uint32 expectedExpiresAt,
+        uint32 expectedNewExpiresAt,
+        uint256 maxFeeTbtc
+    ) external {
         Reservation.ReservationRequest memory reservation = bridge.reservations(
             reservationKey
         );
@@ -278,9 +348,20 @@ contract ReservationVault is IVault, Ownable {
             "Caller is not the reservation owner"
         );
 
+        require(!renewalsPaused, "Renewals are paused");
+        require(!renewalBlocked[reservationKey], "Reservation renewal blocked");
+
         uint256 fee = (uint256(reservation.mintedAmount) *
             SATOSHI_MULTIPLIER *
             extensionFeeBps) / BASIS_POINTS;
+        require(fee <= maxFeeTbtc, "Fee exceeds the caller's bound");
+
+        bridge.extendReservation(
+            reservationKey,
+            expectedExpiresAt,
+            expectedNewExpiresAt
+        );
+
         if (fee > 0) {
             IERC20(tbtcToken).safeTransferFrom(
                 msg.sender,
@@ -291,8 +372,49 @@ contract ReservationVault is IVault, Ownable {
 
         // slither-disable-next-line reentrancy-events
         emit CustodyExtended(reservationKey, msg.sender, fee);
+    }
 
-        bridge.extendReservation(reservationKey);
+    /// @notice Pauses all future renewals. Restrictive and monotonic:
+    ///         callable by the guardian or the owner, effective
+    ///         immediately, and without any effect on already-purchased
+    ///         terms or on redemption/re-anchor/dissolution.
+    function pauseRenewals() external onlyGuardianOrOwner {
+        renewalsPaused = true;
+        emit ReservationRenewalsPaused(msg.sender);
+    }
+
+    /// @notice Unpauses renewals. Restorative: owner (governance) only.
+    function unpauseRenewals() external onlyOwner {
+        renewalsPaused = false;
+        emit ReservationRenewalsUnpaused(msg.sender);
+    }
+
+    /// @notice Blocks future renewals of the given reservation.
+    ///         Restrictive and monotonic: callable by the guardian or the
+    ///         owner, effective immediately.
+    /// @param reservationKey The key of the reservation to block.
+    function blockRenewal(uint256 reservationKey) external onlyGuardianOrOwner {
+        renewalBlocked[reservationKey] = true;
+        emit ReservationRenewalBlocked(reservationKey);
+    }
+
+    /// @notice Unblocks renewals of the given reservation. Restorative:
+    ///         owner (governance) only.
+    /// @param reservationKey The key of the reservation to unblock.
+    function unblockRenewal(uint256 reservationKey) external onlyOwner {
+        renewalBlocked[reservationKey] = false;
+        emit ReservationRenewalUnblocked(reservationKey);
+    }
+
+    /// @notice Replaces the renewal guardian. Owner (governance) only.
+    /// @param newGuardian The new guardian address; the zero address
+    ///        leaves policy actions to the owner alone.
+    function setRenewalGuardian(address newGuardian) external onlyOwner {
+        emit RenewalGuardianUpdated(renewalGuardian, newGuardian);
+        // The zero address is a deliberate setting: it leaves the
+        // restrictive policy actions to the owner alone.
+        // slither-disable-next-line missing-zero-check
+        renewalGuardian = newGuardian;
     }
 
     /// @notice Re-requests an in-kind redemption using the caller's Bank

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -20,21 +20,24 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // pause/block policy; that authority must not remain with the deployer.
   // The vault deploys with renewals paused, so the activation ceremony is
   // entirely in governance hands from here.
-  await deployments.execute(
+  await helpers.ownable.transferOwnership(
     "ReservationVault",
-    { from: deployer, log: true, waitConfirmations: 1 },
-    "transferOwnership",
-    governance
+    governance,
+    deployer
   )
 
   // NOTE: To activate reservations, governance must additionally:
-  // 1. Mark the vault as trusted: `Bridge.setVaultStatus(vault, true)`,
-  // 2. Wire it as the reservation vault and set the parameters:
-  //    `Bridge.updateReservationParameters(vault, ...)`,
-  // 3. Optionally appoint a renewal guardian
+  // 1. Stage and finalize the vault and reservation parameters through
+  //    `BridgeGovernance.beginReservationParametersUpdate(...)` and
+  //    `BridgeGovernance.finalizeReservationParametersUpdate()`,
+  // 2. Optionally appoint a renewal guardian
   //    (`ReservationVault.setRenewalGuardian`),
-  // 4. Unpause renewals (`ReservationVault.unpauseRenewals`) — the vault
-  //    deploys with renewals paused.
+  // 3. If renewals should start enabled, unpause them
+  //    (`ReservationVault.unpauseRenewals`) — the vault deploys paused,
+  // 4. As the final activation step, mark the fully configured vault as
+  //    trusted: `BridgeGovernance.setVaultStatus(vault, true)`.
+  // `unpauseRenewals` gates `extendCustody` only; it is not a global pause for
+  // reserved deposit reveals. Vault trust is the safe activation boundary.
   // None of these actions are performed by this script.
 
   if (hre.network.tags.etherscan) {

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -3,7 +3,7 @@ import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { deployments, getNamedAccounts, helpers } = hre
-  const { deployer } = await getNamedAccounts()
+  const { deployer, governance } = await getNamedAccounts()
 
   const Bank = await deployments.get("Bank")
   const TBTCVault = await deployments.get("TBTCVault")
@@ -16,11 +16,26 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
     waitConfirmations: 1,
   })
 
+  // The vault administers the reservation fee schedule and the renewal
+  // pause/block policy; that authority must not remain with the deployer.
+  // The vault deploys with renewals paused, so the activation ceremony is
+  // entirely in governance hands from here.
+  await deployments.execute(
+    "ReservationVault",
+    { from: deployer, log: true, waitConfirmations: 1 },
+    "transferOwnership",
+    governance
+  )
+
   // NOTE: To activate reservations, governance must additionally:
   // 1. Mark the vault as trusted: `Bridge.setVaultStatus(vault, true)`,
   // 2. Wire it as the reservation vault and set the parameters:
-  //    `Bridge.updateReservationParameters(vault, ...)`.
-  // Neither action is performed by this script.
+  //    `Bridge.updateReservationParameters(vault, ...)`,
+  // 3. Optionally appoint a renewal guardian
+  //    (`ReservationVault.setRenewalGuardian`),
+  // 4. Unpause renewals (`ReservationVault.unpauseRenewals`) — the vault
+  //    deploys with renewals paused.
+  // None of these actions are performed by this script.
 
   if (hre.network.tags.etherscan) {
     await helpers.etherscan.verify(reservationVault)

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1314,7 +1314,7 @@ describe("Bridge - Reservation", () => {
     })
 
     it("stages the parameters and applies them after the governance delay", async () => {
-      await bridgeGovernance
+      const beginTx = await bridgeGovernance
         .connect(governance)
         .beginReservationParametersUpdate(
           reservationVault.address,
@@ -1326,6 +1326,21 @@ describe("Bridge - Reservation", () => {
           MAX_RESERVATIONS_PER_WALLET,
           RESERVATION_ACTION_TIMEOUT,
           RESERVATION_RENEWAL_WINDOW
+        )
+
+      await expect(beginTx)
+        .to.emit(bridgeGovernance, "ReservationParametersUpdateStarted")
+        .withArgs(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW,
+          await lastBlockTime()
         )
 
       await expect(
@@ -1821,6 +1836,20 @@ describe("Bridge - Reservation", () => {
         closingStartedAt: 0,
         pendingMovedFundsSweepRequestsCount: 0,
         state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+    }
+
+    async function movingFundsWallet(pkh: string) {
+      await bridge.setWallet(pkh, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: await lastBlockTime(),
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.MovingFunds,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
     }
@@ -2327,6 +2356,64 @@ describe("Bridge - Reservation", () => {
       const reservation = await bridge.reservations(reservationKey)
       expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
       expect(reservation.state).to.equal(ReservationState.Active)
+    })
+
+    it("allows a permissionless migration re-anchor before dissolution is due", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      await movingFundsWallet(walletPubKeyHash)
+      await liveWallet(secondWalletPubKeyHash)
+
+      const tx = await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationReanchorRequested")
+        .withArgs(
+          reservationKey,
+          2,
+          walletPubKeyHash,
+          secondWalletPubKeyHash,
+          RESERVATION_TX_MAX_FEE
+        )
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.ActionPending
+      )
+    })
+
+    it("rejects migration re-anchors at and after dissolution eligibility", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      await movingFundsWallet(walletPubKeyHash)
+      await liveWallet(secondWalletPubKeyHash)
+
+      const reservation = await bridge.reservations(reservationKey)
+      await ethers.provider.send("evm_setNextBlockTimestamp", [
+        Number(reservation.dissolutionEligibleAt),
+      ])
+      await ethers.provider.send("evm_mine", [])
+
+      // callStatic evaluates at the exact boundary; the transaction below
+      // evaluates after it. Neither can replace dissolution with a fresh
+      // permissionless re-anchor generation.
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .callStatic.requestReservationReanchor(
+            reservationKey,
+            secondWalletPubKeyHash
+          )
+      ).to.be.revertedWith("Reservation is dissolution-eligible")
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Reservation is dissolution-eligible")
+
+      const unchanged = await bridge.reservations(reservationKey)
+      expect(unchanged.state).to.equal(ReservationState.Active)
+      expect(unchanged.requestNonce).to.equal(1)
     })
 
     it("rejects a re-anchor paying a wallet other than the authorized target", async () => {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1144,7 +1144,7 @@ describe("Bridge - Reservation", () => {
         const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
         const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
 
-        await reservationVault.connect(deployer).updateFees(40, 20, 500)
+        await reservationVault.connect(governance).updateFees(40, 20, 500)
 
         await expect(
           reservationVault
@@ -1189,7 +1189,7 @@ describe("Bridge - Reservation", () => {
           (await bridge.reservations(exposedReservationKey)).state
         ).to.equal(2)
 
-        await reservationVault.connect(deployer).updateFees(40, 20, 20)
+        await reservationVault.connect(governance).updateFees(40, 20, 20)
       })
     })
   })

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -37,6 +37,7 @@ const RESERVATION_TX_MAX_FEE = 2000
 const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
 const MAX_RESERVATIONS_PER_WALLET = 10
 const RESERVATION_ACTION_TIMEOUT = 172800 // 48 hours
+const RESERVATION_RENEWAL_WINDOW = 2592000 // 30 days
 
 const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
 
@@ -140,7 +141,8 @@ describe("Bridge - Reservation", () => {
         RESERVATION_GRACE,
         RESERVATION_MAX_TOTAL,
         MAX_RESERVATIONS_PER_WALLET,
-        RESERVATION_ACTION_TIMEOUT
+        RESERVATION_ACTION_TIMEOUT,
+        RESERVATION_RENEWAL_WINDOW
       )
   }
 
@@ -151,20 +153,20 @@ describe("Bridge - Reservation", () => {
     walletPubKeyHash: string,
     amountSat: BigNumber
   ) {
+    const expiresAt = (await lastBlockTime()) + RESERVATION_TERM
     return {
       owner,
       mintedAmount: amountSat,
       acceptedAt: await lastBlockTime(),
       walletPubKeyHash,
       anchorAmount: amountSat,
-      expiresAt: (await lastBlockTime()) + RESERVATION_TERM,
+      expiresAt,
       anchorTxHash: ethers.utils.randomBytes(32),
       anchorTxOutputIndex: 0,
       state: ReservationState.Active,
       requestNonce: 0,
       retryCredit: false,
-      termSeconds: RESERVATION_TERM,
-      gracePeriod: RESERVATION_GRACE,
+      dissolutionEligibleAt: expiresAt + RESERVATION_GRACE,
     }
   }
 
@@ -333,7 +335,8 @@ describe("Bridge - Reservation", () => {
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
               MAX_RESERVATIONS_PER_WALLET,
-              RESERVATION_ACTION_TIMEOUT
+              RESERVATION_ACTION_TIMEOUT,
+              RESERVATION_RENEWAL_WINDOW
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -351,7 +354,8 @@ describe("Bridge - Reservation", () => {
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
             MAX_RESERVATIONS_PER_WALLET,
-            RESERVATION_ACTION_TIMEOUT
+            RESERVATION_ACTION_TIMEOUT,
+            RESERVATION_RENEWAL_WINDOW
           )
 
         await expect(tx)
@@ -366,7 +370,8 @@ describe("Bridge - Reservation", () => {
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
             MAX_RESERVATIONS_PER_WALLET,
-            RESERVATION_ACTION_TIMEOUT
+            RESERVATION_ACTION_TIMEOUT,
+            RESERVATION_RENEWAL_WINDOW
           )
       })
 
@@ -382,11 +387,74 @@ describe("Bridge - Reservation", () => {
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
               MAX_RESERVATIONS_PER_WALLET,
-              RESERVATION_ACTION_TIMEOUT
+              RESERVATION_ACTION_TIMEOUT,
+              RESERVATION_RENEWAL_WINDOW
             )
         ).to.be.revertedWith(
           "Reservation transaction max fee must be greater than zero"
         )
+      })
+
+      it("should revert for a term outside the protocol bounds", async () => {
+        await expect(
+          bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            89 * 24 * 3600, // below the 90-day minimum
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            RESERVATION_ACTION_TIMEOUT,
+            RESERVATION_RENEWAL_WINDOW
+          )
+        ).to.be.revertedWith("Reservation term out of protocol bounds")
+
+        await expect(
+          bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            731 * 24 * 3600, // above the 730-day maximum
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            RESERVATION_ACTION_TIMEOUT,
+            RESERVATION_RENEWAL_WINDOW
+          )
+        ).to.be.revertedWith("Reservation term out of protocol bounds")
+      })
+
+      it("should enforce the renewal window strictly shorter than the term", async () => {
+        await expect(
+          bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_TERM,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            RESERVATION_ACTION_TIMEOUT,
+            RESERVATION_TERM // window == term reopens stacking
+          )
+        ).to.be.revertedWith("Renewal window must be shorter than the term")
+
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET,
+              RESERVATION_ACTION_TIMEOUT,
+              0
+            )
+        ).to.be.revertedWith("Renewal window must be shorter than the term")
       })
 
       it("should revert for a zero action timeout", async () => {
@@ -401,7 +469,8 @@ describe("Bridge - Reservation", () => {
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
               MAX_RESERVATIONS_PER_WALLET,
-              0
+              0,
+              RESERVATION_RENEWAL_WINDOW
             )
         ).to.be.revertedWith(
           "Reservation action timeout must be greater than zero"
@@ -430,7 +499,8 @@ describe("Bridge - Reservation", () => {
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
               MAX_RESERVATIONS_PER_WALLET,
-              RESERVATION_ACTION_TIMEOUT
+              RESERVATION_ACTION_TIMEOUT,
+              RESERVATION_RENEWAL_WINDOW
             )
         ).to.be.revertedWith("Active reservations exist")
       })
@@ -494,64 +564,298 @@ describe("Bridge - Reservation", () => {
     })
   })
 
-  describe("extendReservation", () => {
+  describe("reservation renewal", () => {
     const reservationKey = 777
     const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+    const amountSat = BigNumber.from(100000000)
+    const grossTbtc = amountSat.mul(SATOSHI_MULTIPLIER)
+    const extensionFee = grossTbtc.mul(20).div(10000)
+    let expiresAt: number
 
-    before(async () => {
+    // Renews through the impersonated vault, defaulting the intent values
+    // to the currently correct ones.
+    async function renewViaBridge(
+      overrides: { expected?: number; expectedNew?: number } = {}
+    ) {
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      return bridge
+        .connect(vaultSigner)
+        .extendReservation(
+          reservationKey,
+          overrides.expected ?? expiresAt,
+          overrides.expectedNew ?? expiresAt + RESERVATION_TERM
+        )
+    }
+
+    beforeEach(async () => {
       await createSnapshot()
       await wireReservations()
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
       await bridge.setReservation(
         reservationKey,
-        await activeReservation(
-          thirdParty.address,
-          walletPubKeyHash,
-          BigNumber.from(100000000)
-        )
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
+      expiresAt = (await bridge.reservations(reservationKey)).expiresAt
     })
 
-    after(async () => {
+    afterEach(async () => {
       await restoreSnapshot()
     })
 
-    context("when called by a third party", () => {
-      it("should revert", async () => {
-        await expect(
-          bridge.connect(thirdParty).extendReservation(reservationKey)
-        ).to.be.revertedWith("Caller is not the reservation vault")
-      })
+    it("should revert when called by a third party", async () => {
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .extendReservation(reservationKey, expiresAt, expiresAt + 1)
+      ).to.be.revertedWith("Caller is not the reservation vault")
     })
 
-    context("when called by the reservation vault", () => {
-      it("should extend the reservation term by the snapshotted length", async () => {
-        const before_ = await bridge.reservations(reservationKey)
+    it("should revert before the renewal window opens", async () => {
+      // Just before the window: E - W - a small margin.
+      await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW - 3600)
+      await expect(renewViaBridge()).to.be.revertedWith(
+        "Outside the renewal window"
+      )
+    })
 
-        // Change the live term parameter: the extension must use the
-        // position's snapshot, not the live value.
-        await bridge
-          .connect(bridgeGovernanceSigner)
-          .updateReservationParameters(
+    it("should renew inside the window and close at expiry", async () => {
+      await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW + 60)
+
+      const tx = await renewViaBridge()
+      const newExpiresAt = expiresAt + RESERVATION_TERM
+      await expect(tx)
+        .to.emit(bridge, "ReservationExtended")
+        .withArgs(
+          reservationKey,
+          expiresAt,
+          newExpiresAt,
+          newExpiresAt + RESERVATION_GRACE
+        )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.expiresAt).to.equal(newExpiresAt)
+      // The dissolution eligibility is re-snapshotted for the new term.
+      expect(reservation.dissolutionEligibleAt).to.equal(
+        newExpiresAt + RESERVATION_GRACE
+      )
+    })
+
+    it("should not stack renewals", async () => {
+      await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW + 60)
+      await renewViaBridge()
+
+      // Immediately after a renewal the position is outside its next
+      // window (the window is shorter than the term), so a second renewal
+      // cannot be stacked.
+      const newExpiresAt = expiresAt + RESERVATION_TERM
+      await expect(
+        renewViaBridge({
+          expected: newExpiresAt,
+          expectedNew: newExpiresAt + RESERVATION_TERM,
+        })
+      ).to.be.revertedWith("Outside the renewal window")
+    })
+
+    it("should reject renewal at and after expiry", async () => {
+      await increaseTime(RESERVATION_TERM + 1)
+      await expect(renewViaBridge()).to.be.revertedWith(
+        "Outside the renewal window"
+      )
+    })
+
+    it("should reject stale expiry intent", async () => {
+      await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW + 60)
+      await expect(
+        renewViaBridge({ expected: expiresAt - 1 })
+      ).to.be.revertedWith("Stale renewal: unexpected current expiry")
+    })
+
+    it("should reject a term change between construction and execution", async () => {
+      await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW + 60)
+
+      // Governance doubles the term after the owner constructed their
+      // renewal transaction committing to one old term.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_TERM * 2,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW
+        )
+
+      await expect(
+        renewViaBridge({ expectedNew: expiresAt + RESERVATION_TERM })
+      ).to.be.revertedWith("Stale renewal: unexpected new expiry")
+    })
+
+    it("should not renew a position with a pending action", async () => {
+      await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW + 60)
+      await requestRedemptionViaVault(
+        reservationKey,
+        amountSat,
+        thirdParty.address,
+        "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+      )
+      await expect(renewViaBridge()).to.be.revertedWith(
+        "Reservation is not active"
+      )
+    })
+
+    describe("vault renewal policy", () => {
+      let governanceOwner: SignerWithAddress
+      let guardian: SignerWithAddress
+
+      beforeEach(async () => {
+        // Deploy scripts hand the vault to the governance account and the
+        // vault starts with renewals paused.
+        governanceOwner = governance
+        ;[guardian] = (await ethers.getSigners()).slice(15, 16)
+        await reservationVault
+          .connect(governanceOwner)
+          .setRenewalGuardian(guardian.address)
+        await reservationVault.connect(governanceOwner).unpauseRenewals()
+
+        // Fund the owner with TBTC for the renewal fee.
+        const tbtcOwnerSigner = await impersonateContract(await tbtc.owner())
+        if ((await tbtc.owner()) !== tbtcVault.address) {
+          await tbtc
+            .connect(tbtcOwnerSigner)
+            .transferOwnership(tbtcVault.address)
+        }
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
             reservationVault.address,
-            RESERVATION_MIN_AMOUNT,
-            RESERVATION_TX_MAX_FEE,
-            RESERVATION_TERM * 2,
-            RESERVATION_GRACE,
-            RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET,
-            RESERVATION_ACTION_TIMEOUT
+            [thirdParty.address],
+            [amountSat]
           )
 
-        const vaultSigner = await impersonateContract(reservationVault.address)
-        const tx = await bridge
-          .connect(vaultSigner)
-          .extendReservation(reservationKey)
+        await increaseTime(RESERVATION_TERM - RESERVATION_RENEWAL_WINDOW + 60)
+        await tbtc
+          .connect(thirdParty)
+          .approve(reservationVault.address, extensionFee)
+      })
 
-        const after_ = await bridge.reservations(reservationKey)
-        expect(after_.expiresAt).to.equal(before_.expiresAt + RESERVATION_TERM)
+      it("renews for the owner with a fee bound", async () => {
+        const treasuryBefore = await tbtc.balanceOf(treasury.address)
+        const tx = await reservationVault
+          .connect(thirdParty)
+          .extendCustody(
+            reservationKey,
+            expiresAt,
+            expiresAt + RESERVATION_TERM,
+            extensionFee
+          )
         await expect(tx)
-          .to.emit(bridge, "ReservationExtended")
-          .withArgs(reservationKey, after_.expiresAt)
+          .to.emit(reservationVault, "CustodyExtended")
+          .withArgs(reservationKey, thirdParty.address, extensionFee)
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBefore.add(extensionFee)
+        )
+      })
+
+      it("rejects a fee above the caller's bound", async () => {
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .extendCustody(
+              reservationKey,
+              expiresAt,
+              expiresAt + RESERVATION_TERM,
+              extensionFee.sub(1)
+            )
+        ).to.be.revertedWith("Fee exceeds the caller's bound")
+      })
+
+      it("lets the guardian pause but not unpause", async () => {
+        await reservationVault.connect(guardian).pauseRenewals()
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .extendCustody(
+              reservationKey,
+              expiresAt,
+              expiresAt + RESERVATION_TERM,
+              extensionFee
+            )
+        ).to.be.revertedWith("Renewals are paused")
+
+        await expect(
+          reservationVault.connect(guardian).unpauseRenewals()
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+
+        // Pausing never blocks a redemption.
+        await requestRedemptionViaVault(
+          reservationKey,
+          amountSat,
+          thirdParty.address,
+          "0x160014f4eedc8f40d4b8e30771f792b065ebec0abaddef"
+        )
+        expect((await bridge.reservations(reservationKey)).state).to.equal(
+          ReservationState.ActionPending
+        )
+      })
+
+      it("lets the guardian block a single reservation but not unblock it", async () => {
+        await reservationVault.connect(guardian).blockRenewal(reservationKey)
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .extendCustody(
+              reservationKey,
+              expiresAt,
+              expiresAt + RESERVATION_TERM,
+              extensionFee
+            )
+        ).to.be.revertedWith("Reservation renewal blocked")
+
+        await expect(
+          reservationVault.connect(guardian).unblockRenewal(reservationKey)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+
+        await reservationVault
+          .connect(governanceOwner)
+          .unblockRenewal(reservationKey)
+        const tx = await reservationVault
+          .connect(thirdParty)
+          .extendCustody(
+            reservationKey,
+            expiresAt,
+            expiresAt + RESERVATION_TERM,
+            extensionFee
+          )
+        await expect(tx).to.emit(reservationVault, "CustodyExtended")
+      })
+
+      it("keeps policy actions away from third parties", async () => {
+        await expect(
+          reservationVault.connect(thirdParty).pauseRenewals()
+        ).to.be.revertedWith("Caller is not the renewal guardian or owner")
+        await expect(
+          reservationVault.connect(thirdParty).blockRenewal(reservationKey)
+        ).to.be.revertedWith("Caller is not the renewal guardian or owner")
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .setRenewalGuardian(guardian.address)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
       })
     })
   })
@@ -1020,7 +1324,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
-          RESERVATION_ACTION_TIMEOUT
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW
         )
 
       await expect(
@@ -1049,7 +1354,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
-          RESERVATION_ACTION_TIMEOUT
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW
         )
     })
   })
@@ -1697,8 +2003,11 @@ describe("Bridge - Reservation", () => {
       expect(reservation.anchorAmount).to.equal(anchorAmount)
       expect(reservation.anchorTxHash).to.equal(anchorTx.txHash)
       expect(reservation.state).to.equal(ReservationState.Active)
-      expect(reservation.termSeconds).to.equal(RESERVATION_TERM)
-      expect(reservation.gracePeriod).to.equal(RESERVATION_GRACE)
+      // The dissolution eligibility is snapshotted from the current
+      // dissolution delay at the moment the term is granted.
+      expect(reservation.dissolutionEligibleAt).to.equal(
+        reservation.expiresAt + RESERVATION_GRACE
+      )
 
       // The capacity reserved at authorization released the miner-fee
       // delta at settlement: the total tracks the anchor value.
@@ -1877,7 +2186,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
-          RESERVATION_ACTION_TIMEOUT
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW
         )
 
       const redeemerScript = `0x16${p2wpkhScript(
@@ -2054,10 +2364,10 @@ describe("Bridge - Reservation", () => {
     it("dissolves an expired reservation into the wallet main UTXO", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
 
-      // Not requestable before term + grace.
+      // Not requestable before the dissolution eligibility snapshot.
       await expect(
         bridge.connect(thirdParty).requestReservationDissolution(reservationKey)
-      ).to.be.revertedWith("Reservation term or grace period not elapsed")
+      ).to.be.revertedWith("Reservation not dissolution-eligible yet")
 
       await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
 

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -2077,7 +2077,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
-          6 * 24 * 60 * 60
+          6 * 24 * 60 * 60,
+          RESERVATION_RENEWAL_WINDOW
         )
 
       await expect(
@@ -2100,7 +2101,8 @@ describe("Bridge - Reservation", () => {
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
-          4 * 24 * 60 * 60
+          4 * 24 * 60 * 60,
+          RESERVATION_RENEWAL_WINDOW
         )
       await expect(
         bridge

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -39,6 +39,7 @@ const RESERVATION_TX_MAX_FEE = 2000
 const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
 const MAX_RESERVATIONS_PER_WALLET = 10
 const RESERVATION_ACTION_TIMEOUT = 172800 // 48 hours
+const RESERVATION_RENEWAL_WINDOW = 2592000 // 30 days
 
 const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
 
@@ -136,7 +137,8 @@ describe("Bridge - Reservation settlement", () => {
         RESERVATION_GRACE,
         RESERVATION_MAX_TOTAL,
         MAX_RESERVATIONS_PER_WALLET,
-        RESERVATION_ACTION_TIMEOUT
+        RESERVATION_ACTION_TIMEOUT,
+        RESERVATION_RENEWAL_WINDOW
       )
 
     relay.getCurrentEpochDifficulty.returns(0)
@@ -952,7 +954,8 @@ describe("Bridge - Reservation settlement", () => {
         RESERVATION_GRACE,
         params.reservationTotalAmount, // no room beyond what is reserved
         MAX_RESERVATIONS_PER_WALLET,
-        RESERVATION_ACTION_TIMEOUT
+        RESERVATION_ACTION_TIMEOUT,
+        RESERVATION_RENEWAL_WINDOW
       )
 
       // A new authorization cannot be created any more...
@@ -1121,11 +1124,13 @@ describe("Bridge - Reservation settlement", () => {
       await restoreSnapshot()
     })
 
-    it("rejects requests after the grace period (stranding bound)", async () => {
+    it("rejects requests at and after expiry (stranding bound)", async () => {
       const { reservationKey } = await makeAcceptedReservation()
       await makeAcceptedReservation()
 
-      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      // Strictly pre-expiry: at/after expiry no new redemption generation
+      // can be created; the dissolution delay is not an owner window.
+      await increaseTime(RESERVATION_TERM + 1)
 
       const redemptionFee = grossTbtc.mul(20).div(10000)
       await tbtc
@@ -1135,7 +1140,7 @@ describe("Bridge - Reservation settlement", () => {
         reservationVault
           .connect(thirdParty)
           .redeemReservation(reservationKey, randomRedeemerScript())
-      ).to.be.revertedWith("Reservation past grace period")
+      ).to.be.revertedWith("Reservation expired")
     })
 
     it("rejects requests while the wallet is not Live or MovingFunds", async () => {

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -135,6 +135,34 @@ describe("ReservationRouter", () => {
   })
 
   describe("storage layout parity", () => {
+    it("should consume exactly eight slots from the deployed Bridge gap", async () => {
+      const bridgeLayout = await getStorageLayout(
+        "contracts/bridge/Bridge.sol",
+        "Bridge"
+      )
+      const self = bridgeLayout.storage.find((entry) => entry.label === "self")
+      if (!self) {
+        throw new Error("No BridgeState.Storage entry in Bridge layout")
+      }
+
+      const storageType = bridgeLayout.types[self.type]
+      const gap = storageType.members?.find(
+        (member) => member.label === "__gap"
+      )
+      if (!gap) {
+        throw new Error("No BridgeState.Storage.__gap entry in Bridge layout")
+      }
+
+      // The deployed layout reserves slots 81..128. Reservation state uses
+      // exactly eight of them, so the remaining gap starts at 89, contains
+      // 40 slots, and still ends at the original slot boundary.
+      const gapType = bridgeLayout.types[gap.type]
+      const absoluteGapSlot = Number(self.slot) + Number(gap.slot)
+      expect(absoluteGapSlot).to.equal(89)
+      expect(gapType.numberOfBytes).to.equal((40 * 32).toString())
+      expect(absoluteGapSlot + Number(gapType.numberOfBytes) / 32).to.equal(129)
+    })
+
     it("should give the router the exact storage layout of the Bridge", async () => {
       const bridgeLayout = await getStorageLayout(
         "contracts/bridge/Bridge.sol",

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -342,12 +342,13 @@ describe("ReservationRouter", () => {
             2592000,
             100000000000,
             10,
-            172800
+            172800,
+            2592000
           )
       ).to.be.revertedWith("Caller is not the governance")
 
       await expect(
-        standaloneRouter.connect(thirdParty).extendReservation(1)
+        standaloneRouter.connect(thirdParty).extendReservation(1, 0, 0)
       ).to.be.revertedWith("Caller is not the reservation vault")
 
       await expect(

--- a/solidity/test/deploy/95_deploy_reservation_vault.test.ts
+++ b/solidity/test/deploy/95_deploy_reservation_vault.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { expect } from "chai"
+
+import { equal } from "@keep-network/hardhat-helpers/dist/address"
+import { transferOwnership } from "@keep-network/hardhat-helpers/dist/ownable"
+
+import func from "../../deploy/95_deploy_reservation_vault"
+
+describe("Deploy Script 95: ReservationVault", () => {
+  const deployer = "0x1000000000000000000000000000000000000001"
+  const governance = "0x2000000000000000000000000000000000000002"
+  const bank = "0x3000000000000000000000000000000000000003"
+  const tbtcVault = "0x4000000000000000000000000000000000000004"
+  const bridge = "0x5000000000000000000000000000000000000005"
+  const reservationVault = "0x6000000000000000000000000000000000000006"
+
+  function createMockHre({ failVerification = false } = {}) {
+    let currentOwner = deployer
+    let verificationShouldFail = failVerification
+
+    const executeCalls: Array<{
+      name: string
+      methodName: string
+      args: any[]
+    }> = []
+    const verifyCalls: any[] = []
+
+    const deploymentsByName: Record<string, { address: string }> = {
+      Bank: { address: bank },
+      TBTCVault: { address: tbtcVault },
+      Bridge: { address: bridge },
+    }
+
+    const mockHre: any = {
+      deployments: {
+        get: async (name: string) => deploymentsByName[name],
+        deploy: async () => ({
+          address: reservationVault,
+          newlyDeployed: false,
+        }),
+        read: async () => currentOwner,
+        execute: async (
+          name: string,
+          _options: any,
+          methodName: string,
+          ...args: any[]
+        ) => {
+          if (currentOwner !== deployer) {
+            throw new Error("Ownable: caller is not the owner")
+          }
+          executeCalls.push({ name, methodName, args })
+          const [newOwner] = args
+          currentOwner = newOwner
+          return {}
+        },
+        log: () => undefined,
+      },
+      getNamedAccounts: async () => ({ deployer, governance }),
+      helpers: {
+        address: { equal },
+        etherscan: {
+          verify: async (deployment: any) => {
+            verifyCalls.push(deployment)
+            if (verificationShouldFail) {
+              throw new Error("mock verification failure")
+            }
+          },
+        },
+      },
+      network: { tags: { etherscan: true } },
+    }
+
+    mockHre.helpers.ownable = {
+      transferOwnership: (
+        contractName: string,
+        newOwnerAddress: string,
+        from: string
+      ) => transferOwnership(mockHre, contractName, newOwnerAddress, from),
+    }
+
+    return {
+      mockHre,
+      executeCalls,
+      verifyCalls,
+      owner: () => currentOwner,
+      setVerificationFailure: (value: boolean) => {
+        verificationShouldFail = value
+      },
+    }
+  }
+
+  it("resumes after ownership transfer when verification failed", async () => {
+    const harness = createMockHre({ failVerification: true })
+
+    let firstRunError: Error | undefined
+    try {
+      await func(harness.mockHre)
+    } catch (error) {
+      firstRunError = error as Error
+    }
+
+    expect(firstRunError?.message).to.equal("mock verification failure")
+    expect(harness.owner()).to.equal(governance)
+    expect(harness.executeCalls).to.have.lengthOf(1)
+    expect(harness.executeCalls[0]).to.deep.equal({
+      name: "ReservationVault",
+      methodName: "transferOwnership",
+      args: [governance],
+    })
+
+    harness.setVerificationFailure(false)
+    await func(harness.mockHre)
+
+    expect(harness.owner()).to.equal(governance)
+    expect(harness.executeCalls).to.have.lengthOf(1)
+    expect(harness.verifyCalls).to.have.lengthOf(2)
+  })
+})


### PR DESCRIPTION
Stacked on #1091 (two-phase settlement). Implements the settled renewal/expiry design from the implementation handoff: **permissionless, default-allow renewal with bounded lookahead and exception-only governance controls**.

## Renewal (Bridge)

- `extendReservation(key, expectedExpiresAt, expectedNewExpiresAt)` adds **exactly one current term** and is valid only inside the renewal window: `expiresAt − window ≤ now < expiresAt`. `0 < window < term` is enforced atomically at every parameter change *and* re-checked at execution, so a fresh renewal is immediately outside its next window — **terms can never be stacked**; maximum owner lookahead = one term + window. Reentrant/same-block/repeat calls fail by the same arithmetic.
- **Intent binding**: the call commits to the observed expiry and the expected new expiry — stale transactions and mid-flight term changes revert instead of silently buying a different duration.
- Term bounded by protocol constants **90–730 days** (baseline per the design; flagged for sign-off).
- The grace period becomes a pure **dissolution delay**: each granted term snapshots `dissolutionEligibleAt = expiresAt + currentDissolutionDelay` (re-snapshotted per renewal). Dissolution requests use the snapshot — later governance changes never move the eligibility of a term already granted.
- **Strict expiry cutoff**: new reserved-redemption generations (including the fee-free retry) require `now < expiresAt`. The post-expiry delay is not an owner window; no owner action beginning at/after expiry can delay dissolution. Final expiry + dissolution delay + one action timeout is a hard stranding bound (plus one final front-run term under governance intervention, per the recovery-bound analysis).

## Renewal policy (vault)

- `extendCustody(key, expectedExpiresAt, expectedNewExpiresAt, maxFeeTbtc)`: ownership + policy checks, Bridge renewal executed **before** the fee transfer (atomic either way), fee bounded by the caller's `maxFeeTbtc`.
- Exception-only controls: global `pauseRenewals` + per-key `blockRenewal`, applicable **immediately** by a renewal guardian or the owner (restrictive actions are monotonic — they never shorten a purchased term, never touch funds, never affect redemption/re-anchor/dissolution); only the owner (governance) can `unpauseRenewals`, `unblockRenewal`, or replace the guardian. Blocks key on the stable reservation key, so they survive re-anchors and wallet migration.
- **A fresh vault starts paused**, and the deploy script now transfers vault ownership to governance — activation is entirely in governance hands (trust the vault placement only with the M-04 pending-deposit guard, next in the stack; the vault ships disabled until then).

## Storage

`BridgeState`: `reservationGracePeriod` → `reservationDissolutionDelay` (layout-safe rename) + append `reservationRenewalWindowSeconds` (gap 39→38). Position struct: `termSeconds`/`gracePeriod` snapshots replaced by `dissolutionEligibleAt`. Grouped governance staging updated.

## Defaults surfaced for sign-off

| Parameter | Value |
|---|---|
| Term bounds (protocol constants) | 90–730 days |
| Term default | 365 days |
| Renewal window | 30 days |
| Dissolution delay | 30 days |
| Fees | 40 bps initiation / 20 bps per renewal / 20 bps redemption |

## Tests

Full suite **3081 passing / 0 failing**; slither (CI-pinned 0.9.0) clean. New coverage: window boundaries (before window / in window / at expiry), non-stacking, stale expiry intent, term-change-mid-flight, pending-action exclusion, pause/block/guardian authority split (guardian can restrict, cannot relax; pause does not block redemption), fee bound, term-bounds and `window < term` parameter validation, dissolution-eligibility snapshot assertions, strict-expiry stranding bound.

RFC 13 updated to the renewal model (replaces the earlier grace-window/renewal-horizon text).