### PR TITLE
feat(bridge): claim-equals-anchor backing model with financed in-kind fees

### DIFF
--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -293,6 +293,12 @@ contract BridgeGovernance is Ownable {
     event TreasuryUpdateStarted(address newTreasury, uint256 timestamp);
     event TreasuryUpdated(address treasury);
 
+    event ReservationCapsUpdateStarted(
+        uint64 newMaxReservationsAmountPerWallet,
+        uint64 newReservationMaxSingleAmount,
+        uint256 timestamp
+    );
+
     constructor(Bridge _bridge, uint256 _governanceDelay) {
         bridge = _bridge;
         governanceDelays[0] = _governanceDelay;

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -34,6 +34,7 @@ contract BridgeGovernance is Ownable {
     using BridgeGovernanceParameters for BridgeGovernanceParameters.FraudData;
     using BridgeGovernanceParameters for BridgeGovernanceParameters.TreasuryData;
     using BridgeGovernanceParameters for BridgeGovernanceParameters.ReservationData;
+    using BridgeGovernanceParameters for BridgeGovernanceParameters.ReservationCapsData;
 
     BridgeGovernanceParameters.DepositData internal depositData;
     BridgeGovernanceParameters.RedemptionData internal redemptionData;
@@ -42,6 +43,7 @@ contract BridgeGovernance is Ownable {
     BridgeGovernanceParameters.FraudData internal fraudData;
     BridgeGovernanceParameters.TreasuryData internal treasuryData;
     BridgeGovernanceParameters.ReservationData internal reservationData;
+    BridgeGovernanceParameters.ReservationCapsData internal reservationCapsData;
 
     Bridge internal bridge;
 
@@ -1837,6 +1839,33 @@ contract BridgeGovernance is Ownable {
             _newMaxReservationsPerWallet,
             _newReservationActionTimeout,
             _newReservationRenewalWindowSeconds
+        );
+    }
+
+    /// @notice Begins the reservation caps update process. Both
+    ///         amount-denominated caps are staged together since they are
+    ///         applied atomically via a single Bridge call.
+    /// @dev Can be called only by the contract owner.
+    function beginReservationCapsUpdate(
+        uint64 _newMaxReservationsAmountPerWallet,
+        uint64 _newReservationMaxSingleAmount
+    ) external onlyOwner {
+        reservationCapsData.beginReservationCapsUpdate(
+            _newMaxReservationsAmountPerWallet,
+            _newReservationMaxSingleAmount
+        );
+    }
+
+    /// @notice Finalizes the reservation caps update process.
+    /// @dev Can be called only by the contract owner, after the governance
+    ///      delay elapses.
+    function finalizeReservationCapsUpdate() external onlyOwner {
+        BridgeGovernanceParameters.ReservationCapsData
+            memory staged = reservationCapsData;
+        reservationCapsData.finalizeReservationCapsUpdate(governanceDelay());
+        IReservationBridge(address(bridge)).updateReservationCaps(
+            staged.newMaxReservationsAmountPerWallet,
+            staged.newReservationMaxSingleAmount
         );
     }
 

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -1585,6 +1585,18 @@ library BridgeGovernanceParameters {
         uint256 reservationParametersChangeInitiated;
     }
 
+    struct ReservationCapsData {
+        uint64 newMaxReservationsAmountPerWallet;
+        uint64 newReservationMaxSingleAmount;
+        uint256 reservationCapsChangeInitiated;
+    }
+
+    event ReservationCapsUpdateStarted(
+        uint64 newMaxReservationsAmountPerWallet,
+        uint64 newReservationMaxSingleAmount,
+        uint256 timestamp
+    );
+
     event ReservationParametersUpdateStarted(
         address newReservationVault,
         uint64 newReservationMinAmount,
@@ -1638,6 +1650,42 @@ library BridgeGovernanceParameters {
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Begins the reservation caps update process.
+    function beginReservationCapsUpdate(
+        ReservationCapsData storage self,
+        uint64 _newMaxReservationsAmountPerWallet,
+        uint64 _newReservationMaxSingleAmount
+    ) external {
+        /* solhint-disable not-rely-on-time */
+        self
+            .newMaxReservationsAmountPerWallet = _newMaxReservationsAmountPerWallet;
+        self.newReservationMaxSingleAmount = _newReservationMaxSingleAmount;
+        self.reservationCapsChangeInitiated = block.timestamp;
+        emit ReservationCapsUpdateStarted(
+            _newMaxReservationsAmountPerWallet,
+            _newReservationMaxSingleAmount,
+            block.timestamp
+        );
+        /* solhint-enable not-rely-on-time */
+    }
+
+    /// @notice Finalizes the reservation caps update process.
+    /// @dev The staged values are read by the caller before this call; this
+    ///      function only enforces the governance delay and clears the
+    ///      staged change.
+    function finalizeReservationCapsUpdate(
+        ReservationCapsData storage self,
+        uint256 governanceDelay
+    )
+        external
+        onlyAfterGovernanceDelay(
+            self.reservationCapsChangeInitiated,
+            governanceDelay
+        )
+    {
+        self.reservationCapsChangeInitiated = 0;
     }
 
     /// @notice Finalizes the reservation parameters update process.

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -403,6 +403,17 @@ library BridgeState {
         // dissolutions of a no-main-UTXO wallet could all confirm on
         // Bitcoin with only the first being provable.
         mapping(bytes20 => uint256) walletPendingDissolution;
+        // Total satoshi amount of reservation anchors (and reserved
+        // capacity of pending reservation actions) custodied by the given
+        // wallet. Because the claim always equals the anchor, this is both
+        // the asset- and the liability-side per-wallet figure.
+        mapping(bytes20 => uint64) walletReservationsAmount;
+        // Maximum total satoshi amount of reservation anchors a single
+        // wallet can custody. Zero disables the cap.
+        uint64 maxReservationsAmountPerWallet;
+        // Maximum satoshi amount of a single reservation. Zero disables
+        // the cap.
+        uint64 reservationMaxSingleAmount;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -410,7 +421,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[38] __gap;
+        uint256[36] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/IReservationBridge.sol
+++ b/solidity/contracts/bridge/IReservationBridge.sol
@@ -79,6 +79,21 @@ interface IReservationBridge {
         uint32 reservationRenewalWindowSeconds
     ) external;
 
+    /// @notice See `ReservationRouter.updateReservationCaps`.
+    function updateReservationCaps(
+        uint64 maxReservationsAmountPerWallet,
+        uint64 reservationMaxSingleAmount
+    ) external;
+
+    /// @notice See `ReservationRouter.reservationCaps`.
+    function reservationCaps()
+        external
+        view
+        returns (
+            uint64 maxReservationsAmountPerWallet,
+            uint64 reservationMaxSingleAmount
+        );
+
     /// @notice Bridge treasury address. Declared by the Bridge contract
     ///         itself (not the router); included here so reservation
     ///         consumers can use a single interface against the Bridge

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -295,6 +295,11 @@ library Reservation {
 
     event ReservationVaultUpdated(address reservationVault);
 
+    event ReservationCapsUpdated(
+        uint64 maxReservationsAmountPerWallet,
+        uint64 reservationMaxSingleAmount
+    );
+
     /// @notice Computes the storage key of the action record of the given
     ///         reservation generation.
     function actionKey(uint256 reservationKey, uint64 requestNonce)
@@ -427,6 +432,12 @@ library Reservation {
             );
         }
 
+        require(
+            self.reservationMaxSingleAmount == 0 ||
+                deposit.amount <= self.reservationMaxSingleAmount,
+            "Reservation exceeds the single-reservation cap"
+        );
+
         // Reserve capacity using the deposit value as the upper bound of
         // the anchor value; the settlement releases the miner-fee delta.
         uint64 newTotal = self.reservationTotalAmount + deposit.amount;
@@ -442,6 +453,15 @@ library Reservation {
             "Wallet reservations cap exceeded"
         );
         self.walletReservationsCount[walletPubKeyHash] = walletCount;
+
+        uint64 walletAmount = self.walletReservationsAmount[walletPubKeyHash] +
+            deposit.amount;
+        require(
+            self.maxReservationsAmountPerWallet == 0 ||
+                walletAmount <= self.maxReservationsAmountPerWallet,
+            "Wallet reserved amount cap exceeded"
+        );
+        self.walletReservationsAmount[walletPubKeyHash] = walletAmount;
 
         uint64 requestNonce = ++reservation.requestNonce;
 
@@ -679,8 +699,8 @@ library Reservation {
             "Target wallet must be in Live state"
         );
 
-        // Reserve the target wallet's count capacity; the source wallet's
-        // count is released at settlement (or kept on timeout).
+        // Reserve the target wallet's count and amount capacity; the
+        // source wallet's are released at settlement (or kept on timeout).
         uint32 targetCount = self.walletReservationsCount[
             targetWalletPubKeyHash
         ] + 1;
@@ -689,6 +709,16 @@ library Reservation {
             "Wallet reservations cap exceeded"
         );
         self.walletReservationsCount[targetWalletPubKeyHash] = targetCount;
+
+        uint64 targetAmount = self.walletReservationsAmount[
+            targetWalletPubKeyHash
+        ] + reservation.anchorAmount;
+        require(
+            self.maxReservationsAmountPerWallet == 0 ||
+                targetAmount <= self.maxReservationsAmountPerWallet,
+            "Wallet reserved amount cap exceeded"
+        );
+        self.walletReservationsAmount[targetWalletPubKeyHash] = targetAmount;
 
         reservation.state = ReservationState.ActionPending;
         uint64 requestNonce = ++reservation.requestNonce;
@@ -852,6 +882,9 @@ library Reservation {
             // the refund-locktime margin allows.
             self.reservationTotalAmount -= action.amount;
             self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
+            self.walletReservationsAmount[
+                action.targetWalletPubKeyHash
+            ] -= action.amount;
         } else if (actionType == ActionType.Redemption) {
             reservation.state = ReservationState.Active;
 
@@ -871,8 +904,11 @@ library Reservation {
             self.bank.transferBalance(action.redeemer, action.amount);
         } else if (actionType == ActionType.Reanchor) {
             reservation.state = ReservationState.Active;
-            // Release the target wallet's reserved count capacity.
+            // Release the target wallet's reserved capacity.
             self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
+            self.walletReservationsAmount[
+                action.targetWalletPubKeyHash
+            ] -= action.amount;
         } else {
             // Dissolution.
             reservation.state = ReservationState.Active;
@@ -1122,6 +1158,27 @@ library Reservation {
         );
     }
 
+    /// @notice Updates the amount-denominated reservation caps. Checked
+    ///         and reserved at request/authorization time, never at proof
+    ///         time; a zero value disables the respective cap.
+    /// @param maxReservationsAmountPerWallet New cap on the total satoshi
+    ///        amount of anchors a single wallet can custody.
+    /// @param reservationMaxSingleAmount New cap on the satoshi amount of
+    ///        a single reservation.
+    function updateReservationCaps(
+        BridgeState.Storage storage self,
+        uint64 maxReservationsAmountPerWallet,
+        uint64 reservationMaxSingleAmount
+    ) external {
+        self.maxReservationsAmountPerWallet = maxReservationsAmountPerWallet;
+        self.reservationMaxSingleAmount = reservationMaxSingleAmount;
+
+        emit ReservationCapsUpdated(
+            maxReservationsAmountPerWallet,
+            reservationMaxSingleAmount
+        );
+    }
+
     /// @notice Closes a reservation: adjusts the wallet reservation count
     ///         and the total reserved amount, and marks the reservation as
     ///         Closed.
@@ -1130,6 +1187,9 @@ library Reservation {
         ReservationRequest storage reservation
     ) internal {
         self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
+        self.walletReservationsAmount[
+            reservation.walletPubKeyHash
+        ] -= reservation.anchorAmount;
         self.reservationTotalAmount -= reservation.anchorAmount;
         reservation.state = ReservationState.Closed;
     }

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -27,6 +27,7 @@ import "./Reservation.sol";
 import "./Wallets.sol";
 
 import "../bank/Bank.sol";
+import "../vault/IReservationFeeFinancer.sol";
 
 /// @title Bridge UTXO reservations — settlement
 /// @notice SPV settlement side of the two-phase reservation model (see
@@ -342,6 +343,9 @@ library ReservationProofs {
             // already confirmed on Bitcoin.
             self.reservationTotalAmount += anchorAmount;
             self.walletReservationsCount[action.targetWalletPubKeyHash] += 1;
+            self.walletReservationsAmount[
+                action.targetWalletPubKeyHash
+            ] += anchorAmount;
             emit ReservationLateSettled(
                 reservationKey,
                 requestNonce,
@@ -351,6 +355,9 @@ library ReservationProofs {
             // Release the difference between the reserved upper bound
             // (deposit value) and the actual anchor value (miner fee).
             self.reservationTotalAmount -= (action.amount - anchorAmount);
+            self.walletReservationsAmount[
+                action.targetWalletPubKeyHash
+            ] -= (action.amount - anchorAmount);
         }
 
         address depositor = self.deposits[reservationKey].depositor;
@@ -614,9 +621,12 @@ library ReservationProofs {
         );
 
         if (late) {
-            // The timeout released the target wallet's reserved count;
-            // re-take it. Deliberately no cap check (see acceptance).
+            // The timeout released the target wallet's reserved count and
+            // amount; re-take them. Deliberately no cap check (see
+            // acceptance).
             self.walletReservationsCount[newWalletPubKeyHash] += 1;
+            self.walletReservationsAmount[newWalletPubKeyHash] += reservation
+                .anchorAmount;
 
             // A newer pending generation references an anchor this
             // transaction just consumed; unwind it.
@@ -634,19 +644,41 @@ library ReservationProofs {
             );
         }
 
-        // The source wallet's count is released now; the target wallet's
-        // count was reserved at request time (or re-taken above).
+        // The source wallet's count and amount are released now; the
+        // target wallet's were reserved at request time (or re-taken
+        // above). The target reserved the pre-hop anchor value; release
+        // the miner-fee delta.
         self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
+        self.walletReservationsAmount[
+            reservation.walletPubKeyHash
+        ] -= reservation.anchorAmount;
+        self.walletReservationsAmount[newWalletPubKeyHash] -= (reservation
+            .anchorAmount - newAnchorAmount);
+
+        uint64 minerFee = reservation.anchorAmount - newAnchorAmount;
 
         // The miner fee reduces the on-chain earmarked amount.
-        self.reservationTotalAmount -= (reservation.anchorAmount -
-            newAnchorAmount);
+        self.reservationTotalAmount -= minerFee;
 
         reservation.walletPubKeyHash = newWalletPubKeyHash;
         reservation.anchorAmount = newAnchorAmount;
+        // The claim always equals the anchor: the miner fee is financed
+        // from the vault's custody-fee reserve (which burns supply in
+        // lockstep with the backing loss), and the claim is written down
+        // to the new anchor value. The owner's redemption surrender
+        // shrinks accordingly — rotation costs are borne by the custody
+        // fee that was priced for them, not by the owner and not by the
+        // peg.
+        reservation.mintedAmount = newAnchorAmount;
         reservation.anchorTxHash = reanchorTxHash;
         reservation.anchorTxOutputIndex = 0;
         reservation.state = Reservation.ReservationState.Active;
+
+        if (minerFee > 0) {
+            IReservationFeeFinancer(self.reservationVault).financeInKindFee(
+                minerFee
+            );
+        }
 
         action.state = Reservation.ActionState.Settled;
 
@@ -746,6 +778,18 @@ library ReservationProofs {
             dissolutionTxHash,
             outputValue
         );
+
+        // The dissolution miner fee is a backing loss no party surrenders
+        // TBTC for (the owner keeps their minted balance as an ordinary
+        // pooled claim): finance it from the vault's custody-fee reserve
+        // so total supply reconciles with the net backing added,
+        // atomically with the settlement.
+        uint64 dissolutionFee = inputsTotalValue - outputValue;
+        if (dissolutionFee > 0) {
+            IReservationFeeFinancer(self.reservationVault).financeInKindFee(
+                dissolutionFee
+            );
+        }
     }
 
     /// @notice Parses the dissolution transaction's single output, validates
@@ -935,6 +979,9 @@ library ReservationProofs {
             self.walletReservationsCount[
                 pendingAction.targetWalletPubKeyHash
             ] -= 1;
+            self.walletReservationsAmount[
+                pendingAction.targetWalletPubKeyHash
+            ] -= pendingAction.amount;
         } else if (
             pendingAction.actionType == Reservation.ActionType.Dissolution
         ) {

--- a/solidity/contracts/bridge/ReservationRouter.sol
+++ b/solidity/contracts/bridge/ReservationRouter.sol
@@ -201,6 +201,11 @@ contract ReservationRouter is Governable, Initializable {
 
     event ReservationVaultUpdated(address reservationVault);
 
+    event ReservationCapsUpdated(
+        uint64 maxReservationsAmountPerWallet,
+        uint64 reservationMaxSingleAmount
+    );
+
     // Re-declaration of the event emitted by
     // `BridgeState.setReservationRouter` (invoked through
     // `Bridge.setReservationRouter`). Library events are not part of any
@@ -426,6 +431,52 @@ contract ReservationRouter is Governable, Initializable {
             reservationActionTimeout,
             reservationRenewalWindowSeconds
         );
+    }
+
+    /// @notice Updates the amount-denominated reservation caps: the
+    ///         per-wallet total anchor amount and the single-reservation
+    ///         maximum. A zero value disables the respective cap. Checked
+    ///         and reserved at request/authorization time, never at proof
+    ///         time.
+    /// @param maxReservationsAmountPerWallet New cap on the total satoshi
+    ///        amount of anchors a single wallet can custody.
+    /// @param reservationMaxSingleAmount New cap on the satoshi amount of
+    ///        a single reservation.
+    /// @dev Requirements:
+    ///      - The caller must be the governance.
+    function updateReservationCaps(
+        uint64 maxReservationsAmountPerWallet,
+        uint64 reservationMaxSingleAmount
+    ) external onlyGovernance {
+        self.updateReservationCaps(
+            maxReservationsAmountPerWallet,
+            reservationMaxSingleAmount
+        );
+    }
+
+    /// @notice Returns the amount-denominated reservation caps.
+    function reservationCaps()
+        external
+        view
+        returns (
+            uint64 maxReservationsAmountPerWallet,
+            uint64 reservationMaxSingleAmount
+        )
+    {
+        maxReservationsAmountPerWallet = self.maxReservationsAmountPerWallet;
+        reservationMaxSingleAmount = self.reservationMaxSingleAmount;
+    }
+
+    /// @notice Returns the total satoshi amount of reservation anchors
+    ///         (and reserved capacity of pending reservation actions)
+    ///         custodied by the given wallet.
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet.
+    function walletReservationsAmount(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint64)
+    {
+        return self.walletReservationsAmount[walletPubKeyHash];
     }
 
     /// @notice Collection of all reservation positions indexed by the

--- a/solidity/contracts/vault/IReservationFeeFinancer.sol
+++ b/solidity/contracts/vault/IReservationFeeFinancer.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+/// @notice Interface of the reservation vault's in-kind fee financing hook.
+///         The Bridge calls it when a reservation settlement pays a Bitcoin
+///         miner fee that no party surrenders TBTC for (re-anchor and
+///         dissolution transactions): the vault burns supply equal to the
+///         fee from its custody-fee reserve so total TBTC supply shrinks in
+///         lockstep with the Bitcoin backing.
+interface IReservationFeeFinancer {
+    /// @notice Finances an in-kind Bitcoin miner fee: burns TBTC equal to
+    ///         `feeSat` from the vault's fee reserve and the corresponding
+    ///         Bank balance. If the reserve cannot cover the full amount,
+    ///         the shortfall is recorded as public debt and the call still
+    ///         succeeds — a confirmed Bitcoin spend must never fail to
+    ///         settle because of the reserve level.
+    /// @param feeSat The in-kind fee in satoshi.
+    function financeInKindFee(uint64 feeSat) external;
+}

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -17,7 +17,9 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
+import "./IReservationFeeFinancer.sol";
 import "./IVault.sol";
 import "./TBTCVault.sol";
 import "../bank/Bank.sol";
@@ -52,7 +54,7 @@ import "../token/TBTC.sol";
 /// @dev The vault deliberately keeps no claim registry of its own -- the
 ///      Bridge's reservation records are the single source of truth and are
 ///      consulted for ownership checks.
-contract ReservationVault is IVault, Ownable {
+contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     using SafeERC20 for IERC20;
 
     /// @notice Multiplier to convert satoshi to TBTC token units.
@@ -103,6 +105,22 @@ contract ReservationVault is IVault, Ownable {
     ///         unpause, unblock, or replace the guardian.
     address public renewalGuardian;
 
+    /// @notice TBTC amount (18 decimals) of custody-fee revenue the vault
+    ///         retains as the in-kind fee reserve. All protocol fees
+    ///         accumulate in the vault; `sweepFees` can move only the
+    ///         balance exceeding this target to the treasury. The reserve
+    ///         finances the Bitcoin miner fees of re-anchor and dissolution
+    ///         transactions — the settlements where no party surrenders
+    ///         TBTC — keeping total supply matched to the Bitcoin backing.
+    uint256 public feeReserveTarget;
+
+    /// @notice Outstanding in-kind fee debt in satoshi: miner fees of
+    ///         already-settled re-anchor/dissolution transactions the fee
+    ///         reserve could not cover at settlement time. While non-zero,
+    ///         total TBTC supply exceeds the Bitcoin backing by this
+    ///         amount; `repayInKindFeeDebt` burns it down.
+    uint64 public inKindFeeDebtSat;
+
     event ReservationCreditProcessed(
         address indexed owner,
         uint256 satAmount,
@@ -140,6 +158,14 @@ contract ReservationVault is IVault, Ownable {
         address indexed oldGuardian,
         address indexed newGuardian
     );
+
+    event InKindFeeFinanced(uint64 feeSat, uint64 shortfallSat);
+
+    event InKindFeeDebtRepaid(address indexed payer, uint64 amountSat);
+
+    event FeeReserveTargetUpdated(uint256 feeReserveTarget);
+
+    event FeesSwept(address indexed recipient, uint256 amountTbtc);
 
     modifier onlyBank() {
         require(msg.sender == address(bank), "Caller is not the Bank");
@@ -238,9 +264,9 @@ contract ReservationVault is IVault, Ownable {
             );
         }
 
-        if (totalFee > 0) {
-            IERC20(tbtcToken).safeTransfer(bridge.treasury(), totalFee);
-        }
+        // The initiation fee stays in the vault: all custody-fee revenue
+        // accumulates here as the in-kind fee reserve, and only the excess
+        // over `feeReserveTarget` can be swept to the treasury.
     }
 
     /// @notice Requests an in-kind redemption of the caller's reservation.
@@ -277,14 +303,13 @@ contract ReservationVault is IVault, Ownable {
             SATOSHI_MULTIPLIER;
         uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
 
+        // The redemption fee stays in the vault as part of the in-kind
+        // fee reserve; see `feeReserveTarget`.
         IERC20(tbtcToken).safeTransferFrom(
             msg.sender,
             address(this),
             grossTbtc + fee
         );
-        if (fee > 0) {
-            IERC20(tbtcToken).safeTransfer(bridge.treasury(), fee);
-        }
 
         // Unmint the gross TBTC back into Bank balance and let the Bridge
         // take it when registering the reserved redemption request.
@@ -363,11 +388,9 @@ contract ReservationVault is IVault, Ownable {
         );
 
         if (fee > 0) {
-            IERC20(tbtcToken).safeTransferFrom(
-                msg.sender,
-                bridge.treasury(),
-                fee
-            );
+            // The renewal fee stays in the vault as part of the in-kind
+            // fee reserve; see `feeReserveTarget`.
+            IERC20(tbtcToken).safeTransferFrom(msg.sender, address(this), fee);
         }
 
         // slither-disable-next-line reentrancy-events
@@ -480,6 +503,118 @@ contract ReservationVault is IVault, Ownable {
             false,
             true // Consume the retry entitlement instead of paying the fee.
         );
+    }
+
+    /// @notice Finances an in-kind Bitcoin miner fee of a settled
+    ///         re-anchor or dissolution transaction: burns TBTC equal to
+    ///         the fee from the vault's fee reserve together with the
+    ///         corresponding Bank balance, so total supply shrinks in
+    ///         lockstep with the Bitcoin backing. Called by the Bridge
+    ///         during settlement.
+    /// @param feeSat The in-kind fee in satoshi.
+    /// @dev Requirements:
+    ///      - The caller must be the Bridge.
+    ///
+    ///      If the reserve cannot cover the full amount, the shortfall is
+    ///      recorded as `inKindFeeDebtSat` and the call still succeeds: a
+    ///      confirmed Bitcoin spend must never fail to settle because of
+    ///      the reserve level. While the debt is non-zero the system is
+    ///      over-supplied by exactly that amount, publicly visible and
+    ///      repayable by anyone via `repayInKindFeeDebt`.
+    function financeInKindFee(uint64 feeSat) external override {
+        require(msg.sender == address(bridge), "Caller is not the Bridge");
+
+        if (feeSat == 0) {
+            return;
+        }
+
+        uint256 reserveTbtc = tbtcToken.balanceOf(address(this));
+        uint64 coverableSat = uint64(
+            Math.min(uint256(feeSat), reserveTbtc / SATOSHI_MULTIPLIER)
+        );
+
+        if (coverableSat > 0) {
+            uint256 burnTbtc = uint256(coverableSat) * SATOSHI_MULTIPLIER;
+            IERC20(tbtcToken).safeIncreaseAllowance(
+                address(tbtcVault),
+                burnTbtc
+            );
+            tbtcVault.unmint(burnTbtc);
+            bank.decreaseBalance(coverableSat);
+        }
+
+        uint64 shortfallSat = feeSat - coverableSat;
+        if (shortfallSat > 0) {
+            // The external calls above touch only trusted protocol
+            // contracts (TBTC token, TBTC vault, Bank).
+            // slither-disable-next-line reentrancy-benign
+            inKindFeeDebtSat += shortfallSat;
+        }
+
+        // slither-disable-next-line reentrancy-events
+        emit InKindFeeFinanced(feeSat, shortfallSat);
+    }
+
+    /// @notice Repays outstanding in-kind fee debt: pulls TBTC from the
+    ///         caller, burns it together with the corresponding Bank
+    ///         balance and reduces the recorded debt. Callable by anyone.
+    /// @param amountSat The debt amount in satoshi to repay; capped at the
+    ///        outstanding debt.
+    function repayInKindFeeDebt(uint64 amountSat) external {
+        uint64 repaySat = uint64(
+            Math.min(uint256(amountSat), uint256(inKindFeeDebtSat))
+        );
+        require(repaySat > 0, "No debt to repay");
+
+        uint256 repayTbtc = uint256(repaySat) * SATOSHI_MULTIPLIER;
+        IERC20(tbtcToken).safeTransferFrom(
+            msg.sender,
+            address(this),
+            repayTbtc
+        );
+        IERC20(tbtcToken).safeIncreaseAllowance(address(tbtcVault), repayTbtc);
+        tbtcVault.unmint(repayTbtc);
+        bank.decreaseBalance(repaySat);
+
+        // The external calls above touch only trusted protocol contracts
+        // (TBTC token, TBTC vault, Bank).
+        // slither-disable-next-line reentrancy-no-eth,reentrancy-benign
+        inKindFeeDebtSat -= repaySat;
+
+        // slither-disable-next-line reentrancy-events
+        emit InKindFeeDebtRepaid(msg.sender, repaySat);
+    }
+
+    /// @notice Updates the TBTC amount of fee revenue the vault retains as
+    ///         the in-kind fee reserve.
+    /// @param _feeReserveTarget The new reserve target, in TBTC (18
+    ///        decimals).
+    /// @dev Requirements:
+    ///      - The caller must be the vault owner (governance).
+    function updateFeeReserveTarget(uint256 _feeReserveTarget)
+        external
+        onlyOwner
+    {
+        feeReserveTarget = _feeReserveTarget;
+        emit FeeReserveTargetUpdated(_feeReserveTarget);
+    }
+
+    /// @notice Sweeps fee revenue exceeding the reserve target to the
+    ///         given recipient (normally the Bridge treasury).
+    /// @param recipient The recipient of the swept fees.
+    /// @dev Requirements:
+    ///      - The caller must be the vault owner (governance),
+    ///      - The vault TBTC balance must exceed the reserve target.
+    function sweepFees(address recipient) external onlyOwner {
+        require(recipient != address(0), "Recipient must not be zero");
+        uint256 balance = tbtcToken.balanceOf(address(this));
+        require(balance > feeReserveTarget, "Nothing above the reserve target");
+
+        uint256 amount = balance - feeReserveTarget;
+        IERC20(tbtcToken).safeTransfer(recipient, amount);
+        // The TBTC token is a trusted protocol contract.
+        // slither-disable-next-line reentrancy-events
+        emit FeesSwept(recipient, amount);
     }
 
     /// @notice Updates the vault fee parameters.

--- a/solidity/deploy/95_deploy_reservation_vault.ts
+++ b/solidity/deploy/95_deploy_reservation_vault.ts
@@ -30,12 +30,19 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   // 1. Stage and finalize the vault and reservation parameters through
   //    `BridgeGovernance.beginReservationParametersUpdate(...)` and
   //    `BridgeGovernance.finalizeReservationParametersUpdate()`,
-  // 2. Optionally appoint a renewal guardian
+  // 2. Stage and finalize the reservation caps through
+  //    `BridgeGovernance.beginReservationCapsUpdate(...)` and
+  //    `BridgeGovernance.finalizeReservationCapsUpdate()`,
+  // 3. Set the in-kind fee reserve target
+  //    (`ReservationVault.updateFeeReserveTarget(...)`),
+  // 4. Optionally appoint a renewal guardian
   //    (`ReservationVault.setRenewalGuardian`),
-  // 3. If renewals should start enabled, unpause them
+  // 5. If renewals should start enabled, unpause them
   //    (`ReservationVault.unpauseRenewals`) — the vault deploys paused,
-  // 4. As the final activation step, mark the fully configured vault as
+  // 6. As the final activation step, mark the fully configured vault as
   //    trusted: `BridgeGovernance.setVaultStatus(vault, true)`.
+  // Required steps 1-3 must be completed while the vault is untrusted. Any
+  // applicable steps 4-5 must also precede step 6.
   // `unpauseRenewals` gates `extendCustody` only; it is not a global pause for
   // reserved deposit reveals. Vault trust is the safe activation boundary.
   // None of these actions are performed by this script.

--- a/solidity/test/bridge/Bridge.Governance.test.ts
+++ b/solidity/test/bridge/Bridge.Governance.test.ts
@@ -4430,6 +4430,47 @@ describe("Bridge - Governance", () => {
     })
   })
 
+  describe("beginReservationCapsUpdate", () => {
+    const maxReservationsAmountPerWallet = 100000000
+    const reservationMaxSingleAmount = 50000000
+    let tx: ContractTransaction
+
+    before(async () => {
+      await createSnapshot()
+
+      tx = await bridgeGovernance
+        .connect(governance)
+        .beginReservationCapsUpdate(
+          maxReservationsAmountPerWallet,
+          reservationMaxSingleAmount
+        )
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("should declare the exact ReservationCapsUpdateStarted event in the ABI", async () => {
+      expect(
+        bridgeGovernance.interface
+          .getEvent("ReservationCapsUpdateStarted")
+          .format()
+      ).to.equal("ReservationCapsUpdateStarted(uint64,uint64,uint256)")
+    })
+
+    it("should emit ReservationCapsUpdateStarted event", async () => {
+      const blockTimestamp = await helpers.time.lastBlockTime()
+
+      await expect(tx)
+        .to.emit(bridgeGovernance, "ReservationCapsUpdateStarted")
+        .withArgs(
+          maxReservationsAmountPerWallet,
+          reservationMaxSingleAmount,
+          blockTimestamp
+        )
+    })
+  })
+
   describe("setRedemptionWatchtower", () => {
     const watchtower = "0xE8ebaEc51bAeeaBff71707dE2AD028C7fB642A3F"
 

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -1149,7 +1149,7 @@ describe("Bridge - Reservation", () => {
           .approve(reservationVault.address, ethers.constants.MaxUint256)
 
         const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
-        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+        const reserveBefore = await tbtc.balanceOf(reservationVault.address)
 
         await reservationVault.connect(governance).updateFees(40, 20, 500)
 
@@ -1166,8 +1166,8 @@ describe("Bridge - Reservation", () => {
         expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
           ownerBalanceBefore
         )
-        expect(await tbtc.balanceOf(treasury.address)).to.equal(
-          treasuryBalanceBefore
+        expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+          reserveBefore
         )
         expect(
           (await bridge.reservations(exposedReservationKey)).state
@@ -1189,8 +1189,8 @@ describe("Bridge - Reservation", () => {
             grossTbtc,
             updatedFee
           )
-        expect(await tbtc.balanceOf(treasury.address)).to.equal(
-          treasuryBalanceBefore.add(updatedFee)
+        expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+          reserveBefore.add(updatedFee)
         )
         expect(
           (await bridge.reservations(exposedReservationKey)).state

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -754,7 +754,7 @@ describe("Bridge - Reservation", () => {
       })
 
       it("renews for the owner with a fee bound", async () => {
-        const treasuryBefore = await tbtc.balanceOf(treasury.address)
+        const reserveBefore = await tbtc.balanceOf(reservationVault.address)
         const tx = await reservationVault
           .connect(thirdParty)
           .extendCustody(
@@ -766,8 +766,10 @@ describe("Bridge - Reservation", () => {
         await expect(tx)
           .to.emit(reservationVault, "CustodyExtended")
           .withArgs(reservationKey, thirdParty.address, extensionFee)
-        expect(await tbtc.balanceOf(treasury.address)).to.equal(
-          treasuryBefore.add(extensionFee)
+        // The renewal fee accumulates in the vault as the in-kind fee
+        // reserve.
+        expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+          reserveBefore.add(extensionFee)
         )
       })
 
@@ -1031,12 +1033,15 @@ describe("Bridge - Reservation", () => {
             [amountSat]
           )
 
-        // 40 bps initiation fee.
+        // 40 bps initiation fee, retained by the vault as the in-kind fee
+        // reserve.
         const expectedFee = grossTbtc.mul(40).div(10000)
         expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
           grossTbtc.sub(expectedFee)
         )
-        expect(await tbtc.balanceOf(treasury.address)).to.equal(expectedFee)
+        expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+          expectedFee
+        )
       })
     })
 
@@ -1089,7 +1094,7 @@ describe("Bridge - Reservation", () => {
 
       it("should surrender gross TBTC, charge the redemption fee, and register the redemption", async () => {
         const fee = grossTbtc.mul(20).div(10000)
-        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+        const reserveBefore = await tbtc.balanceOf(reservationVault.address)
 
         await tbtc
           .connect(thirdParty)
@@ -1104,8 +1109,10 @@ describe("Bridge - Reservation", () => {
           .withArgs(reservationKey, thirdParty.address, grossTbtc, fee)
         await expect(tx).to.emit(bridge, "ReservedRedemptionRequested")
 
-        expect(await tbtc.balanceOf(treasury.address)).to.equal(
-          treasuryBalanceBefore.add(fee)
+        // The redemption fee accumulates in the vault as the in-kind fee
+        // reserve.
+        expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+          reserveBefore.add(fee)
         )
         expect((await bridge.reservations(reservationKey)).state).to.equal(
           ReservationState.ActionPending

--- a/solidity/test/bridge/Bridge.ReservationBacking.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationBacking.test.ts
@@ -415,7 +415,7 @@ describe("Bridge - Reservation backing", () => {
         )
       await reservationVault
         .connect(thirdParty)
-        .redeemReservation(reservationKey, redeemerScript)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
 
       const redemptionTx = buildTx(
         [{ txHash: reanchorTx.txHash, index: 0 }],
@@ -707,7 +707,7 @@ describe("Bridge - Reservation backing", () => {
         .approve(reservationVault.address, grossTbtc.add(redemptionFee))
       await reservationVault
         .connect(thirdParty)
-        .redeemReservation(first.reservationKey, redeemerScript)
+        .redeemReservation(first.reservationKey, redeemerScript, redemptionFee)
       const redemptionTx = buildTx(
         [{ txHash: first.anchorTx.txHash, index: 0 }],
         [

--- a/solidity/test/bridge/Bridge.ReservationBacking.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationBacking.test.ts
@@ -1,0 +1,739 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+// Backing-integrity tests for the reservation claim/anchor model: the claim
+// always equals the current anchor, in-kind Bitcoin miner fees of
+// re-anchor and dissolution transactions are financed from the vault's
+// custody-fee reserve (burning supply in lockstep with the backing loss),
+// reserve poverty degrades to public, repayable debt instead of blocking
+// settlement, and the amount-denominated caps bind at request time.
+
+import { ethers, helpers, waffle } from "hardhat"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber, Contract } from "ethers"
+import chai, { expect } from "chai"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+import type {
+  Bank,
+  BankStub,
+  Bridge,
+  BridgeStub,
+  IRelay,
+  ReservationRouter,
+  ReservationVault,
+  TBTCVault,
+  TBTC,
+} from "../../typechain"
+import bridgeFixture from "../fixtures/bridge"
+import { walletState } from "../fixtures"
+
+chai.use(smock.matchers)
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime, increaseTime } = helpers.time
+
+const ZERO_BYTES32 = ethers.constants.HashZero
+
+const RESERVATION_TERM = 31536000 // 365 days
+const RESERVATION_GRACE = 2592000 // 30 days
+const RESERVATION_MIN_AMOUNT = 10000
+const RESERVATION_TX_MAX_FEE = 2000
+const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
+const MAX_RESERVATIONS_PER_WALLET = 10
+const RESERVATION_ACTION_TIMEOUT = 172800 // 48 hours
+const RESERVATION_RENEWAL_WINDOW = 2592000 // 30 days
+
+const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
+
+const ProofType = {
+  Acceptance: 0,
+  Redemption: 1,
+  Reanchor: 2,
+  Dissolution: 3,
+}
+
+const ReservationState = {
+  Unknown: 0,
+  Active: 1,
+  ActionPending: 2,
+  Closed: 3,
+  Stranded: 4,
+}
+
+describe("Bridge - Reservation backing", () => {
+  let governance: SignerWithAddress
+  let spvMaintainer: SignerWithAddress
+  let thirdParty: SignerWithAddress
+  let treasury: SignerWithAddress
+
+  let bank: Bank & BankStub
+  let relay: FakeContract<IRelay>
+  let bridge: Bridge & BridgeStub & ReservationRouter
+  let tbtc: TBTC & Contract
+  let tbtcVault: TBTCVault & Contract
+  let reservationVault: ReservationVault
+  let bridgeGovernanceSigner: SignerWithAddress
+
+  const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+  const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
+  const blindingFactor = "0xf9f0c90d00039523"
+  const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
+  const refundLocktime = "0x60bcea61"
+  const NO_MAIN_UTXO_PARAM = {
+    txHash: ZERO_BYTES32,
+    txOutputIndex: 0,
+    txOutputValue: 0,
+  }
+
+  const depositAmount = BigNumber.from(3000000)
+  const anchorFee = 1500
+  const anchorAmount = depositAmount.sub(anchorFee)
+  const grossTbtc = anchorAmount.mul(SATOSHI_MULTIPLIER)
+  const initiationFeeTbtc = grossTbtc.mul(40).div(10000)
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({
+      governance,
+      spvMaintainer,
+      thirdParty,
+      treasury,
+      bank,
+      relay,
+      bridge,
+      tbtc,
+      tbtcVault,
+    } = await waffle.loadFixture(bridgeFixture))
+
+    reservationVault = await helpers.contracts.getContract("ReservationVault")
+    bridgeGovernanceSigner = await impersonateContract(
+      await bridge.governance()
+    )
+
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .setVaultStatus(reservationVault.address, true)
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        RESERVATION_ACTION_TIMEOUT,
+        RESERVATION_RENEWAL_WINDOW
+      )
+
+    relay.getCurrentEpochDifficulty.returns(0)
+    relay.getPrevEpochDifficulty.returns(0)
+
+    await bridge.setDepositDustThreshold(10000)
+    await bridge.setDepositTxMaxFee(2000)
+    await bridge.setDepositRevealAheadPeriod(0)
+    await liveWallet(walletPubKeyHash)
+    await liveWallet(secondWalletPubKeyHash)
+
+    const tbtcOwner = await impersonateContract(await tbtc.owner())
+    await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+  })
+
+  async function impersonateContract(
+    address: string
+  ): Promise<SignerWithAddress> {
+    await ethers.provider.send("hardhat_impersonateAccount", [address])
+    await ethers.provider.send("hardhat_setBalance", [
+      address,
+      "0x8AC7230489E80000",
+    ])
+    return ethers.getSigner(address)
+  }
+
+  async function liveWallet(pkh: string) {
+    await bridge.setWallet(pkh, {
+      ecdsaWalletID: ethers.utils.randomBytes(32),
+      mainUtxoHash: ZERO_BYTES32,
+      pendingRedemptionsValue: 0,
+      createdAt: await lastBlockTime(),
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+    })
+  }
+
+  // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
+
+  const REGTEST_BITS_LE = "ffff7f20"
+  const REGTEST_TARGET = BigNumber.from("0x7fffff").mul(
+    BigNumber.from(2).pow(8 * (0x20 - 3))
+  )
+
+  const reverseHex = (hex: string): string =>
+    hex.replace(/^0x/, "").match(/../g)!.reverse().join("")
+
+  const hash256 = (hexData: string): string =>
+    ethers.utils.sha256(ethers.utils.sha256(hexData))
+
+  const toLE = (value: number | BigNumber, byteLength: number): string =>
+    reverseHex(
+      BigNumber.from(value)
+        .toHexString()
+        .slice(2)
+        .padStart(byteLength * 2, "0")
+    )
+
+  const compactSize = (n: number): string => {
+    if (n >= 0xfd) {
+      throw new Error("compactSize > 252 not supported in fixtures")
+    }
+    return n.toString(16).padStart(2, "0")
+  }
+
+  function buildTx(
+    inputs: { txHash: string; index: number }[],
+    outputs: { valueSat: BigNumber | number; script: string }[]
+  ) {
+    const inputVector = `0x${compactSize(inputs.length)}${inputs
+      .map((i) => `${i.txHash.slice(2)}${toLE(i.index, 4)}00ffffffff`)
+      .join("")}`
+    const outputVector = `0x${compactSize(outputs.length)}${outputs
+      .map(
+        (o) =>
+          `${toLE(BigNumber.from(o.valueSat), 8)}${compactSize(
+            o.script.length / 2
+          )}${o.script}`
+      )
+      .join("")}`
+    const info = {
+      version: "0x01000000",
+      inputVector,
+      outputVector,
+      locktime: "0x00000000",
+    }
+    const txHash = hash256(
+      `0x01000000${inputVector.slice(2)}${outputVector.slice(2)}00000000`
+    )
+    return { info, txHash }
+  }
+
+  function mineHeader(merkleRoot: string): string {
+    const prevBlock = ethers.utils
+      .hexlify(ethers.utils.randomBytes(32))
+      .slice(2)
+    const base = `20000000${prevBlock}${merkleRoot.slice(
+      2
+    )}662a2c68${REGTEST_BITS_LE}`
+    for (let nonce = 0; ; nonce++) {
+      const header = `0x${base}${toLE(nonce, 4)}`
+      if (
+        BigNumber.from(`0x${reverseHex(hash256(header))}`).lte(REGTEST_TARGET)
+      ) {
+        return header
+      }
+    }
+  }
+
+  function proofFor(txHash: string) {
+    const coinbasePreimage = ethers.utils.sha256(ethers.utils.randomBytes(32))
+    const coinbaseTxId = ethers.utils.sha256(coinbasePreimage)
+    const merkleRoot = hash256(`0x${coinbaseTxId.slice(2)}${txHash.slice(2)}`)
+    return {
+      merkleProof: coinbaseTxId,
+      txIndexInBlock: 1,
+      bitcoinHeaders: mineHeader(merkleRoot),
+      coinbasePreimage,
+      coinbaseProof: txHash,
+    }
+  }
+
+  const buildDepositScript = (
+    depositor: string,
+    blinding: string,
+    walletPkh: string,
+    refundPkh: string,
+    locktime: string
+  ): string =>
+    `14${depositor.slice(2)}7508${blinding.slice(2)}7576a914${walletPkh
+      .slice(2)
+      .toLowerCase()}8763ac6776a914${refundPkh.slice(2)}8804${locktime.slice(
+      2
+    )}b175ac68`
+
+  const p2wshScript = (script: string): string =>
+    `0020${ethers.utils.sha256(`0x${script}`).slice(2)}`
+
+  const p2wpkhScript = (pkh: string): string => `0014${pkh.slice(2)}`
+
+  const randomRedeemerScript = (): string =>
+    `0x16${p2wpkhScript(ethers.utils.hexlify(ethers.utils.randomBytes(20)))}`
+
+  async function makeAcceptedReservation(custodian = walletPubKeyHash) {
+    const fundingTx = buildTx(
+      [
+        {
+          txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+          index: 0,
+        },
+      ],
+      [
+        {
+          valueSat: depositAmount,
+          script: p2wshScript(
+            buildDepositScript(
+              thirdParty.address,
+              blindingFactor,
+              custodian,
+              refundPubKeyHash,
+              refundLocktime
+            )
+          ),
+        },
+      ]
+    )
+
+    await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+      fundingOutputIndex: 0,
+      blindingFactor,
+      walletPubKeyHash: custodian,
+      refundPubKeyHash,
+      refundLocktime,
+      vault: reservationVault.address,
+    })
+
+    const reservationKey = BigNumber.from(
+      ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.txHash, 0]
+      )
+    )
+
+    await bridge
+      .connect(thirdParty)
+      .requestReservationAcceptance(reservationKey, custodian)
+
+    const anchorTx = buildTx(
+      [{ txHash: fundingTx.txHash, index: 0 }],
+      [{ valueSat: anchorAmount, script: p2wpkhScript(custodian) }]
+    )
+
+    await bridge
+      .connect(spvMaintainer)
+      .submitReservationProof(
+        ProofType.Acceptance,
+        anchorTx.info,
+        proofFor(anchorTx.txHash),
+        NO_MAIN_UTXO_PARAM,
+        reservationKey,
+        1
+      )
+
+    return { fundingTx, anchorTx, reservationKey }
+  }
+
+  describe("claim tracks the anchor across re-anchors", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    const reanchorFee = 1000
+
+    it("finances the re-anchor miner fee and writes the claim down", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      const supplyBefore = await tbtc.totalSupply()
+      const reserveBefore = await tbtc.balanceOf(reservationVault.address)
+      expect(reserveBefore).to.equal(initiationFeeTbtc)
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const newAnchorAmount = anchorAmount.sub(reanchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: newAnchorAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      // Claim == anchor at all times.
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.mintedAmount).to.equal(newAnchorAmount)
+      expect(reservation.anchorAmount).to.equal(newAnchorAmount)
+
+      // The miner fee was financed from the vault reserve: total supply
+      // shrank in lockstep with the Bitcoin backing.
+      const financedTbtc = BigNumber.from(reanchorFee).mul(SATOSHI_MULTIPLIER)
+      expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(financedTbtc))
+      expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+        reserveBefore.sub(financedTbtc)
+      )
+      expect(await reservationVault.inKindFeeDebtSat()).to.equal(0)
+
+      // The per-wallet amount accounting moved with the anchor.
+      expect(await bridge.walletReservationsAmount(walletPubKeyHash)).to.equal(
+        0
+      )
+      expect(
+        await bridge.walletReservationsAmount(secondWalletPubKeyHash)
+      ).to.equal(newAnchorAmount)
+
+      // Redemption after the hop surrenders exactly the written-down
+      // claim; supply and backing reconcile with no residue.
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = randomRedeemerScript()
+      const redemptionFee = newAnchorAmount
+        .mul(SATOSHI_MULTIPLIER)
+        .mul(20)
+        .div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(
+          reservationVault.address,
+          newAnchorAmount.mul(SATOSHI_MULTIPLIER).add(redemptionFee)
+        )
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript)
+
+      const redemptionTx = buildTx(
+        [{ txHash: reanchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: newAnchorAmount.sub(500),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      const supplyBeforeSettle = await tbtc.totalSupply()
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+
+      // The escrowed written-down claim was burned at settlement (the
+      // ERC-20 leg burned at request time via unmint).
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+      expect(await tbtc.totalSupply()).to.equal(supplyBeforeSettle)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Closed
+      )
+    })
+  })
+
+  describe("dissolution reconciles supply with net backing", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("finances the dissolution miner fee atomically with settlement", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationDissolution(reservationKey)
+
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      const supplyBefore = await tbtc.totalSupply()
+      const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      // The pool gained anchor - fee while the owner's full minted claim
+      // remains outstanding; the fee is financed by burning reserve
+      // supply, so supply == backing again.
+      expect(await tbtc.totalSupply()).to.equal(
+        supplyBefore.sub(BigNumber.from(dissolutionFee).mul(SATOSHI_MULTIPLIER))
+      )
+      // The owner's balance is untouched: their claim simply became an
+      // ordinary pooled claim.
+      expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+        ownerBalanceBefore
+      )
+      expect(await reservationVault.inKindFeeDebtSat()).to.equal(0)
+    })
+  })
+
+  describe("reserve poverty degrades to public repayable debt", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("records debt instead of blocking settlement, then repays", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      // Governance sweeps the whole reserve away (target defaults to 0).
+      await reservationVault.connect(governance).sweepFees(treasury.address)
+      expect(await tbtc.balanceOf(reservationVault.address)).to.equal(0)
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const reanchorFee = 1000
+      const newAnchorAmount = anchorAmount.sub(reanchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: newAnchorAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      // Settlement must proceed despite the empty reserve.
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+      await expect(tx)
+        .to.emit(reservationVault, "InKindFeeFinanced")
+        .withArgs(reanchorFee, reanchorFee)
+
+      expect(await reservationVault.inKindFeeDebtSat()).to.equal(reanchorFee)
+      expect((await bridge.reservations(reservationKey)).mintedAmount).to.equal(
+        newAnchorAmount
+      )
+
+      // Anyone can repay the debt, burning the over-supply.
+      const repayTbtc = BigNumber.from(reanchorFee).mul(SATOSHI_MULTIPLIER)
+      const supplyBefore = await tbtc.totalSupply()
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, repayTbtc)
+      await expect(
+        reservationVault.connect(thirdParty).repayInKindFeeDebt(reanchorFee)
+      )
+        .to.emit(reservationVault, "InKindFeeDebtRepaid")
+        .withArgs(thirdParty.address, reanchorFee)
+
+      expect(await reservationVault.inKindFeeDebtSat()).to.equal(0)
+      expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(repayTbtc))
+    })
+  })
+
+  describe("amount-denominated caps", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("binds the single-reservation cap at acceptance request", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationCaps(0, depositAmount.sub(1))
+
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Reservation exceeds the single-reservation cap")
+    })
+
+    it("binds the per-wallet amount cap at acceptance and re-anchor requests", async () => {
+      // Set up the positions before tightening the cap: one reservation on
+      // each wallet, plus a fee-funding one on the second wallet.
+      const first = await makeAcceptedReservation()
+      const second = await makeAcceptedReservation(secondWalletPubKeyHash)
+      await makeAcceptedReservation(secondWalletPubKeyHash) // fee funding
+
+      // Now allow roughly one reservation per wallet by amount.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationCaps(depositAmount.add(1000), 0)
+
+      // A second acceptance for the same wallet exceeds the amount cap
+      // (even though the count cap would allow it).
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(
+            BigNumber.from(
+              ethers.utils.solidityKeccak256(
+                ["bytes32", "uint32"],
+                [fundingTx.txHash, 0]
+              )
+            ),
+            walletPubKeyHash
+          )
+      ).to.be.revertedWith("Wallet reserved amount cap exceeded")
+
+      // A re-anchor into a wallet already at its amount cap is rejected
+      // at request time.
+      await expect(
+        bridge
+          .connect(bridgeGovernanceSigner)
+          .requestReservationReanchor(second.reservationKey, walletPubKeyHash)
+      ).to.be.revertedWith("Wallet reserved amount cap exceeded")
+
+      // Releasing the first wallet's capacity (via redemption) makes the
+      // re-anchor request possible again.
+      const redeemerScript = randomRedeemerScript()
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(first.reservationKey, redeemerScript)
+      const redemptionTx = buildTx(
+        [{ txHash: first.anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(500),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          first.reservationKey,
+          2
+        )
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(second.reservationKey, walletPubKeyHash)
+      expect((await bridge.reservations(second.reservationKey)).state).to.equal(
+        ReservationState.ActionPending
+      )
+    })
+  })
+})

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -822,8 +822,13 @@ describe("Bridge - Reservation settlement", () => {
       expect(
         (await bridge.reservationActions(reservationKey, 5)).usedRetryCredit
       ).to.be.true
-      expect(await bank.balanceOf(thirdParty.address)).to.equal(0)
-      expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
+      // The backing branch writes the claim down by the re-anchor miner fee.
+      // The restored credit therefore re-escrows the current claim, leaving
+      // the financed 500-satoshi write-down in the redeemer's Bank balance.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(500)
+      expect(await bank.balanceOf(bridge.address)).to.equal(
+        anchorAmount.sub(500)
+      )
     })
 
     it("does not mint credit when the superseded redemption paid a fee", async () => {

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -2486,4 +2486,239 @@ describe("Bridge - Reservation settlement", () => {
       expect(walletRegistry.closeWallet).not.to.have.been.called
     })
   })
+
+  // Characterization of an ACCEPTED, DOCUMENTED regression, not a bug
+  // report. `#1093` has no equivalent of `#1102`'s
+  // `maxCumulativeReanchorFee`, so cumulative re-anchor fee loss on one
+  // reservation is bounded only by the dust floor, which scales with the
+  // claim instead of being capped at a small governance-set constant.
+  // Milestone 1 accepts that (see `docs/spec/reservations/pr-review-followups.md`
+  // item 7, lever 4, and the accompanying deferral note), and these tests
+  // exist so the accepted exposure is executable rather than asserted.
+  //
+  // Two limits, for whoever edits this next:
+  //
+  // 1. The assertions below are deliberately BOUNDS (`gt`, `gte`), not exact
+  //    figures, so a fixture change cannot fail them spuriously. The exact
+  //    measured numbers (2,598,499 sat, 86.7%, 7 hops) live in the spec prose
+  //    instead, which means the prose can drift away from reality without
+  //    anything here going red. If these bounds are edited, re-check that
+  //    prose too.
+  // 2. The second test pins the governance gate this acceptance rests on, but
+  //    it can only catch the gate being REMOVED. It cannot catch `privileged`
+  //    being BROADENED, e.g. a second authorized role added alongside
+  //    `governance` in `ReservationRouter.sol`, which would reopen the grind
+  //    to a non-governance caller with every test here still green. Anyone
+  //    touching how `privileged` is derived is changing the assumption this
+  //    whole block documents, and voids the acceptance regardless of whether
+  //    CI complains.
+  describe("cumulative re-anchor fee exposure (accepted regression)", () => {
+    // A scaled parameter regime, the same technique `#1102`'s own
+    // characterization test used: at the default 2,000 sat `txMaxFee` a
+    // full grind of this fixture's 2,998,500 sat anchor would take ~1,498
+    // hops. Raising the fee bound compresses it to 7 without changing the
+    // mechanism under test. `reservationMinAmount` has to move with it to
+    // satisfy `reservationMinAmount > reservationTxMaxFee`.
+    const GRIND_TX_MAX_FEE = 400000
+    const GRIND_MIN_AMOUNT = 500000
+
+    // `#1102`'s fixture ceiling, for the comparison assertion below.
+    const PR1102_CAP = 100000
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    async function raiseFeeBound() {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          GRIND_MIN_AMOUNT,
+          GRIND_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW
+        )
+    }
+
+    // One governance-authorized hop, ping-ponging between two Live
+    // wallets. Returns the settled transaction so the next hop can spend
+    // its output.
+    async function grindOneHop(
+      reservationKey: BigNumber,
+      sourceTx: { txHash: string },
+      target: string,
+      newAnchorValue: BigNumber,
+      nonce: number
+    ) {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, target)
+
+      const hopTx = buildTx(
+        [{ txHash: sourceTx.txHash, index: 0 }],
+        [{ valueSat: newAnchorValue, script: p2wpkhScript(target) }]
+      )
+
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          hopTx.info,
+          proofFor(hopTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          nonce
+        )
+
+      return hopTx
+    }
+
+    it("lets most of a claim evaporate into miner fees, with no absolute ceiling", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+      await raiseFeeBound()
+
+      const reserveBefore = await tbtc.balanceOf(reservationVault.address)
+      const debtBefore = await reservationVault.inKindFeeDebtSat()
+
+      // Grind at the maximum permitted fee per hop until the next full-fee
+      // hop would breach the dust floor. The hop count is derived, never
+      // hardcoded: that is the point, since it scales with the claim.
+      let currentTx = anchorTx
+      let currentAnchor = anchorAmount
+      let target = secondWalletPubKeyHash
+      let nonce = 2
+      let hops = 0
+
+      while (currentAnchor.sub(GRIND_TX_MAX_FEE).gt(GRIND_TX_MAX_FEE)) {
+        const nextAnchor = currentAnchor.sub(GRIND_TX_MAX_FEE)
+        // Sequential on purpose: each hop spends the previous hop's output,
+        // so these cannot be batched or parallelised.
+        // eslint-disable-next-line no-await-in-loop
+        currentTx = await grindOneHop(
+          reservationKey,
+          currentTx,
+          target,
+          nextAnchor,
+          nonce
+        )
+        currentAnchor = nextAnchor
+        target =
+          target === secondWalletPubKeyHash
+            ? walletPubKeyHash
+            : secondWalletPubKeyHash
+        nonce += 1
+        hops += 1
+      }
+
+      // One final partial-fee hop lands the anchor exactly on the dust
+      // floor's boundary, `txMaxFee + 1`, which is the true worst case.
+      const floorBoundary = BigNumber.from(GRIND_TX_MAX_FEE + 1)
+      if (currentAnchor.gt(floorBoundary)) {
+        currentTx = await grindOneHop(
+          reservationKey,
+          currentTx,
+          target,
+          floorBoundary,
+          nonce
+        )
+        currentAnchor = floorBoundary
+        nonce += 1
+        hops += 1
+        // The reservation now sits on `target`, so the terminal attempt
+        // below has to name the other wallet. Inside the loop this flip
+        // happens on every iteration; here it has to happen explicitly.
+        target =
+          target === secondWalletPubKeyHash
+            ? walletPubKeyHash
+            : secondWalletPubKeyHash
+      }
+
+      const reservation = await bridge.reservations(reservationKey)
+      const cumulativeFee = anchorAmount.sub(currentAnchor)
+
+      // The claim is written down to the surviving anchor: the owner's
+      // redemption right shrinks by the full grind.
+      expect(reservation.anchorAmount).to.equal(currentAnchor)
+      expect(reservation.mintedAmount).to.equal(currentAnchor)
+
+      // Every satoshi of the grind is financed in kind: burned from the
+      // vault's reserve where it could cover, recorded as global debt
+      // where it could not. Nothing is left unaccounted.
+      const reserveAfter = await tbtc.balanceOf(reservationVault.address)
+      const debtAfter = await reservationVault.inKindFeeDebtSat()
+      const burnedSat = reserveBefore.sub(reserveAfter).div(SATOSHI_MULTIPLIER)
+      expect(burnedSat.add(debtAfter.sub(debtBefore))).to.equal(cumulativeFee)
+
+      // The characterization itself. Both assertions would FAIL if an
+      // absolute per-reservation ceiling were ported, which is exactly
+      // what makes the accepted regression executable rather than a claim
+      // in a document.
+      expect(cumulativeFee).to.be.gt(PR1102_CAP)
+      expect(cumulativeFee.mul(100).div(anchorAmount)).to.be.gte(86)
+
+      // And the grind is genuinely terminal: one more full-fee hop cannot
+      // settle, because the dust floor is the only thing that ever stopped
+      // it.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, target)
+      const belowFloorTx = buildTx(
+        [{ txHash: currentTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: BigNumber.from(GRIND_TX_MAX_FEE),
+            script: p2wpkhScript(target),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            belowFloorTx.info,
+            proofFor(belowFloorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            nonce
+          )
+      ).to.be.revertedWith("Re-anchor amount below the dust floor")
+
+      // Recorded for the deferral note: the hop count scales with the
+      // claim, so this figure is regime-specific, not a constant bound.
+      expect(hops).to.be.gte(7)
+    })
+
+    it("depends on the governance gate: a Live wallet's anchor cannot be rotated permissionlessly", async () => {
+      // The accepted regression above is only tolerable because reaching
+      // it requires governance to authorize every hop. If this gate is
+      // ever relaxed, the unbounded exposure becomes reachable by the
+      // custodying wallet operator alone, which is the threat model
+      // `pr-review-followups.md` item 7 scored as the severity-driving
+      // case. This test is the tripwire for that change.
+      //
+      // Scope, per limit 2 in this block's header: this catches the gate
+      // being removed, not `privileged` being widened to admit a second
+      // caller. A green run here is not evidence the assumption still
+      // holds; it is only evidence this particular gate still exists.
+      const { reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Only governance can rotate a Live wallet's anchor")
+    })
+  })
 })

--- a/solidity/test/deploy/95_deploy_reservation_vault.test.ts
+++ b/solidity/test/deploy/95_deploy_reservation_vault.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { expect } from "chai"
+import fs from "fs"
+import path from "path"
 
 import { equal } from "@keep-network/hardhat-helpers/dist/address"
 import { transferOwnership } from "@keep-network/hardhat-helpers/dist/ownable"
@@ -99,6 +101,38 @@ describe("Deploy Script 95: ReservationVault", () => {
 
   it("does not recursively execute the Bridge deployment", () => {
     expect(func.dependencies).to.deep.equal(["Bank", "TBTCVault"])
+  })
+
+  it("documents the complete safe activation order", () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, "../../deploy/95_deploy_reservation_vault.ts"),
+      "utf8"
+    )
+    const orderedActions = [
+      "BridgeGovernance.beginReservationParametersUpdate(...)",
+      "BridgeGovernance.finalizeReservationParametersUpdate()",
+      "BridgeGovernance.beginReservationCapsUpdate(...)",
+      "BridgeGovernance.finalizeReservationCapsUpdate()",
+      "ReservationVault.updateFeeReserveTarget(...)",
+      "ReservationVault.setRenewalGuardian",
+      "ReservationVault.unpauseRenewals",
+      "BridgeGovernance.setVaultStatus(vault, true)",
+    ]
+
+    let previousActionIndex = -1
+    orderedActions.forEach((action) => {
+      const actionIndex = source.indexOf(action)
+      expect(actionIndex, `${action} is missing`).to.be.greaterThan(-1)
+      expect(actionIndex, `${action} is out of order`).to.be.greaterThan(
+        previousActionIndex
+      )
+      previousActionIndex = actionIndex
+    })
+
+    expect(source).to.include(
+      "Required steps 1-3 must be completed while the vault is untrusted"
+    )
+    expect(source).to.include("As the final activation step")
   })
 
   it("reads the existing Bridge address for the vault constructor", async () => {


### PR DESCRIPTION
Stacked on #1092 (renewal). Closes **H-04** (dissolution permanently underbacks by cumulative in-kind fees; re-anchors temporarily underback) and **M-06** (caps don't match the design; liability vs anchor tracking).

## The rule: claim ≡ anchor, always

- **All custody-fee revenue stays in the vault** as an in-kind fee reserve; `sweepFees` moves only the excess over a governable `feeReserveTarget` to the treasury.
- **Re-anchor settlement**: the claim is written down to the new anchor value and the vault **finances the miner fee** — unmints TBTC equal to the fee from the reserve and burns the matching Bank balance — so supply shrinks in lockstep with backing. Rotation costs land on the custody fee that was priced for them (the rotation-SLA funding intent), not on the owner and not on the peg. The redemption surrender is always exactly the current anchor.
- **Dissolution settlement**: the vault finances the dissolution miner fee atomically with the proof — the pool absorbs anchor−fee while the owner's claim remains outstanding as ordinary TBTC, and the financed burn reconciles `mintedAmount` against the net backing added. This is the H-04 "reconcile exactly" fix.
- **Reserve poverty degrades, never blocks**: a confirmed Bitcoin spend always settles; any uncovered fee is recorded as public `inKindFeeDebtSat`, repayable by anyone (`repayInKindFeeDebt` burns the over-supply down). Global-accounting tests assert debt is zero across normal lifecycles.

## Caps (M-06)

With claim ≡ anchor, one number is both the asset- and liability-side figure. New amount caps bind **at request time, never at proof time**: per-wallet total anchor amount and single-reservation maximum (zero = disabled), tracked symmetrically through request/timeout/settle/unwind/close via `walletReservationsAmount`. Governance stages them with the standard delay (`beginReservationCapsUpdate`/`finalize…`).

**Deliberately not on-chain**: a fraction-of-backing cap. The Bank exposes no trustless aggregate backing figure, and an oracle for a throttle is worse than the throttle; the reserved-fraction target (10–20 % per the design) is documented as the governance operating rule for calibrating the absolute total cap. Flagged for sign-off.

## Storage

`walletReservationsAmount` mapping + packed `maxReservationsAmountPerWallet`/`reservationMaxSingleAmount` (gap 38→36, append-only).

## Tests

Full suite **3086 passing / 0 failing**; slither (CI-pinned 0.9.0) clean. New backing suite: claim write-down + financed fee across a re-anchor (supply and reserve drop by exactly the fee; per-wallet amounts move with the anchor; post-hop redemption reconciles with zero residue), dissolution fee financed atomically with owner balance untouched, poverty→debt→repay round trip, and both amount caps binding at acceptance/re-anchor request with release-then-retry.

## Defaults flagged

`feeReserveTarget` default 0 (governance sets during activation; suggested initial: a few TBTC), caps default 0 (disabled) until governance activation sets launch values.