### PR TITLE
feat(reservation): partial reserved redemption (1-in-2-out split)

### DIFF
--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -233,7 +233,13 @@ preconditions; no watchtower window applies).
 * if a newer pending generation exists but does *not* match the
   transaction (different redeemer script), late settlement additionally
   unwinds the pending generation: its escrow is refunded, because its
-  anchor no longer exists.
+  anchor no longer exists. If the superseded generation consumed a retry
+  entitlement and the late settlement leaves the position open (re-anchor
+  or partial redemption), that entitlement's source binding is restored.
+  A partial settlement of the source generation itself retires the restored
+  entitlement; settlement of an older generation preserves a newer source.
+  A whole redemption closes the position and never restores an unusable
+  entitlement.
 * a proof against a `Vetoed` generation is rejected forever: only a wallet
   that signed before authorization can be in this position.
 

--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -107,9 +107,14 @@ Every Bitcoin action of a reservation's life is one of four *action types*:
 |1-in (revealed reserved deposit) → 1-out (wallet P2(W)PKH anchor)
 |Position created; gross anchor value credited via vault (mint)
 
-|Redemption
+|Redemption (whole)
 |1-in (anchor) → 1-out (redeemer script)
 |Claim burned; position closed
+
+|Redemption (partial)
+|1-in (anchor) → 2-out (redeemer script; wallet P2(W)PKH remainder)
+|Redeemed portion burned; remainder re-anchored to the wallet; position stays
+`Active`
 
 |Re-anchor
 |1-in (anchor) → 1-out (target wallet P2(W)PKH)
@@ -119,6 +124,21 @@ Every Bitcoin action of a reservation's life is one of four *action types*:
 |1-in (anchor) [+ 2nd in: wallet main UTXO] → 1-out (wallet P2(W)PKH)
 |Anchor merged into pooled main UTXO; position closed; miner fee financed
 |===
+
+Whole and partial redemption share one action type (`Redemption`,
+distinguished by an `isPartial` flag on the generation), so there are still
+four action types. A partial redemption redeems an owner-chosen amount
+strictly between the fee floor and the whole claim: its transaction pays the
+redeemer script on output 0 — which *bears the entire miner fee*, so its value
+is `redeemAmount − fee` — and re-anchors the remainder to the custodying
+wallet on output 1, whose value must equal `anchor − redeemAmount` to the
+satoshi. Claim-equals-anchor therefore holds across the split and no foreign
+sats enter (the remainder is the wallet's own change). On settlement the
+redeemed portion is burned and the position's claim, anchor value, and
+reserved capacity each drop by `redeemAmount` while the position stays
+`Active` on the new remainder outpoint; a timeout instead returns the *full*
+anchor and refunds the escrow. Partials chain — each spends the prior
+remainder — and a whole redemption closes whatever remains.
 
 Each action goes through the same *two-phase* lifecycle:
 

--- a/docs/rfc/rfc-13.adoc
+++ b/docs/rfc/rfc-13.adoc
@@ -140,6 +140,12 @@ reserved capacity each drop by `redeemAmount` while the position stays
 anchor and refunds the escrow. Partials chain — each spends the prior
 remainder — and a whole redemption closes whatever remains.
 
+The owner-facing partial-redemption entry point carries `maxFeeTbtc`, an
+upper bound on the proportional TBTC redemption fee. The vault checks the
+live governed fee against that bound before transferring any TBTC, so a fee
+update cannot turn a broad token allowance into authorization to exceed the
+owner's quote.
+
 Each action goes through the same *two-phase* lifecycle:
 
 ----

--- a/docs/utxo-reservation-frozen-spec.md
+++ b/docs/utxo-reservation-frozen-spec.md
@@ -30,8 +30,17 @@ here is final until governance sign-off. Companion: `docs/rfc/rfc-13.adoc`,
 | `reservationDissolutionDelay`     | Post-expiry delay before dissolvable (renamed grace)       | 7 days _(prov. 2026-08-09)_                       | Snapshotted per granted term; not an owner-action window                             |
 | `reservationMaxTotalAmount`       | Global reserved-anchor cap (sat)                           | 100 BTC (10,000,000,000 sat) _(prov. 2026-08-09)_ | The absolute lever; the reserved-fraction target is enforced through it (§3)         |
 | `maxReservationsPerWallet`        | Per-wallet reservation count cap                           | 10 _(prov. 2026-08-09)_                           | Bounds re-anchor ceremonies in a rotation window                                     |
-| `reservationActionTimeout`        | Timeout for acceptance/re-anchor/dissolution actions       | 48 hours _(prov. 2026-08-09)_                     | > 0; redemptions use `redemptionTimeout`                                             |
+| `reservationActionTimeout`        | Timeout for acceptance/re-anchor/dissolution actions       | 48 hours _(prov. 2026-08-09)_                     | Must be **> 2 h**; see the timing note below                                         |
 | `reservationRenewalWindowSeconds` | Renewal window before expiry                               | 30 days _(prov. 2026-08-09)_                      | `0 < window < term`, enforced atomically                                             |
+
+Acceptance has an additional timing constraint: its proposal validator requires
+the deposit to be older than 2 hours, as well as preserving the final 2-hour
+action-timeout safety margin. An acceptance requested immediately after reveal
+therefore needs `reservationActionTimeout > 4 hours` to have any valid proposal
+window. A shorter timeout that still satisfies the hard `> 2 hours` bound is
+usable only if the requester waits for the deposit to age before requesting.
+In either case, the entire authorization must also fit within the deposit's
+remaining guaranteed reveal-ahead window.
 
 ### Bridge reservation caps (`updateReservationCaps`)
 
@@ -142,9 +151,9 @@ the contracts do not enforce but that governance must respect:
 | --------------------------------------------------------- | -------------------------- | --------- |
 | Term bounds 90–730 d, default 365 d                       | governance                 | ☐         |
 | Renewal window 30 d                                       | governance                 | ☐         |
-| Dissolution delay 30 d                                    | governance                 | ☐         |
+| Dissolution delay 7 d                                     | governance                 | ☐         |
 | Min reservation 10 BTC                                    | governance                 | ☐         |
-| Global cap 500 BTC / 10 % fraction                        | governance                 | ☐         |
+| Global cap 100 BTC / 10 % fraction                        | governance                 | ☐         |
 | Per-wallet count ~10, amount cap                          | governance                 | ☐         |
 | Action timeout 48 h                                       | governance                 | ☐         |
 | Fee schedule 40 / 20 / 20                                 | governance (settled prior) | ☐ confirm |

--- a/docs/utxo-reservation-frozen-spec.md
+++ b/docs/utxo-reservation-frozen-spec.md
@@ -55,6 +55,16 @@ numbers are proposals. Companion: `docs/rfc/rfc-13.adoc`,
   at every horizon. Stable across the FROST transition by design; the
   minimum reservation size, not a fee change, keeps carry ≥ per-position
   lifecycle cost.
+- **Custody is prepaid and non-refundable.** The 20 bps/yr custody fee is
+  charged up front on the full position for the full term (first year in the
+  40 bps initiation, each further year via the 20 bps extension). Redemption —
+  whole or partial — never rebates unexpired custody on the exited amount; a
+  partial additionally pays the 20 bps redeem-leg fee on the redeemed portion.
+  This is deliberate: no per-position custody accrual, and no refund outflow
+  path. Renewal after a partial is charged on the reduced remainder
+  (`extendCustody` reads the live `mintedAmount`), so the surviving position is
+  never over-charged going forward — only the redeemed slice forfeits its
+  unexpired prepayment, once, at the moment of the partial.
 - **Renewal is exactly one term.** Proration is moot (a renewal never adds
   a partial term) and a renewal-horizon cap is unnecessary (the window <
   term makes stacking impossible). Maximum owner lookahead = one term +

--- a/docs/utxo-reservation-frozen-spec.md
+++ b/docs/utxo-reservation-frozen-spec.md
@@ -15,7 +15,7 @@ numbers are proposals. Companion: `docs/rfc/rfc-13.adoc`,
 | --------------------------------- | ---------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
 | `reservationVault`                | Liability-side vault; deposits revealed to it are reserved | deployed vault          | Changeable only with zero active reservations **and** zero pending reserved deposits |
 | `reservationMinAmount`            | Minimum anchor amount (sat)                                | 10 BTC _(sign-off)_     | Must exceed `reservationTxMaxFee`; the count/size dial for pre-FROST ceremony cost   |
-| `reservationTxMaxFee`             | Per-transaction Bitcoin miner-fee cap (sat)                | governance _(sign-off)_ | > 0                                                                                  |
+| `reservationTxMaxFee`             | Per-transaction Bitcoin miner-fee cap (sat)                | governance _(sign-off)_ | > 0; a partial redemption's redeemed portion and remainder must each exceed it       |
 | `reservationTermSeconds`          | Custody term granted per acceptance/renewal                | 365 days _(sign-off)_   | Hard bounds **90–730 days** (protocol constants)                                     |
 | `reservationDissolutionDelay`     | Post-expiry delay before dissolvable (renamed grace)       | 30 days _(sign-off)_    | Snapshotted per granted term; not an owner-action window                             |
 | `reservationMaxTotalAmount`       | Global reserved-anchor cap (sat)                           | 500 BTC _(sign-off)_    | The absolute lever; the reserved-fraction target is enforced through it (§3)         |
@@ -32,21 +32,23 @@ numbers are proposals. Companion: `docs/rfc/rfc-13.adoc`,
 
 ### ReservationVault fees and reserve
 
-| Parameter              | Meaning                             | Value                   | Notes                                                 |
-| ---------------------- | ----------------------------------- | ----------------------- | ----------------------------------------------------- |
-| `initiationFeeBps`     | Acceptance fee (bps of gross)       | 40                      | 20 bps mint-leg parity + 20 bps first-year custody    |
-| `extensionFeeBps`      | Renewal fee (bps of gross)          | 20                      | Per renewed term                                      |
-| `redemptionFeeBps`     | Redemption fee (bps of gross)       | 20                      | Pooled parity; not re-charged on wallet-fault retries |
-| `MAX_FEE_BASIS_POINTS` | Per-fee hard cap                    | 500 (constant)          |                                                       |
-| `feeReserveTarget`     | Retained in-kind fee reserve (TBTC) | governance _(sign-off)_ | Seed before unpausing; excess sweeps to treasury      |
+| Parameter              | Meaning                             | Value                   | Notes                                                                                               |
+| ---------------------- | ----------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- |
+| `initiationFeeBps`     | Acceptance fee (bps of gross)       | 40                      | 20 bps mint-leg parity + 20 bps first-year custody                                                  |
+| `extensionFeeBps`      | Renewal fee (bps of gross)          | 20                      | Per renewed term                                                                                    |
+| `redemptionFeeBps`     | Redemption fee (bps of gross)       | 20                      | Pooled parity; not re-charged on wallet-fault retries; a partial charges it on the redeemed portion |
+| `MAX_FEE_BASIS_POINTS` | Per-fee hard cap                    | 500 (constant)          |                                                                                                     |
+| `feeReserveTarget`     | Retained in-kind fee reserve (TBTC) | governance _(sign-off)_ | Seed before unpausing; excess sweeps to treasury                                                    |
 
 ## 2. Economic model (frozen mechanics)
 
 - **Claim ≡ anchor, always.** `mintedAmount` tracks `anchorAmount` at every
-  instant. Acceptance mints the gross anchor value; redemption burns it;
-  re-anchor and dissolution write it down to the new anchor and finance the
-  miner fee from the vault reserve. There is no netting and no per-position
-  accumulating leakage.
+  instant. Acceptance mints the gross anchor value; a whole redemption burns
+  it, and a partial burns the redeemed portion while re-anchoring the
+  remainder to the wallet (claim and anchor drop by the redeemed amount in
+  lockstep); re-anchor and dissolution write it down to the new anchor and
+  finance the miner fee from the vault reserve. There is no netting and no
+  per-position accumulating leakage.
 - **Fee schedule 40 / 20 / 20**, all-in initiation 40 bps (endpoints at
   pooled parity, so the purchased premium is exactly the 20 bps/yr custody
   fee). N-year holding pays `40 + 20N` bps vs pooled 40 — strictly premium

--- a/docs/utxo-reservation-frozen-spec.md
+++ b/docs/utxo-reservation-frozen-spec.md
@@ -2,43 +2,53 @@
 
 Status: **DRAFT pending governance sign-off.** This document freezes the
 parameter surface and economic model of the UTXO reservation feature for
-audit. Every value below marked _(sign-off)_ is a governance decision the
-implementation exposes but does not settle; the mechanics are fixed, the
-numbers are proposals. Companion: `docs/rfc/rfc-13.adoc`,
+audit. The mechanics are fixed; the numbers are governance decisions the
+implementation exposes but does not settle. Values marked _(prov. DATE)_ are
+**provisionally confirmed by the owner** on that date and to be revisited
+before launch; items marked _(pending, …)_ still need a final number. Nothing
+here is final until governance sign-off. Companion: `docs/rfc/rfc-13.adoc`,
 `docs/utxo-reservation-design.md`.
 
 ## 1. Parameter surface
 
+> **Provisional launch values set 2026-08-09 (owner), to be revisited before
+> launch.** Term 365 d, renewal window 30 d, dissolution delay 7 d, minimum
+> 10 BTC, global cap 100 BTC, single-reservation cap 25 BTC, per-wallet amount
+> cap 50 BTC, ~10 reservations/wallet, action timeout 48 h, fees 40/20/20. The
+> two `_(pending)_` items — `reservationTxMaxFee` (fee-market) and
+> `feeReserveTarget` (reserve seed) — still need a final number. Final
+> governance sign-off is a launch gate (see the runbook checklist).
+
 ### Bridge reservation parameters (`updateReservationParameters`)
 
-| Parameter                         | Meaning                                                    | Launch value            | Bounds / notes                                                                       |
-| --------------------------------- | ---------------------------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
-| `reservationVault`                | Liability-side vault; deposits revealed to it are reserved | deployed vault          | Changeable only with zero active reservations **and** zero pending reserved deposits |
-| `reservationMinAmount`            | Minimum anchor amount (sat)                                | 10 BTC _(sign-off)_     | Must exceed `reservationTxMaxFee`; the count/size dial for pre-FROST ceremony cost   |
-| `reservationTxMaxFee`             | Per-transaction Bitcoin miner-fee cap (sat)                | governance _(sign-off)_ | > 0; a partial redemption's redeemed portion and remainder must each exceed it       |
-| `reservationTermSeconds`          | Custody term granted per acceptance/renewal                | 365 days _(sign-off)_   | Hard bounds **90–730 days** (protocol constants)                                     |
-| `reservationDissolutionDelay`     | Post-expiry delay before dissolvable (renamed grace)       | 30 days _(sign-off)_    | Snapshotted per granted term; not an owner-action window                             |
-| `reservationMaxTotalAmount`       | Global reserved-anchor cap (sat)                           | 500 BTC _(sign-off)_    | The absolute lever; the reserved-fraction target is enforced through it (§3)         |
-| `maxReservationsPerWallet`        | Per-wallet reservation count cap                           | ~10 _(sign-off)_        | Bounds re-anchor ceremonies in a rotation window                                     |
-| `reservationActionTimeout`        | Timeout for acceptance/re-anchor/dissolution actions       | 48 hours _(sign-off)_   | > 0; redemptions use `redemptionTimeout`                                             |
-| `reservationRenewalWindowSeconds` | Renewal window before expiry                               | 30 days _(sign-off)_    | `0 < window < term`, enforced atomically                                             |
+| Parameter                         | Meaning                                                    | Launch value                                      | Bounds / notes                                                                       |
+| --------------------------------- | ---------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `reservationVault`                | Liability-side vault; deposits revealed to it are reserved | deployed vault                                    | Changeable only with zero active reservations **and** zero pending reserved deposits |
+| `reservationMinAmount`            | Minimum anchor amount (sat)                                | 10 BTC (1,000,000,000 sat) _(prov. 2026-08-09)_   | Must exceed `reservationTxMaxFee`; the count/size dial for pre-FROST ceremony cost   |
+| `reservationTxMaxFee`             | Per-transaction Bitcoin miner-fee cap (sat)                | 50,000 sat (0.0005 BTC) _(pending, fee-market)_   | > 0; a partial redemption's redeemed portion and remainder must each exceed it       |
+| `reservationTermSeconds`          | Custody term granted per acceptance/renewal                | 365 days _(prov. 2026-08-09)_                     | Hard bounds **90–730 days** (protocol constants)                                     |
+| `reservationDissolutionDelay`     | Post-expiry delay before dissolvable (renamed grace)       | 7 days _(prov. 2026-08-09)_                       | Snapshotted per granted term; not an owner-action window                             |
+| `reservationMaxTotalAmount`       | Global reserved-anchor cap (sat)                           | 100 BTC (10,000,000,000 sat) _(prov. 2026-08-09)_ | The absolute lever; the reserved-fraction target is enforced through it (§3)         |
+| `maxReservationsPerWallet`        | Per-wallet reservation count cap                           | 10 _(prov. 2026-08-09)_                           | Bounds re-anchor ceremonies in a rotation window                                     |
+| `reservationActionTimeout`        | Timeout for acceptance/re-anchor/dissolution actions       | 48 hours _(prov. 2026-08-09)_                     | > 0; redemptions use `redemptionTimeout`                                             |
+| `reservationRenewalWindowSeconds` | Renewal window before expiry                               | 30 days _(prov. 2026-08-09)_                      | `0 < window < term`, enforced atomically                                             |
 
 ### Bridge reservation caps (`updateReservationCaps`)
 
-| Parameter                        | Meaning                              | Launch value              | Notes      |
-| -------------------------------- | ------------------------------------ | ------------------------- | ---------- |
-| `maxReservationsAmountPerWallet` | Per-wallet total anchor amount (sat) | governance _(sign-off)_   | 0 disables |
-| `reservationMaxSingleAmount`     | Single-reservation maximum (sat)     | 0 = disabled _(sign-off)_ | 0 disables |
+| Parameter                        | Meaning                              | Launch value                                    | Notes      |
+| -------------------------------- | ------------------------------------ | ----------------------------------------------- | ---------- |
+| `maxReservationsAmountPerWallet` | Per-wallet total anchor amount (sat) | 50 BTC (5,000,000,000 sat) _(prov. 2026-08-09)_ | 0 disables |
+| `reservationMaxSingleAmount`     | Single-reservation maximum (sat)     | 25 BTC (2,500,000,000 sat) _(prov. 2026-08-09)_ | 0 disables |
 
 ### ReservationVault fees and reserve
 
-| Parameter              | Meaning                             | Value                   | Notes                                                                                               |
-| ---------------------- | ----------------------------------- | ----------------------- | --------------------------------------------------------------------------------------------------- |
-| `initiationFeeBps`     | Acceptance fee (bps of gross)       | 40                      | 20 bps mint-leg parity + 20 bps first-year custody                                                  |
-| `extensionFeeBps`      | Renewal fee (bps of gross)          | 20                      | Per renewed term                                                                                    |
-| `redemptionFeeBps`     | Redemption fee (bps of gross)       | 20                      | Pooled parity; not re-charged on wallet-fault retries; a partial charges it on the redeemed portion |
-| `MAX_FEE_BASIS_POINTS` | Per-fee hard cap                    | 500 (constant)          |                                                                                                     |
-| `feeReserveTarget`     | Retained in-kind fee reserve (TBTC) | governance _(sign-off)_ | Seed before unpausing; excess sweeps to treasury                                                    |
+| Parameter              | Meaning                             | Value                                         | Notes                                                                                               |
+| ---------------------- | ----------------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `initiationFeeBps`     | Acceptance fee (bps of gross)       | 40                                            | 20 bps mint-leg parity + 20 bps first-year custody                                                  |
+| `extensionFeeBps`      | Renewal fee (bps of gross)          | 20                                            | Per renewed term                                                                                    |
+| `redemptionFeeBps`     | Redemption fee (bps of gross)       | 20                                            | Pooled parity; not re-charged on wallet-fault retries; a partial charges it on the redeemed portion |
+| `MAX_FEE_BASIS_POINTS` | Per-fee hard cap                    | 500 (constant)                                |                                                                                                     |
+| `feeReserveTarget`     | Retained in-kind fee reserve (TBTC) | governance _(pending, seed before unpausing)_ | Seed before unpausing; excess sweeps to treasury                                                    |
 
 ## 2. Economic model (frozen mechanics)
 
@@ -83,8 +93,10 @@ protects against. Instead:
 - The absolute `reservationMaxTotalAmount` is the on-chain lever.
 - Governance sets it to at most the target fraction of the current total
   BTC backing, observed off-chain, and re-tightens it as backing moves.
-- Launch target: **10 %** of backing _(sign-off)_, realized as a 500 BTC
-  absolute cap at the assumed launch backing _(sign-off)_.
+- Launch cap: **100 BTC** _(prov. 2026-08-09)_ — a deliberately conservative
+  start that sits **below** the 10 % reserved-fraction target at any plausible
+  launch backing, ramping up toward that target as the feature proves out.
+  The 10–20 % fraction remains the governing off-chain rule the cap serves.
 
 Flag this as an explicit accepted limitation for the audit.
 

--- a/docs/utxo-reservation-release-runbook.md
+++ b/docs/utxo-reservation-release-runbook.md
@@ -21,7 +21,7 @@ duties the feature adds. It assumes the stacked PRs
 | `ReservationVault`                 | Plain `Ownable` contract                   | New. Liability-side vault + renewal policy + fee reserve/financing.                                                 |
 | `RedemptionWatchtower`             | Transparent proxy (impl upgrade)           | Reserved-objection surface reworked to per-generation keys; imports the reservation types.                          |
 | `WalletProposalValidator`          | Plain contract (non-upgradeable)           | New reservation proposal validators; redeploy + repoint.                                                            |
-| `BridgeGovernance`                 | Plain `Ownable` contract (non-upgradeable) | New grouped begin/finalize for reservation params + caps.                                                           |
+| `BridgeGovernance`                 | Plain `Ownable` contract (non-upgradeable) | Immediate router/re-anchor forwarders + grouped delayed reservation params/caps.                                    |
 
 The Bridge and the watchtower are the only upgradeable pieces. Everything
 else is a fresh deploy or a redeploy-and-repoint.
@@ -40,10 +40,16 @@ Deploy inert, then activate last.
    candidate implementation before submitting.
 2. **Deploy the libraries** (`Reservation` linking `ReservationProofs`) and
    the **`ReservationRouter`** (linking `Reservation`). One router instance
-   serves the Bridge; it is stateless code.
-3. **Wire the router**: `Bridge.setReservationRouter(router)` — one-time,
-   governance-gated. Until this is set, every reservation selector reverts
-   with `"Unknown function"`; the pooled Bridge is unaffected.
+   serves the Bridge; it is stateless code. Before continuing to step 3,
+   complete the **`BridgeGovernance` replacement** in §6 and verify the new
+   instance is the Bridge's active governance. The incumbent does not expose
+   the router forwarder needed by the next step.
+3. **Wire the router**:
+   `BridgeGovernance.setReservationRouter(router)` — the owner-gated forwarder
+   invokes the Bridge's one-time governance setter. Until this is set, every
+   reservation selector reverts with `"Unknown function"`; the pooled Bridge
+   is unaffected. Do not trust the future reservation vault during this step;
+   it must remain untrusted through all configuration below.
 4. **Watchtower implementation upgrade** (per-generation reserved
    objections). Independent of vault activation; can precede it.
 5. **Deploy `ReservationVault`** (`95_deploy_reservation_vault.ts`). It
@@ -51,9 +57,10 @@ Deploy inert, then activate last.
    the governance account. Do not skip the ownership transfer.
 6. **Redeploy `WalletProposalValidator`** against the upgraded Bridge and
    repoint the coordinator/maintainer configuration at the new address.
-7. **Activation (governance, last):**
-   1. `Bridge.setVaultStatus(vault, true)` — trust the vault so deposits
-      can be revealed to it.
+7. **Configuration and activation (governance, last):**
+   1. Confirm `Bridge.isVaultTrusted(vault) == false`. A fresh vault is
+      untrusted by default; stop if this precondition does not hold, and keep
+      it untrusted through step 7.6.
    2. `BridgeGovernance.beginReservationParametersUpdate(...)` →
       `finalizeReservationParametersUpdate()` after the governance delay,
       setting `reservationVault` to the deployed vault plus the launch
@@ -64,13 +71,18 @@ Deploy inert, then activate last.
       fee reserve target (see §5).
    5. `ReservationVault.setRenewalGuardian(guardian)` — optional; appoint
       the renewal guardian.
-   6. `ReservationVault.unpauseRenewals()` — the final switch; renewals
-      (and, since the vault is now the reservation vault, the whole
-      reservation lane) go live.
+   6. `ReservationVault.unpauseRenewals()` if renewals should be available at
+      launch. This changes only the `extendCustody` policy; it does not enable
+      deposit reveals, acceptance, or any other reservation action.
+   7. `BridgeGovernance.setVaultStatus(vault, true)` — **the final activation
+      transaction**. Trusting the fully configured vault permits deposit
+      reveals to it and opens the reservation lane.
 
-Between steps 5 and 7.2 the vault exists but is not the Bridge's
-reservation vault, so no deposit can route to it and no reservation state
-can be created — the inert window the review requires.
+From deployment through step 7.6 the vault is untrusted, so any deposit
+reveal naming it fails the Bridge trust check and no reserved deposit or
+acceptance can begin. This remains true after the Bridge's `reservationVault`
+parameter is configured. Step 7.7 is therefore the sole final activation
+gate; do not use the renewal pause as a global reservation pause.
 
 ## 3. Bridge proxy upgrade procedure
 
@@ -118,7 +130,7 @@ Standard transparent-proxy upgrade via `BridgeGovernance` /
   total TBTC matched to the Bitcoin backing. Governance sets
   `feeReserveTarget` (TBTC, 18 decimals); `sweepFees(recipient)` moves only
   the balance **above** the target to the treasury. Seed the target before
-  unpausing so the first settlements are covered.
+  the final vault-trust activation so the first settlements are covered.
 - **In-kind fee debt**: if the reserve is ever short at a settlement, the
   settlement still proceeds and the shortfall becomes public
   `inKindFeeDebtSat`. Monitor it; `repayInKindFeeDebt(amountSat)` (anyone)
@@ -137,22 +149,36 @@ Standard transparent-proxy upgrade via `BridgeGovernance` /
 ## 6. BridgeGovernance replacement plan
 
 `BridgeGovernance` is **non-upgradeable**. The reservation feature adds two
-grouped begin/finalize flows (`...ReservationParametersUpdate`,
+immediate, owner-gated forwarding calls (`setReservationRouter` and the
+governance-approved `requestReservationReanchor` path for Live wallets), plus
+two grouped delayed begin/finalize flows (`...ReservationParametersUpdate`,
 `...ReservationCapsUpdate`). Adopting them requires **deploying a new
-`BridgeGovernance` instance** and transferring Bridge governance to it:
+`BridgeGovernance` instance** and transferring Bridge governance to it. This
+replacement is a mandatory prerequisite to the router wiring in deployment
+step 3:
 
-1. Deploy the new `BridgeGovernance` with the same `governanceDelays`
-   configuration as the incumbent.
-2. From the incumbent governance, `Bridge.transferGovernance(newGov)` (via
-   the incumbent's own transfer path).
-3. Re-point any owner-of-owner (the Threshold Council / timelock) at the
-   new instance.
-4. Verify every pre-existing parameter surface still finalizes through the
-   new instance (run the governance suite against it) before decommissioning
-   the old one.
+1. Deploy `newGov` with the intended governance delay.
+2. Immediately have the deployer call
+   `newGov.transferOwnership(councilOrTimelock)`, then verify
+   `newGov.owner() == councilOrTimelock`. Complete this ownership handoff
+   before proposing `newGov` as Bridge governance.
+3. Have the incumbent governance owner call
+   `incumbent.beginBridgeGovernanceTransfer(address(newGov))`.
+4. Wait at least the incumbent governance delay reported by
+   `incumbent.governanceDelays(0)`.
+5. Have the incumbent governance owner call
+   `incumbent.finalizeBridgeGovernanceTransfer()`.
+6. Verify both `Bridge.governance() == address(newGov)` and
+   `newGov.owner() == councilOrTimelock`.
+7. Verify every pre-existing parameter surface still finalizes through the
+   new instance and that the new immediate and delayed reservation surfaces
+   pass the governance suite before decommissioning the old one. Do not invoke
+   the one-time router setter until deployment step 3.
 
-Because governance transfer is a single Bridge call, there is no window
-where the Bridge is ungoverned; the swap is atomic from the Bridge's view.
+The Bridge remains under the incumbent during the delay and switches to
+`newGov` atomically when step 5 finalizes. Never finalize while the deployer
+still owns `newGov`; the ownership prerequisite prevents temporary deployer
+control of the live Bridge.
 
 ## 7. keep-core follow-up (gated on ABI publish)
 
@@ -186,7 +212,8 @@ published npm artifacts), same as the SDK work.
       margin; router/libraries each under EIP-170.
 - [ ] Storage-layout diff append-only and expected (parity test green).
 - [ ] Deployment dry-run on a fork exercises the full activation sequence
-      and leaves the vault inert until the final governance steps.
+      and leaves the vault untrusted and inert until the final
+      `setVaultStatus(vault, true)` transaction.
 - [ ] `docs/utxo-reservation-frozen-spec.md` parameter values signed off by
       governance (launch values provisionally set 2026-08-09; the two
       `_(pending)_` items — `reservationTxMaxFee`, `feeReserveTarget` — and

--- a/docs/utxo-reservation-release-runbook.md
+++ b/docs/utxo-reservation-release-runbook.md
@@ -188,7 +188,9 @@ published npm artifacts), same as the SDK work.
 - [ ] Deployment dry-run on a fork exercises the full activation sequence
       and leaves the vault inert until the final governance steps.
 - [ ] `docs/utxo-reservation-frozen-spec.md` parameter values signed off by
-      governance.
+      governance (launch values provisionally set 2026-08-09; the two
+      `_(pending)_` items — `reservationTxMaxFee`, `feeReserveTarget` — and
+      final governance sign-off still outstanding).
 - [ ] keep-core executor updated for the two-phase ABI (or explicitly
       out-of-scope for the audit with the feature deployed disabled).
 - [ ] Codex (or equivalent) re-review confirms the settlement class from

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -1813,6 +1813,42 @@ contract BridgeGovernance is Ownable {
         bridge.setRebateStaking(rebateStaking);
     }
 
+    /// @notice Sets the reservation router address. This function does not
+    ///         have a governance delay as setting the reservation router is
+    ///         a one-off action performed during reservation initialization.
+    /// @param reservationRouter Address of the reservation router.
+    /// @dev Requirements:
+    ///      - The caller must be the owner,
+    ///      - The Bridge implementation is expected to enforce that the
+    ///        reservation router address is set exactly once and is not 0x0.
+    function setReservationRouter(address reservationRouter)
+        external
+        onlyOwner
+    {
+        bridge.setReservationRouter(reservationRouter);
+    }
+
+    /// @notice Requests a governance-approved re-anchor of a reservation to
+    ///         another wallet. Forwarding through this contract makes the
+    ///         Bridge governance the caller, allowing a rotation away from a
+    ///         Live wallet.
+    /// @param reservationKey The key of the reservation to re-anchor.
+    /// @param targetWalletPubKeyHash 20-byte public key hash of the target
+    ///        wallet.
+    /// @dev Requirements:
+    ///      - The caller must be the owner,
+    ///      - The reservation and wallets must satisfy the Bridge's re-anchor
+    ///        requirements.
+    function requestReservationReanchor(
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash
+    ) external onlyOwner {
+        IReservationBridge(address(bridge)).requestReservationReanchor(
+            reservationKey,
+            targetWalletPubKeyHash
+        );
+    }
+
     /// @notice Begins the reservation parameters update process. All
     ///         reservation parameters (including the reservation vault) are
     ///         staged together since they are applied atomically via a

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -380,7 +380,8 @@ library BridgeState {
         // Time in seconds after which a requested reservation action
         // (acceptance anchor, re-anchor, dissolution) can be reported
         // timed out. Reserved redemptions use `redemptionTimeout` instead.
-        // Snapshotted into each action record at request time.
+        // Must strictly exceed the wallet proposal validator's timeout
+        // safety margin. Snapshotted into each action record at request time.
         uint32 reservationActionTimeout;
         // Length in seconds of the renewal window: a reservation owner may
         // renew (extend by exactly one current term) only while
@@ -434,6 +435,11 @@ library BridgeState {
         // Index-plus-one of each reservation key inside its wallet's
         // `walletReservationKeys` array (zero means absent).
         mapping(uint256 => uint256) walletReservationKeyIndex;
+        // Generation that minted a reservation's outstanding retry credit.
+        // The terminal action record supplies the exact redemption amount
+        // and whole/partial shape the fee-free retry must preserve. Zero
+        // means there is no bound source generation.
+        mapping(uint256 => uint64) reservationRetryCreditActionNonce;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -441,7 +447,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[32] __gap;
+        uint256[31] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/Deposit.sol
+++ b/solidity/contracts/bridge/Deposit.sol
@@ -342,7 +342,17 @@ library Deposit {
             : 0;
         deposit.extraData = extraData;
 
-        if (deposit.treasuryFee > 0 && self.rebateStaking != address(0)) {
+        bool isReservedDeposit = reveal.vault != address(0) &&
+            reveal.vault == self.reservationVault;
+
+        // Reserved deposits pay their initiation fee to the reservation
+        // vault, so applying a pooled deposit rebate here would consume the
+        // depositor's rebate allowance without discounting that fee.
+        if (
+            deposit.treasuryFee > 0 &&
+            self.rebateStaking != address(0) &&
+            !isReservedDeposit
+        ) {
             deposit.treasuryFee = RebateStaking(self.rebateStaking)
                 .applyForRebate(
                     deposit.depositor,
@@ -351,9 +361,7 @@ library Deposit {
                 );
         }
 
-        if (
-            reveal.vault != address(0) && reveal.vault == self.reservationVault
-        ) {
+        if (isReservedDeposit) {
             // A deposit routed to the reservation vault is a reserved
             // deposit: record its designated wallet — proven by the
             // reveal's script commitment — so the acceptance authorization

--- a/solidity/contracts/bridge/IReservationBridge.sol
+++ b/solidity/contracts/bridge/IReservationBridge.sol
@@ -38,6 +38,16 @@ interface IReservationBridge {
         bool useRetryCredit
     ) external;
 
+    /// @notice See `ReservationRouter.requestPartialReservedRedemption`.
+    function requestPartialReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript,
+        uint64 redeemAmount,
+        bool feePaid,
+        bool useRetryCredit
+    ) external;
+
     /// @notice See `ReservationRouter.requestReservationReanchor`.
     function requestReservationReanchor(
         uint256 reservationKey,

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -427,8 +427,12 @@ library Reservation {
 
         BridgeState.PendingReservedDeposit storage reservedDeposit = self
             .pendingReservedDeposit[reservationKey];
+        // The pending marker and designated-wallet binding are checked
+        // together: stale or accepted deposits have a zero marker, and only
+        // the wallet committed by the deposit script may become custodian.
         require(
-            reservedDeposit.walletPubKeyHash != bytes20(0),
+            reservedDeposit.walletPubKeyHash != bytes20(0) &&
+                reservedDeposit.walletPubKeyHash == walletPubKeyHash,
             "Wallet is not the deposit's designated wallet"
         );
 
@@ -443,16 +447,6 @@ library Reservation {
             getAction(self, reservationKey, reservation.requestNonce).state !=
                 ActionState.Pending,
             "Acceptance already pending"
-        );
-
-        // The anchor must be bound to the wallet the deposit was revealed
-        // for: only that wallet's key can spend the deposit, and only it
-        // may become the custodian. The mapping doubles as the pending
-        // marker — a deposit marked stale (or already accepted) cannot be
-        // re-authorized.
-        require(
-            reservedDeposit.walletPubKeyHash == walletPubKeyHash,
-            "Wallet is not the deposit's designated wallet"
         );
 
         require(

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -183,9 +183,11 @@ library Reservation {
         // times out through the wallet's fault. The source generation is
         // stored separately and binds partial retries to its exact amount
         // and whole retries to no more than its original full claim. It is
-        // returned if a late re-anchor supersedes the retry that consumed it.
-        // Consumed by the next strictly pre-expiry retry request; voided by a
-        // dissolution request.
+        // returned if a late re-anchor or partial redemption supersedes the
+        // retry that consumed it while leaving the reservation open. A late
+        // partial settlement retires the entitlement when it settles that
+        // entitlement's source generation. Consumed by the next strictly
+        // pre-expiry retry request; voided by a dissolution request.
         bool retryCredit;
         // UNIX timestamp the reservation becomes dissolvable at. Set to
         // `expiresAt + reservationDissolutionDelay` whenever a term is
@@ -242,7 +244,8 @@ library Reservation {
         bytes32 expectedMainUtxoHash;
         // True when this redemption generation consumed the reservation's
         // single-use retry entitlement. Needed to return the entitlement if
-        // a late re-anchor makes the generation impossible to settle.
+        // a late action consumes the expected anchor while leaving the
+        // reservation open and makes this generation impossible to settle.
         bool usedRetryCredit;
         // True when a redemption generation is partial: it redeems only
         // `amount` of the reservation's claim in a 1-input-2-output spend
@@ -254,8 +257,8 @@ library Reservation {
         bool isPartial;
         // Fee-paid redemption generation that originated the retry credit
         // consumed by this action. Zero when `usedRetryCredit` is false.
-        // Kept on the action so a late re-anchor can restore the exact
-        // amount/shape binding after superseding the retry.
+        // Kept on the action so a late re-anchor or partial redemption can
+        // restore the exact amount/shape binding after superseding the retry.
         uint64 retryCreditSourceNonce;
     }
 

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -252,6 +252,11 @@ library Reservation {
         // every non-redemption action. Appended to the end of the struct so
         // the existing field layout is unchanged.
         bool isPartial;
+        // Fee-paid redemption generation that originated the retry credit
+        // consumed by this action. Zero when `usedRetryCredit` is false.
+        // Kept on the action so a late re-anchor can restore the exact
+        // amount/shape binding after superseding the retry.
+        uint64 retryCreditSourceNonce;
     }
 
     event ReservationAcceptanceRequested(
@@ -707,8 +712,9 @@ library Reservation {
             "Reservation expired"
         );
 
+        uint64 retryCreditSourceNonce;
         if (useRetryCredit) {
-            consumeRetryCredit(
+            retryCreditSourceNonce = consumeRetryCredit(
                 self,
                 reservation,
                 reservationKey,
@@ -760,6 +766,7 @@ library Reservation {
         action.txMaxFee = self.reservationTxMaxFee;
         action.feePaid = feePaid;
         action.usedRetryCredit = useRetryCredit;
+        action.retryCreditSourceNonce = retryCreditSourceNonce;
         action.redeemer = redeemer;
         action.amount = redeemAmount;
         action.redeemerOutputScriptHash = keccak256(redeemerOutputScriptMem);
@@ -790,12 +797,10 @@ library Reservation {
         uint256 reservationKey,
         uint64 redeemAmount,
         bool isPartial
-    ) internal {
+    ) internal returns (uint64 sourceNonce) {
         require(reservation.retryCredit, "No retry entitlement");
 
-        uint64 sourceNonce = self.reservationRetryCreditActionNonce[
-            reservationKey
-        ];
+        sourceNonce = self.reservationRetryCreditActionNonce[reservationKey];
         ReservationAction storage sourceAction = getAction(
             self,
             reservationKey,

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -214,8 +214,10 @@ library Reservation {
         // redemption generation time out. Zero for other action types.
         address redeemer;
         // Amount in satoshi associated with the generation: the escrowed
-        // gross claim for redemptions, the capacity-reserved deposit value
-        // for acceptances, the anchor value at request time otherwise.
+        // gross claim for redemptions (the full claim for a whole
+        // redemption, the redeemed portion for a partial), the
+        // capacity-reserved deposit value for acceptances, the anchor
+        // value at request time otherwise.
         uint64 amount;
         // keccak256 hash of the length-prefixed redeemer output script a
         // redemption generation must pay to. Zero for other action types.
@@ -225,6 +227,14 @@ library Reservation {
         // Zero for other action types, and for dissolutions of wallets
         // with no main UTXO.
         bytes32 expectedMainUtxoHash;
+        // True when a redemption generation is partial: it redeems only
+        // `amount` of the reservation's claim in a 1-input-2-output spend
+        // (redeemer output + re-anchored remainder) and leaves the
+        // reservation open with a reduced anchor. False for a whole
+        // redemption (1-input-1-output, closes the reservation) and for
+        // every non-redemption action. Appended to the end of the struct so
+        // the existing field layout is unchanged.
+        bool isPartial;
     }
 
     event ReservationAcceptanceRequested(
@@ -551,6 +561,94 @@ library Reservation {
         bool feePaid,
         bool useRetryCredit
     ) external {
+        // A whole redemption redeems the full minted claim (1-in-1-out,
+        // closes the reservation). Passing the full `mintedAmount` marks
+        // the generation non-partial.
+        _requestReservedRedemption(
+            self,
+            reservationKey,
+            redeemer,
+            redeemerOutputScript,
+            self.reservations[reservationKey].mintedAmount,
+            false,
+            feePaid,
+            useRetryCredit
+        );
+    }
+
+    /// @notice Requests a partial in-kind redemption of a reservation: the
+    ///         wallet is expected to spend the anchor in a 1-input-2-output
+    ///         transaction paying `redeemAmount` (less the miner fee) to
+    ///         the redeemer and re-anchoring the remainder back to the
+    ///         custodying wallet. The reservation stays open with its claim
+    ///         and anchor both reduced by `redeemAmount`.
+    /// @param reservationKey The key of the reservation to partially redeem.
+    /// @param redeemer The address able to claim the escrowed portion back
+    ///        if the redemption times out.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param redeemAmount The satoshi portion of the claim to redeem.
+    /// @param feePaid True when the vault collected the (proportional)
+    ///        redemption fee for this request.
+    /// @param useRetryCredit True when the request consumes the fee-free
+    ///        retry entitlement instead of paying the fee.
+    /// @dev Requirements (in addition to the shared redemption
+    ///      requirements):
+    ///      - `redeemAmount` must exceed the per-transaction fee bound (so
+    ///        the redeemer output is positive after the miner fee),
+    ///      - `redeemAmount` must be strictly less than the minted claim
+    ///        (a full-claim redemption uses the whole-redemption path),
+    ///      - the remainder (`mintedAmount - redeemAmount`) must stay above
+    ///        the dust floor so the surviving reservation is still
+    ///        redeemable and dissolvable.
+    function requestPartialReservedRedemption(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript,
+        uint64 redeemAmount,
+        bool feePaid,
+        bool useRetryCredit
+    ) external {
+        uint64 mintedAmount = self.reservations[reservationKey].mintedAmount;
+        require(
+            redeemAmount > self.reservationTxMaxFee,
+            "Redeemed amount below the dust floor"
+        );
+        require(
+            redeemAmount < mintedAmount,
+            "Use the whole redemption path for a full claim"
+        );
+        require(
+            mintedAmount - redeemAmount > self.reservationTxMaxFee,
+            "Remainder below the dust floor"
+        );
+
+        _requestReservedRedemption(
+            self,
+            reservationKey,
+            redeemer,
+            redeemerOutputScript,
+            redeemAmount,
+            true,
+            feePaid,
+            useRetryCredit
+        );
+    }
+
+    /// @notice Shared body for whole and partial reserved redemption
+    ///         requests. Escrows `redeemAmount` gross from the reservation
+    ///         vault's Bank balance and records a redemption generation.
+    function _requestReservedRedemption(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript,
+        uint64 redeemAmount,
+        bool isPartial,
+        bool feePaid,
+        bool useRetryCredit
+    ) internal {
         require(
             msg.sender == self.reservationVault,
             "Caller is not the reservation vault"
@@ -629,6 +727,7 @@ library Reservation {
         );
         action.actionType = ActionType.Redemption;
         action.state = ActionState.Pending;
+        action.isPartial = isPartial;
         /* solhint-disable-next-line not-rely-on-time */
         action.requestedAt = uint32(block.timestamp);
         /* solhint-disable-next-line not-rely-on-time */
@@ -636,7 +735,7 @@ library Reservation {
         action.txMaxFee = self.reservationTxMaxFee;
         action.feePaid = feePaid;
         action.redeemer = redeemer;
-        action.amount = reservation.mintedAmount;
+        action.amount = redeemAmount;
         action.redeemerOutputScriptHash = keccak256(redeemerOutputScriptMem);
 
         // slither-disable-next-line reentrancy-events
@@ -645,16 +744,12 @@ library Reservation {
             requestNonce,
             redeemer,
             redeemerOutputScript,
-            reservation.mintedAmount,
+            redeemAmount,
             action.txMaxFee,
             feePaid
         );
 
-        self.bank.transferBalanceFrom(
-            msg.sender,
-            address(this),
-            reservation.mintedAmount
-        );
+        self.bank.transferBalanceFrom(msg.sender, address(this), redeemAmount);
     }
 
     /// @notice Requests the re-anchoring of a reservation to another

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -712,7 +712,7 @@ library Reservation {
             "Reservation expired"
         );
 
-        uint64 retryCreditSourceNonce;
+        uint64 retryCreditSourceNonce = 0;
         if (useRetryCredit) {
             retryCreditSourceNonce = consumeRetryCredit(
                 self,

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -74,6 +74,15 @@ library Reservation {
     uint32 internal constant MIN_RESERVATION_TERM = 90 days;
     uint32 internal constant MAX_RESERVATION_TERM = 730 days;
 
+    /// @notice Time reserved between the latest valid wallet proposal and
+    ///         the point at which its reservation action can be reported
+    ///         timed out. The action timeout must strictly exceed this
+    ///         margin so the validator's subtraction cannot underflow or
+    ///         collapse the latest valid instant to the request timestamp.
+    ///         Acceptance also has the deposit-age timing constraint described
+    ///         on `requestReservationAcceptance`.
+    uint32 internal constant RESERVATION_ACTION_TIMEOUT_SAFETY_MARGIN = 2 hours;
+
     /// @notice Represents the state of a reservation position.
     enum ReservationState {
         /// @dev The reservation is unknown to the Bridge. Acceptance
@@ -171,8 +180,9 @@ library Reservation {
         uint64 requestNonce;
         // True when the owner holds a single-use, fee-free redemption
         // retry entitlement, minted when a fee-paid redemption request
-        // times out through the wallet's fault. Consumed by the next
-        // (strictly pre-expiry) retry request.
+        // times out through the wallet's fault. The source generation is
+        // stored separately and binds the retry to its amount and
+        // whole/partial shape.
         bool retryCredit;
         // UNIX timestamp the reservation becomes dissolvable at. Set to
         // `expiresAt + reservationDissolutionDelay` whenever a term is
@@ -385,6 +395,12 @@ library Reservation {
     ///      - The deposit amount must satisfy the reservation minimum plus
     ///        the transaction fee allowance, so a compliant anchor always
     ///        satisfies the minimum after fees,
+    ///      - The deposit must reach the proposal validator's minimum age
+    ///        before the action's final valid signing time. An acceptance
+    ///        requested immediately after reveal therefore needs an action
+    ///        timeout longer than the minimum age plus the timeout safety
+    ///        margin; otherwise the requester must wait for the deposit to
+    ///        age before requesting,
     ///      - The authorization window (now + action timeout) must end
     ///        before the deposit's guaranteed refund-locktime margin
     ///        (`revealedAt + depositRevealAheadPeriod`), so an authorized
@@ -542,13 +558,11 @@ library Reservation {
     ///        approved the Bridge in the Bank for the gross minted amount,
     ///      - The reservation must be Active and custodied by a Live or
     ///        MovingFunds wallet,
-    ///      - The custody term plus (snapshotted) grace period must not
-    ///        have elapsed — after grace only dissolution is possible, so
-    ///        request/timeout cycling cannot defeat the stranding bound.
-    ///        A retry-entitled request is exempt until a dissolution is
-    ///        requested (which voids the entitlement),
-    ///      - When `useRetryCredit` is set, the position must hold the
-    ///        retry entitlement (consumed by this call),
+    ///      - The custody term must not have expired; paid requests and
+    ///        retries both stop strictly before expiry,
+    ///      - When `useRetryCredit` is set, the position must hold an
+    ///        entitlement for the same amount and whole/partial shape
+    ///        (consumed by this call),
     ///      - If the redemption watchtower is set, neither the owner nor
     ///        the redeemer may be banned,
     ///      - `redeemerOutputScript` must be a standard type and must not
@@ -688,8 +702,13 @@ library Reservation {
         );
 
         if (useRetryCredit) {
-            require(reservation.retryCredit, "No retry entitlement");
-            reservation.retryCredit = false;
+            consumeRetryCredit(
+                self,
+                reservation,
+                reservationKey,
+                redeemAmount,
+                isPartial
+            );
         }
 
         if (self.redemptionWatchtower != address(0)) {
@@ -750,6 +769,42 @@ library Reservation {
         );
 
         self.bank.transferBalanceFrom(msg.sender, address(this), redeemAmount);
+    }
+
+    /// @notice Consumes the retry credit minted by a timed-out, fee-paid
+    ///         redemption generation after verifying the new request keeps
+    ///         that generation's amount and whole/partial shape.
+    /// @dev The source action is terminal and immutable, so binding the
+    ///      credit to its nonce also binds all retry-critical fields without
+    ///      duplicating them in reservation storage.
+    function consumeRetryCredit(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        uint256 reservationKey,
+        uint64 redeemAmount,
+        bool isPartial
+    ) internal {
+        require(reservation.retryCredit, "No retry entitlement");
+
+        uint64 sourceNonce = self.reservationRetryCreditActionNonce[
+            reservationKey
+        ];
+        ReservationAction storage sourceAction = getAction(
+            self,
+            reservationKey,
+            sourceNonce
+        );
+        require(
+            sourceAction.actionType == ActionType.Redemption &&
+                sourceAction.state == ActionState.TimedOut &&
+                sourceAction.feePaid &&
+                sourceAction.amount == redeemAmount &&
+                sourceAction.isPartial == isPartial,
+            "Retry entitlement does not match redemption"
+        );
+
+        reservation.retryCredit = false;
+        delete self.reservationRetryCreditActionNonce[reservationKey];
     }
 
     /// @notice Requests the re-anchoring of a reservation to another
@@ -878,9 +933,9 @@ library Reservation {
     ///        of a no-main-UTXO wallet could otherwise all confirm on
     ///        Bitcoin with only the first being provable.
     ///
-    ///      Requesting a dissolution voids the position's redemption retry
-    ///      entitlement: dissolution is the terminal cleanup and the
-    ///      stranding bound takes precedence.
+    ///      Any outstanding redemption retry entitlement is already unusable
+    ///      here: paid requests and retries stop strictly at expiry, while
+    ///      dissolution starts no earlier than `dissolutionEligibleAt`.
     function requestReservationDissolution(
         BridgeState.Storage storage self,
         uint256 reservationKey
@@ -1004,6 +1059,9 @@ library Reservation {
 
             if (action.feePaid) {
                 reservation.retryCredit = true;
+                self.reservationRetryCreditActionNonce[
+                    reservationKey
+                ] = requestNonce;
                 emit ReservationRetryCreditMinted(reservationKey);
             }
 
@@ -1200,7 +1258,8 @@ library Reservation {
     ///        than the term (checked atomically here and re-checked at
     ///        renewal execution, so neither parameter change can reopen
     ///        term stacking),
-    ///      - Reservation action timeout must be greater than zero,
+    ///      - Reservation action timeout must strictly exceed the wallet
+    ///        proposal validator's timeout safety margin,
     ///      - The reservation vault can only be changed while there are no
     ///        active reservations (total reserved amount is zero).
     ///
@@ -1238,8 +1297,8 @@ library Reservation {
             "Renewal window must be shorter than the term"
         );
         require(
-            reservationActionTimeout > 0,
-            "Reservation action timeout must be greater than zero"
+            reservationActionTimeout > RESERVATION_ACTION_TIMEOUT_SAFETY_MARGIN,
+            "Reservation action timeout must exceed the safety margin"
         );
 
         if (reservationVault != self.reservationVault) {
@@ -1362,38 +1421,7 @@ library Reservation {
             );
         }
 
-        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
-        self.walletReservationsAmount[
-            reservation.walletPubKeyHash
-        ] -= reservation.anchorAmount;
-        self.reservationTotalAmount -= reservation.anchorAmount;
-        removeWalletReservationKey(
-            self,
-            reservation.walletPubKeyHash,
-            reservationKey
-        );
-        reservation.state = ReservationState.Stranded;
-
-        // The anchor is deliberately NOT marked as honestly spent: a
-        // spend by the terminated wallet remains recognizable as such.
-        delete self.reservationsByAnchorUtxo[
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        reservation.anchorTxHash,
-                        reservation.anchorTxOutputIndex
-                    )
-                )
-            )
-        ];
-
-        // slither-disable-next-line reentrancy-events
-        emit ReservationStranded(
-            reservationKey,
-            reservation.walletPubKeyHash,
-            reservation.owner,
-            reservation.anchorAmount
-        );
+        strandReservation(self, reservation, reservationKey);
     }
 
     /// @notice Updates the amount-denominated reservation caps. Checked
@@ -1449,6 +1477,51 @@ library Reservation {
         }
         keys.pop();
         delete self.walletReservationKeyIndex[reservationKey];
+    }
+
+    /// @notice Stops tracking an anchor that its custodying wallet can no
+    ///         longer manage through the reservation lifecycle. The owner's
+    ///         minted balance remains an ordinary pooled claim.
+    /// @dev The caller must first unwind any pending generation and ensure
+    ///      the reservation and its capacity are registered against the
+    ///      current custodying wallet.
+    function strandReservation(
+        BridgeState.Storage storage self,
+        ReservationRequest storage reservation,
+        uint256 reservationKey
+    ) internal {
+        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
+        self.walletReservationsAmount[
+            reservation.walletPubKeyHash
+        ] -= reservation.anchorAmount;
+        self.reservationTotalAmount -= reservation.anchorAmount;
+        removeWalletReservationKey(
+            self,
+            reservation.walletPubKeyHash,
+            reservationKey
+        );
+        reservation.state = ReservationState.Stranded;
+
+        // The unmanageable anchor is deliberately NOT marked as honestly
+        // spent: a later spend by the wallet remains recognizable as such.
+        delete self.reservationsByAnchorUtxo[
+            uint256(
+                keccak256(
+                    abi.encodePacked(
+                        reservation.anchorTxHash,
+                        reservation.anchorTxOutputIndex
+                    )
+                )
+            )
+        ];
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservationStranded(
+            reservationKey,
+            reservation.walletPubKeyHash,
+            reservation.owner,
+            reservation.anchorAmount
+        );
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -181,8 +181,8 @@ library Reservation {
         // True when the owner holds a single-use, fee-free redemption
         // retry entitlement, minted when a fee-paid redemption request
         // times out through the wallet's fault. The source generation is
-        // stored separately and binds the retry to its amount and
-        // whole/partial shape.
+        // stored separately and binds partial retries to its exact amount
+        // and whole retries to no more than its original full claim.
         bool retryCredit;
         // UNIX timestamp the reservation becomes dissolvable at. Set to
         // `expiresAt + reservationDissolutionDelay` whenever a term is
@@ -560,9 +560,9 @@ library Reservation {
     ///        MovingFunds wallet,
     ///      - The custody term must not have expired; paid requests and
     ///        retries both stop strictly before expiry,
-    ///      - When `useRetryCredit` is set, the position must hold an
-    ///        entitlement for the same amount and whole/partial shape
-    ///        (consumed by this call),
+    ///      - When `useRetryCredit` is set, the position must hold a
+    ///        matching partial entitlement or a whole entitlement covering
+    ///        the current full claim (consumed by this call),
     ///      - If the redemption watchtower is set, neither the owner nor
     ///        the redeemer may be banned,
     ///      - `redeemerOutputScript` must be a standard type and must not
@@ -773,7 +773,7 @@ library Reservation {
 
     /// @notice Consumes the retry credit minted by a timed-out, fee-paid
     ///         redemption generation after verifying the new request keeps
-    ///         that generation's amount and whole/partial shape.
+    ///         that generation's shape and does not exceed its paid amount.
     /// @dev The source action is terminal and immutable, so binding the
     ///      credit to its nonce also binds all retry-critical fields without
     ///      duplicating them in reservation storage.
@@ -794,12 +794,21 @@ library Reservation {
             reservationKey,
             sourceNonce
         );
+
+        // A partial retry must preserve the exact paid amount. A whole
+        // redemption paid for the source generation's entire claim, so a
+        // later re-anchor write-down may retry the current full claim as
+        // long as it did not grow beyond that paid amount.
+        bool retryMatches = isPartial
+            ? sourceAction.isPartial && sourceAction.amount == redeemAmount
+            : !sourceAction.isPartial &&
+                redeemAmount == reservation.mintedAmount &&
+                redeemAmount <= sourceAction.amount;
         require(
             sourceAction.actionType == ActionType.Redemption &&
                 sourceAction.state == ActionState.TimedOut &&
                 sourceAction.feePaid &&
-                sourceAction.amount == redeemAmount &&
-                sourceAction.isPartial == isPartial,
+                retryMatches,
             "Retry entitlement does not match redemption"
         );
 

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -84,6 +84,14 @@ library ReservationProofs {
         bytes32 redemptionTxHash
     );
 
+    event ReservationPartiallyRedeemed(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes32 redemptionTxHash,
+        uint64 redeemedAmount,
+        uint64 newAnchorAmount
+    );
+
     event ReservationReanchored(
         uint256 indexed reservationKey,
         uint64 requestNonce,
@@ -533,7 +541,45 @@ library ReservationProofs {
 
         consumeAnchor(self, reservation, redemptionTx.inputVector);
 
-        bytes memory output = parseSingleOutput(redemptionTx.outputVector);
+        if (action.isPartial) {
+            settlePartialRedemption(
+                self,
+                reservation,
+                reservationKey,
+                requestNonce,
+                action,
+                late,
+                redemptionTxHash,
+                redemptionTx.outputVector
+            );
+        } else {
+            settleWholeRedemption(
+                self,
+                reservation,
+                reservationKey,
+                requestNonce,
+                action,
+                late,
+                redemptionTxHash,
+                redemptionTx.outputVector
+            );
+        }
+    }
+
+    /// @notice Settles a whole reserved redemption: a 1-input-1-output
+    ///         spend that pays the full claim to the redeemer and closes
+    ///         the reservation.
+    function settleWholeRedemption(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ReservationAction storage action,
+        bool late,
+        bytes32 redemptionTxHash,
+        bytes memory outputVector
+    ) internal {
+        bytes memory output = parseSingleOutput(outputVector);
         uint64 outputValue = output.extractValue();
 
         {
@@ -555,12 +601,13 @@ library ReservationProofs {
         );
 
         if (late) {
-            resolveLateRedemptionAgainstPending(
+            resolveLateAgainstPending(
                 self,
                 reservation,
                 reservationKey,
                 action,
-                outputValue
+                outputValue,
+                reservation.anchorAmount
             );
 
             emit ReservationLateSettled(
@@ -588,6 +635,139 @@ library ReservationProofs {
             // redemption request.
             self.bank.decreaseBalance(action.amount);
         }
+    }
+
+    /// @notice Settles a partial reserved redemption: a 1-input-2-output
+    ///         spend that pays `action.amount` (less the miner fee) to the
+    ///         redeemer and re-anchors the remainder back to the custodying
+    ///         wallet. The reservation stays open with its claim and anchor
+    ///         reduced by the redeemed portion — claim always equals the new
+    ///         anchor — and the remainder output becomes the new anchor
+    ///         (output index 1).
+    function settlePartialRedemption(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ReservationAction storage action,
+        bool late,
+        bytes32 redemptionTxHash,
+        bytes memory outputVector
+    ) internal {
+        (uint64 redeemerValue, uint64 remainderValue) = validatePartialOutputs(
+            self,
+            reservation,
+            action,
+            outputVector
+        );
+
+        if (late) {
+            resolveLateAgainstPending(
+                self,
+                reservation,
+                reservationKey,
+                action,
+                redeemerValue,
+                action.amount
+            );
+
+            emit ReservationLateSettled(
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Redemption
+            );
+            // No Bank movement: the timeout already refunded the escrowed
+            // portion and slashed the wallet.
+        }
+
+        action.state = Reservation.ActionState.Settled;
+
+        // Reduce the reservation to the remainder anchor; it stays Active.
+        // Because the claim equals the anchor, the redeemed portion drops
+        // out of both the claim and the reserved capacity in lockstep.
+        self.reservationTotalAmount -= action.amount;
+        self.walletReservationsAmount[reservation.walletPubKeyHash] -= action
+            .amount;
+
+        reservation.mintedAmount -= action.amount;
+        reservation.anchorAmount = remainderValue;
+        reservation.anchorTxHash = redemptionTxHash;
+        reservation.anchorTxOutputIndex = 1;
+        reservation.state = Reservation.ReservationState.Active;
+
+        self.reservationsByAnchorUtxo[
+            uint256(keccak256(abi.encodePacked(redemptionTxHash, uint32(1))))
+        ] = reservationKey;
+
+        emit ReservationPartiallyRedeemed(
+            reservationKey,
+            requestNonce,
+            redemptionTxHash,
+            action.amount,
+            remainderValue
+        );
+
+        if (!late) {
+            // Burn the redeemed portion held by the Bridge since the
+            // request.
+            self.bank.decreaseBalance(action.amount);
+        }
+    }
+
+    /// @notice Validates the two outputs of a partial redemption
+    ///         transaction and returns their values.
+    /// @return redeemerValue Value of the redeemer output (output 0).
+    /// @return remainderValue Value of the re-anchored remainder (output 1).
+    function validatePartialOutputs(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        Reservation.ReservationAction storage action,
+        bytes memory outputVector
+    ) internal view returns (uint64 redeemerValue, uint64 remainderValue) {
+        (, uint256 outputsCount) = outputVector.parseVarInt();
+        require(
+            outputsCount == 2,
+            "Partial redemption must have exactly two outputs"
+        );
+
+        bytes memory redeemerOutput = outputVector.extractOutputAtIndex(0);
+        bytes memory remainderOutput = outputVector.extractOutputAtIndex(1);
+
+        redeemerValue = redeemerOutput.extractValue();
+        remainderValue = remainderOutput.extractValue();
+
+        // Output 0 pays the requested redeemer script; its value is the
+        // redeemed portion less the miner fee, which the redeemer bears.
+        {
+            bytes memory redeemerScript = redeemerOutput.slice(
+                8,
+                redeemerOutput.length - 8
+            );
+            require(
+                keccak256(redeemerScript) == action.redeemerOutputScriptHash,
+                "First output does not pay the requested redeemer script"
+            );
+        }
+        require(
+            redeemerValue <= action.amount &&
+                action.amount - redeemerValue <= action.txMaxFee,
+            "Redeemer output value is not within the acceptable range"
+        );
+
+        // Output 1 re-anchors to the custodying wallet; its value must equal
+        // the anchor minus the redeemed portion, so the surviving claim
+        // still equals the surviving anchor to the satoshi. The whole miner
+        // fee is therefore borne by the redeemer output, never the
+        // remainder.
+        require(
+            self.extractPubKeyHash(remainderOutput) ==
+                reservation.walletPubKeyHash,
+            "Second output must re-anchor to the custodying wallet"
+        );
+        require(
+            remainderValue == reservation.anchorAmount - action.amount,
+            "Remainder value must equal the anchor minus the redeemed amount"
+        );
     }
 
     /// @notice Used by the wallet to prove a re-anchor transaction moving a
@@ -967,12 +1147,13 @@ library ReservationProofs {
     ///         generations can claim the transaction); otherwise the
     ///         pending generation's anchor is provably gone and it is
     ///         unwound.
-    function resolveLateRedemptionAgainstPending(
+    function resolveLateAgainstPending(
         BridgeState.Storage storage self,
         Reservation.ReservationRequest storage reservation,
         uint256 reservationKey,
         Reservation.ReservationAction storage action,
-        uint64 outputValue
+        uint64 redeemerValue,
+        uint64 effectiveRedeemAmount
     ) internal {
         if (reservation.state != Reservation.ReservationState.ActionPending) {
             return;
@@ -982,11 +1163,23 @@ library ReservationProofs {
             .reservationActions[
                 Reservation.actionKey(reservationKey, reservation.requestNonce)
             ];
+        // The pending generation is satisfied by this same transaction only
+        // if it is a redemption of the same shape (whole vs partial), the
+        // same redeemer script, the same redeemed amount, and the redeemer
+        // output falls within its snapshotted fee bound. `redeemerValue` is
+        // the redeemer's output value and `effectiveRedeemAmount` is the
+        // value it is measured against (the anchor for a whole redemption,
+        // the redeemed portion for a partial). When it matches, settling the
+        // timed-out generation (no burn) while unwinding the pending one
+        // (refund) would lose the burn, so the proof must settle the pending
+        // generation instead.
         if (
             pendingAction.actionType == Reservation.ActionType.Redemption &&
+            pendingAction.isPartial == action.isPartial &&
             pendingAction.redeemerOutputScriptHash ==
             action.redeemerOutputScriptHash &&
-            reservation.anchorAmount - outputValue <= pendingAction.txMaxFee
+            pendingAction.amount == action.amount &&
+            effectiveRedeemAmount - redeemerValue <= pendingAction.txMaxFee
         ) {
             revert("Must settle the pending generation");
         }

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -1343,8 +1343,16 @@ library ReservationProofs {
         }
 
         // The pending generation cannot claim the transaction; its anchor
-        // is gone, so unwind it.
-        unwindPendingAction(self, reservation, reservationKey, false);
+        // is gone, so unwind it. A late partial leaves the reservation open,
+        // so preserve any retry provenance consumed by the superseded
+        // generation. The post-settlement source-nonce check retires it when
+        // this is the source generation itself and preserves it otherwise.
+        unwindPendingAction(
+            self,
+            reservation,
+            reservationKey,
+            action.isPartial
+        );
     }
 
     /// @notice Unwinds the position's current pending generation during a
@@ -1353,9 +1361,11 @@ library ReservationProofs {
     ///         consumed, so the generation can never settle. Its escrow is
     ///         refunded (redemptions), its reserved capacity and locks are
     ///         released, and it is terminally marked `Superseded`. Retry
-    ///         credit restoration is enabled only by the late-reanchor call
-    ///         site, whose successful settlement leaves the reservation
-    ///         Active on a replacement anchor.
+    ///         credit restoration is enabled only by late re-anchor and late
+    ///         partial-redemption call sites, whose successful settlements
+    ///         leave the reservation Active on a replacement anchor. A late
+    ///         partial's source-nonce retirement then removes the credit when
+    ///         its own source settled and preserves a newer source.
     function unwindPendingAction(
         BridgeState.Storage storage self,
         Reservation.ReservationRequest storage reservation,

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -1377,6 +1377,9 @@ library ReservationProofs {
         if (pendingAction.actionType == Reservation.ActionType.Redemption) {
             if (restoreRetryCredit && pendingAction.usedRetryCredit) {
                 reservation.retryCredit = true;
+                self.reservationRetryCreditActionNonce[
+                    reservationKey
+                ] = pendingAction.retryCreditSourceNonce;
                 emit ReservationRetryCreditMinted(reservationKey);
             }
 

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -211,6 +211,35 @@ library ReservationProofs {
         late = action.state == Reservation.ActionState.TimedOut;
     }
 
+    /// @notice Converts a late settlement into the existing stranded-position
+    ///         accounting when its target wallet retired after timeout
+    ///         released the target's reserved capacity.
+    /// @dev Live and MovingFunds wallets can still manage the newly settled
+    ///      anchor. Terminated wallets retain the existing permissionless
+    ///      `notifyReservationStranded` cleanup path. Closing and Closed
+    ///      wallets accept no reservation action, so retaining the anchor as
+    ///      Active would permanently pin both the position and wallet.
+    function strandLateSettlementIfTargetWalletClosed(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        bool late
+    ) internal {
+        if (!late) {
+            return;
+        }
+
+        Wallets.WalletState walletState = self
+            .registeredWallets[reservation.walletPubKeyHash]
+            .state;
+        if (
+            walletState == Wallets.WalletState.Closing ||
+            walletState == Wallets.WalletState.Closed
+        ) {
+            self.strandReservation(reservation, reservationKey);
+        }
+    }
+
     /// @notice Used by the wallet to prove the BTC anchor transaction of an
     ///         authorized reserved deposit acceptance and to credit the
     ///         owner's balance accordingly.
@@ -462,6 +491,13 @@ library ReservationProofs {
             depositors,
             amounts
         );
+
+        strandLateSettlementIfTargetWalletClosed(
+            self,
+            reservation,
+            reservationKey,
+            late
+        );
     }
 
     /// @notice Used by the wallet to prove the BTC reserved redemption
@@ -563,6 +599,33 @@ library ReservationProofs {
                 redemptionTxHash,
                 redemptionTx.outputVector
             );
+        }
+
+        if (late) {
+            retireRetryCreditForGeneration(
+                self,
+                reservation,
+                reservationKey,
+                requestNonce
+            );
+        }
+    }
+
+    /// @notice Retires a retry credit only when the generation that minted
+    ///         it has now settled late. A credit minted by a newer timed-out
+    ///         generation remains valid.
+    function retireRetryCreditForGeneration(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal {
+        if (
+            self.reservationRetryCreditActionNonce[reservationKey] ==
+            requestNonce
+        ) {
+            reservation.retryCredit = false;
+            delete self.reservationRetryCreditActionNonce[reservationKey];
         }
     }
 
@@ -927,6 +990,13 @@ library ReservationProofs {
             reanchorTxHash,
             newAnchorAmount
         );
+
+        strandLateSettlementIfTargetWalletClosed(
+            self,
+            reservation,
+            reservationKey,
+            late
+        );
     }
 
     /// @notice Used by the wallet to prove a dissolution transaction
@@ -1101,6 +1171,7 @@ library ReservationProofs {
             sweepRequest.state = MovingFunds
                 .MovedFundsSweepRequestState
                 .Pending;
+            wallet.pendingMovedFundsSweepRequestsCount++;
         }
 
         if (late) {

--- a/solidity/contracts/bridge/ReservationRouter.sol
+++ b/solidity/contracts/bridge/ReservationRouter.sol
@@ -455,7 +455,12 @@ contract ReservationRouter is Governable, Initializable {
     /// @param maxReservationsPerWallet New cap on the number of active
     ///        reservations a single wallet can custody.
     /// @param reservationActionTimeout New value of the reservation action
-    ///        timeout in seconds.
+    ///        timeout in seconds. Must strictly exceed the two-hour proposal
+    ///        safety margin. For acceptance, an immediate post-reveal request
+    ///        needs more than four hours so the two-hour deposit minimum age
+    ///        elapses before that margin; with a shorter valid timeout, the
+    ///        requester must wait for the deposit to age. The authorization
+    ///        must also fit within the remaining guaranteed reveal-ahead window.
     /// @param reservationRenewalWindowSeconds New length of the renewal
     ///        window; must stay strictly shorter than the term.
     /// @dev Requirements:

--- a/solidity/contracts/bridge/ReservationRouter.sol
+++ b/solidity/contracts/bridge/ReservationRouter.sol
@@ -133,6 +133,14 @@ contract ReservationRouter is Governable, Initializable {
         bytes32 redemptionTxHash
     );
 
+    event ReservationPartiallyRedeemed(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes32 redemptionTxHash,
+        uint64 redeemedAmount,
+        uint64 newAnchorAmount
+    );
+
     event ReservationReanchorRequested(
         uint256 indexed reservationKey,
         uint64 requestNonce,
@@ -271,6 +279,42 @@ contract ReservationRouter is Governable, Initializable {
             reservationKey,
             redeemer,
             redeemerOutputScript,
+            feePaid,
+            useRetryCredit
+        );
+    }
+
+    /// @notice Requests a partial in-kind redemption of a reservation: the
+    ///         wallet spends the anchor in a 1-input-2-output transaction
+    ///         paying `redeemAmount` (less the miner fee) to the redeemer
+    ///         and re-anchoring the remainder, leaving the reservation open
+    ///         with a reduced claim and anchor. Can only be called by the
+    ///         reservation vault. See
+    ///         `Reservation.requestPartialReservedRedemption`.
+    /// @param reservationKey The key of the reservation to partially redeem.
+    /// @param redeemer The address able to claim the escrowed portion back
+    ///        if the redemption times out.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param redeemAmount The satoshi portion of the claim to redeem.
+    /// @param feePaid True when the vault collected the redemption fee for
+    ///        this request.
+    /// @param useRetryCredit True when the request consumes the fee-free
+    ///        retry entitlement instead of paying the fee.
+    function requestPartialReservedRedemption(
+        uint256 reservationKey,
+        address redeemer,
+        bytes calldata redeemerOutputScript,
+        uint64 redeemAmount,
+        bool feePaid,
+        bool useRetryCredit
+    ) external {
+        // The caller is checked in the library function.
+        self.requestPartialReservedRedemption(
+            reservationKey,
+            redeemer,
+            redeemerOutputScript,
+            redeemAmount,
             feePaid,
             useRetryCredit
         );

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -192,7 +192,8 @@ contract WalletProposalValidator {
     ///         For example, if a request times out after 8 pm and
     ///         REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN is 2 hours, the
     ///         request is valid for processing only before 6 pm.
-    uint32 public constant REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN = 2 hours;
+    uint32 public constant REDEMPTION_REQUEST_TIMEOUT_SAFETY_MARGIN =
+        Reservation.RESERVATION_ACTION_TIMEOUT_SAFETY_MARGIN;
 
     /// @notice The maximum count of redemption requests that can be processed
     ///         within a single redemption.

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -334,6 +334,114 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
         );
     }
 
+    /// @notice Requests a partial in-kind redemption of the caller's
+    ///         reservation: surrenders `redeemAmount` of the minted claim
+    ///         (plus the proportional redemption fee) and asks the Bridge to
+    ///         have the wallet pay that portion to the redeemer script while
+    ///         re-anchoring the remainder. The reservation stays open with a
+    ///         reduced claim.
+    /// @param reservationKey The key of the reservation to partially redeem.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param redeemAmount The satoshi portion of the claim to redeem.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner,
+    ///      - The caller must have approved this vault for
+    ///        `redeemAmount * SATOSHI_MULTIPLIER * (1 + redemptionFeeBps/10000)`
+    ///        TBTC,
+    ///      - See `Reservation.requestPartialReservedRedemption` for the
+    ///        amount bounds.
+    function redeemReservationPartial(
+        uint256 reservationKey,
+        bytes calldata redeemerOutputScript,
+        uint64 redeemAmount
+    ) external {
+        require(
+            bridge.reservations(reservationKey).owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+
+        uint256 grossTbtc = uint256(redeemAmount) * SATOSHI_MULTIPLIER;
+        uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
+
+        // The redemption fee stays in the vault as part of the in-kind fee
+        // reserve; see `feeReserveTarget`.
+        IERC20(tbtcToken).safeTransferFrom(
+            msg.sender,
+            address(this),
+            grossTbtc + fee
+        );
+
+        // Unmint the redeemed portion back into Bank balance and let the
+        // Bridge take it when registering the partial redemption request.
+        IERC20(tbtcToken).safeIncreaseAllowance(address(tbtcVault), grossTbtc);
+        tbtcVault.unmint(grossTbtc);
+        bank.approveBalance(address(bridge), redeemAmount);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionInitiated(
+            reservationKey,
+            msg.sender,
+            grossTbtc,
+            fee
+        );
+
+        bridge.requestPartialReservedRedemption(
+            reservationKey,
+            msg.sender,
+            redeemerOutputScript,
+            redeemAmount,
+            true, // The redemption fee was collected above.
+            false
+        );
+    }
+
+    /// @notice Re-requests a partial in-kind redemption using the caller's
+    ///         Bank balance — the state a timed-out partial redemption
+    ///         leaves the owner in — consuming the fee-free retry
+    ///         entitlement instead of paying the fee.
+    /// @param reservationKey The key of the reservation to partially redeem.
+    /// @param redeemerOutputScript The redeemer's length-prefixed output
+    ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
+    /// @param redeemAmount The satoshi portion of the claim to redeem.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner,
+    ///      - The caller must have approved this vault in the Bank for
+    ///        `redeemAmount`,
+    ///      - The reservation must hold the retry entitlement.
+    function retryRedeemReservationPartial(
+        uint256 reservationKey,
+        bytes calldata redeemerOutputScript,
+        uint64 redeemAmount
+    ) external {
+        require(
+            bridge.reservations(reservationKey).owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+
+        uint256 grossTbtc = uint256(redeemAmount) * SATOSHI_MULTIPLIER;
+
+        bank.transferBalanceFrom(msg.sender, address(this), redeemAmount);
+        bank.approveBalance(address(bridge), redeemAmount);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservedRedemptionInitiated(
+            reservationKey,
+            msg.sender,
+            grossTbtc,
+            0
+        );
+
+        bridge.requestPartialReservedRedemption(
+            reservationKey,
+            msg.sender,
+            redeemerOutputScript,
+            redeemAmount,
+            false,
+            true // Consume the retry entitlement instead of paying the fee.
+        );
+    }
+
     /// @notice Renews the custody term of the caller's reservation by
     ///         exactly one current term, charging the extension fee in
     ///         TBTC. Renewal is possible only inside the renewal window

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -563,8 +563,9 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     ///      - The caller must have approved this vault in the Bank for the
     ///        gross minted amount (`Bank.approveBalance`),
     ///      - The reservation must hold a single-use retry entitlement
-    ///        sourced from a fee-paid whole redemption of the same amount
-    ///        that timed out through the wallet's fault (enforced by the
+    ///        sourced from a fee-paid whole redemption that timed out
+    ///        through the wallet's fault. A later anchor write-down may
+    ///        reduce the current full-claim retry amount (enforced by the
     ///        Bridge and consumed by this call).
     ///
     ///      The redemption fee is not re-charged: it was collected by the

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -399,7 +399,8 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     /// @notice Re-requests a partial in-kind redemption using the caller's
     ///         Bank balance — the state a timed-out partial redemption
     ///         leaves the owner in — consuming the fee-free retry
-    ///         entitlement instead of paying the fee.
+    ///         entitlement for that same partial amount instead of paying
+    ///         the fee.
     /// @param reservationKey The key of the reservation to partially redeem.
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
@@ -408,7 +409,8 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     ///      - The caller must be the reservation owner,
     ///      - The caller must have approved this vault in the Bank for
     ///        `redeemAmount`,
-    ///      - The reservation must hold the retry entitlement.
+    ///      - The reservation must hold a retry entitlement sourced from a
+    ///        timed-out partial redemption of exactly `redeemAmount`.
     function retryRedeemReservationPartial(
         uint256 reservationKey,
         bytes calldata redeemerOutputScript,
@@ -552,7 +554,7 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     ///         balance -- the state a timed-out reserved redemption leaves
     ///         the owner in (the Bridge refunds the surrendered amount as
     ///         Bank balance). The caller surrenders the gross minted amount
-    ///         as Bank balance and pays the redemption fee in TBTC.
+    ///         as Bank balance without paying the redemption fee again.
     /// @param reservationKey The key of the reservation to redeem.
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
@@ -560,10 +562,10 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     ///      - The caller must be the reservation owner,
     ///      - The caller must have approved this vault in the Bank for the
     ///        gross minted amount (`Bank.approveBalance`),
-    ///      - The reservation must hold the single-use retry entitlement
-    ///        the Bridge mints when a fee-paid redemption request times
-    ///        out through the wallet's fault (enforced by the Bridge and
-    ///        consumed by this call).
+    ///      - The reservation must hold a single-use retry entitlement
+    ///        sourced from a fee-paid whole redemption of the same amount
+    ///        that timed out through the wallet's fault (enforced by the
+    ///        Bridge and consumed by this call).
     ///
     ///      The redemption fee is not re-charged: it was collected by the
     ///      original `redeemReservation` call and the retry only exists

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -344,8 +344,11 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     /// @param redeemerOutputScript The redeemer's length-prefixed output
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
     /// @param redeemAmount The satoshi portion of the claim to redeem.
+    /// @param maxFeeTbtc Upper bound on the TBTC fee the caller accepts;
+    ///        an unexpected fee update reverts instead of overcharging.
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
+    ///      - The fee must not exceed `maxFeeTbtc`,
     ///      - The caller must have approved this vault for
     ///        `redeemAmount * SATOSHI_MULTIPLIER * (1 + redemptionFeeBps/10000)`
     ///        TBTC,
@@ -354,7 +357,8 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
     function redeemReservationPartial(
         uint256 reservationKey,
         bytes calldata redeemerOutputScript,
-        uint64 redeemAmount
+        uint64 redeemAmount,
+        uint256 maxFeeTbtc
     ) external {
         require(
             bridge.reservations(reservationKey).owner == msg.sender,
@@ -363,6 +367,7 @@ contract ReservationVault is IVault, IReservationFeeFinancer, Ownable {
 
         uint256 grossTbtc = uint256(redeemAmount) * SATOSHI_MULTIPLIER;
         uint256 fee = (grossTbtc * redemptionFeeBps) / BASIS_POINTS;
+        require(fee <= maxFeeTbtc, "Fee exceeds the caller's bound");
 
         // The redemption fee stays in the vault as part of the in-kind fee
         // reserve; see `feeReserveTarget`.

--- a/solidity/test/bridge/Bridge.Deposit.test.ts
+++ b/solidity/test/bridge/Bridge.Deposit.test.ts
@@ -16,6 +16,7 @@ import type {
   IVault,
   BridgeGovernance,
   RebateStaking,
+  ReservationRouter,
 } from "../../typechain"
 import type {
   DepositRevealInfoStruct,
@@ -51,7 +52,7 @@ describe("Bridge - Deposit", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
-  let bridge: Bridge & BridgeStub
+  let bridge: Bridge & BridgeStub & ReservationRouter
   let bridgeGovernance: BridgeGovernance
   let t: Contract
   let rebateStaking: RebateStaking
@@ -308,7 +309,7 @@ describe("Bridge - Deposit", () => {
                     }
                   )
                   context(
-                    "when depositor has stake in rebate staking contract",
+                    "when an ordinary deposit depositor has stake in rebate staking contract",
                     () => {
                       let tx: ContractTransaction
 
@@ -405,6 +406,109 @@ describe("Bridge - Deposit", () => {
                             )
                           ).toNumber()
                         ).to.be.lessThan(availableRebate)
+                      })
+
+                      it("should apply the deposit rebate", async () => {
+                        await expect(tx).to.emit(
+                          rebateStaking,
+                          "RebateReceived"
+                        )
+                      })
+                    }
+                  )
+
+                  context(
+                    "when a reserved deposit depositor has stake in rebate staking contract",
+                    () => {
+                      let tx: ContractTransaction
+
+                      const stakeAmount = to1e18(5)
+                      let availableRebate: number
+
+                      before(async () => {
+                        await createSnapshot()
+
+                        await t
+                          .connect(deployer)
+                          .mint(depositor.address, stakeAmount)
+                        await t
+                          .connect(depositor)
+                          .approve(rebateStaking.address, stakeAmount)
+                        await rebateStaking
+                          .connect(depositor)
+                          .stake(stakeAmount)
+                        availableRebate = (
+                          await rebateStaking.getAvailableRebate(
+                            depositor.address
+                          )
+                        ).toNumber()
+
+                        const bridgeGovernanceAddress =
+                          await bridge.governance()
+                        await ethers.provider.send(
+                          "hardhat_impersonateAccount",
+                          [bridgeGovernanceAddress]
+                        )
+                        await ethers.provider.send("hardhat_setBalance", [
+                          bridgeGovernanceAddress,
+                          "0x8AC7230489E80000",
+                        ])
+                        const bridgeGovernanceSigner = await ethers.getSigner(
+                          bridgeGovernanceAddress
+                        )
+
+                        await bridge
+                          .connect(bridgeGovernanceSigner)
+                          .updateReservationParameters(
+                            reveal.vault,
+                            10000,
+                            2000,
+                            31536000,
+                            2592000,
+                            BigNumber.from("2100000000000000"),
+                            10,
+                            172800,
+                            2592000
+                          )
+
+                        tx = await bridge
+                          .connect(depositor)
+                          .revealDeposit(P2SHFundingTx, reveal)
+                      })
+
+                      after(async () => {
+                        await restoreSnapshot()
+                      })
+
+                      it("should keep the full deposit treasury fee", async () => {
+                        const depositKey = ethers.utils.solidityKeccak256(
+                          ["bytes32", "uint32"],
+                          [
+                            "0x17350f81cdb61cd8d7014ad1507d4af8d032b75812cf88d2c636c1c022991af2",
+                            reveal.fundingOutputIndex,
+                          ]
+                        )
+
+                        const deposit = await bridge.deposits(depositKey)
+
+                        expect(deposit.treasuryFee).to.be.equal(5)
+                      })
+
+                      it("should not apply a deposit rebate", async () => {
+                        await expect(tx).to.not.emit(
+                          rebateStaking,
+                          "RebateReceived"
+                        )
+                      })
+
+                      it("should not decrease available rebate", async () => {
+                        expect(
+                          (
+                            await rebateStaking.getAvailableRebate(
+                              depositor.address
+                            )
+                          ).toNumber()
+                        ).to.be.equal(availableRebate)
                       })
                     }
                   )

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -104,8 +104,8 @@ describe("Bridge - Reservation", () => {
     reservationVault = await helpers.contracts.getContract("ReservationVault")
 
     // The Bridge is governed by the BridgeGovernance contract in the
-    // fixture; impersonate it to exercise onlyGovernance functions
-    // directly. Production wiring through BridgeGovernance is a follow-up.
+    // fixture; impersonate it where tests need to exercise low-level
+    // onlyGovernance functions directly.
     bridgeGovernanceSigner = await impersonateContract(
       await bridge.governance()
     )
@@ -457,7 +457,37 @@ describe("Bridge - Reservation", () => {
         ).to.be.revertedWith("Renewal window must be shorter than the term")
       })
 
-      it("should revert for a zero action timeout", async () => {
+      it("should reject action timeouts that do not exceed the safety margin", async () => {
+        const timeoutSafetyMargin = 2 * 60 * 60
+
+        const expectTimeoutRejected = async (actionTimeout: number) => {
+          await expect(
+            bridge
+              .connect(bridgeGovernanceSigner)
+              .updateReservationParameters(
+                reservationVault.address,
+                RESERVATION_MIN_AMOUNT,
+                RESERVATION_TX_MAX_FEE,
+                RESERVATION_TERM,
+                RESERVATION_GRACE,
+                RESERVATION_MAX_TOTAL,
+                MAX_RESERVATIONS_PER_WALLET,
+                actionTimeout,
+                RESERVATION_RENEWAL_WINDOW
+              )
+          ).to.be.revertedWith(
+            "Reservation action timeout must exceed the safety margin"
+          )
+        }
+
+        await expectTimeoutRejected(0)
+        await expectTimeoutRejected(timeoutSafetyMargin - 1)
+        await expectTimeoutRejected(timeoutSafetyMargin)
+      })
+
+      it("should accept an action timeout above the safety margin", async () => {
+        const actionTimeout = 2 * 60 * 60 + 1
+
         await expect(
           bridge
             .connect(bridgeGovernanceSigner)
@@ -469,12 +499,21 @@ describe("Bridge - Reservation", () => {
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
               MAX_RESERVATIONS_PER_WALLET,
-              0,
+              actionTimeout,
               RESERVATION_RENEWAL_WINDOW
             )
-        ).to.be.revertedWith(
-          "Reservation action timeout must be greater than zero"
         )
+          .to.emit(bridge, "ReservationParametersUpdated")
+          .withArgs(
+            RESERVATION_MIN_AMOUNT,
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_TERM,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            actionTimeout,
+            RESERVATION_RENEWAL_WINDOW
+          )
       })
 
       it("should revert when changing the vault with active reservations", async () => {
@@ -2301,8 +2340,16 @@ describe("Bridge - Reservation", () => {
           .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
       ).to.be.revertedWith("Only governance can rotate a Live wallet's anchor")
 
-      await bridge
-        .connect(bridgeGovernanceSigner)
+      // A non-owner cannot obtain the BridgeGovernance contract's privileged
+      // caller identity.
+      await expect(
+        bridgeGovernance
+          .connect(thirdParty)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
+
+      await bridgeGovernance
+        .connect(governance)
         .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
 
       // Migrate with a 1-sat fee: the anchor stays above the dust floor.

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -799,6 +799,148 @@ describe("Bridge - Reservation partial redemption", () => {
     })
   })
 
+  describe("partial redemption retry credit", () => {
+    const failedAmount = 100000
+    const largerAmount = 200000
+
+    let anchorTx: { txHash: string }
+    let reservationKey: BigNumber
+    let redeemerScript: string
+
+    beforeEach(async () => {
+      await createSnapshot()
+      ;({ anchorTx, reservationKey } = await makeAcceptedReservation())
+      redeemerScript = randomRedeemerScript()
+
+      await requestPartial(reservationKey, redeemerScript, failedAmount)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("allows one fee-free retry of the timed-out partial amount", async () => {
+      await retryPartial(reservationKey, redeemerScript, failedAmount)
+
+      const action = await bridge.reservationActions(reservationKey, 3)
+      expect(action.state).to.equal(ActionState.Pending)
+      expect(action.isPartial).to.be.true
+      expect(action.amount).to.equal(failedAmount)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+    })
+
+    it("rejects using a small partial timeout credit for a larger partial", async () => {
+      // Combine the timeout refund with TBTC from the remaining claim, which
+      // is the funding shape that made the unbound boolean exploitable.
+      const additionalAmount = largerAmount - failedAmount
+      const additionalGross = grossFor(additionalAmount)
+      await tbtc.connect(thirdParty).approve(tbtcVault.address, additionalGross)
+      await tbtcVault.connect(thirdParty).unmint(additionalGross)
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, largerAmount)
+
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservationPartial(
+            reservationKey,
+            redeemerScript,
+            largerAmount
+          )
+      ).to.be.revertedWith("Retry entitlement does not match redemption")
+
+      // The failed attempt is atomic and leaves the valid credit available.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(largerAmount)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+    })
+
+    it("rejects using a partial timeout credit for a whole redemption", async () => {
+      // BankStub supplies the balance independently of the authorization
+      // check, modeling an owner who acquired enough TBTC/Bank balance to
+      // fund the larger request.
+      await bank.setBalance(thirdParty.address, anchorAmount)
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, anchorAmount)
+
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservation(reservationKey, redeemerScript)
+      ).to.be.revertedWith("Retry entitlement does not match redemption")
+
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+    })
+
+    it("retires the credit when its original partial settles late", async () => {
+      const partialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        failedAmount - 800,
+        anchorAmount.sub(failedAmount)
+      )
+
+      await proveRedemption(partialTx, reservationKey, 2)
+
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, failedAmount)
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservationPartial(
+            reservationKey,
+            redeemerScript,
+            failedAmount
+          )
+      ).to.be.revertedWith("No retry entitlement")
+    })
+
+    it("preserves a newer generation's credit when an older partial settles late", async () => {
+      const oldPartialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        failedAmount - 800,
+        anchorAmount.sub(failedAmount)
+      )
+
+      // Pay for another request of the same amount and shape without using
+      // the older credit. Its timeout replaces the outstanding entitlement
+      // with one sourced from generation 3.
+      const newerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, newerScript, failedAmount)
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      await proveRedemption(oldPartialTx, reservationKey, 2)
+
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+
+      // Late settlement of generation 2 must not erase generation 3's
+      // independently fee-paid retry entitlement.
+      await retryPartial(reservationKey, newerScript, failedAmount)
+      const retryAction = await bridge.reservationActions(reservationKey, 4)
+      expect(retryAction.state).to.equal(ActionState.Pending)
+      expect(retryAction.amount).to.equal(failedAmount)
+    })
+  })
+
   describe("late partial settlement matrix", () => {
     const redeemAmount = 1000000
     const redeemerValue = redeemAmount - 800 // 999200

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -77,6 +77,7 @@ const ProofType = {
 }
 
 describe("Bridge - Reservation partial redemption", () => {
+  let governance: SignerWithAddress
   let spvMaintainer: SignerWithAddress
   let thirdParty: SignerWithAddress
 
@@ -105,8 +106,16 @@ describe("Bridge - Reservation partial redemption", () => {
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
-    ;({ spvMaintainer, thirdParty, bank, relay, bridge, tbtc, tbtcVault } =
-      await waffle.loadFixture(bridgeFixture))
+    ;({
+      governance,
+      spvMaintainer,
+      thirdParty,
+      bank,
+      relay,
+      bridge,
+      tbtc,
+      tbtcVault,
+    } = await waffle.loadFixture(bridgeFixture))
 
     reservationVault = await helpers.contracts.getContract("ReservationVault")
     bridgeGovernanceSigner = await impersonateContract(
@@ -361,7 +370,12 @@ describe("Bridge - Reservation partial redemption", () => {
       .approve(reservationVault.address, gross.add(feeFor(gross)))
     await reservationVault
       .connect(thirdParty)
-      .redeemReservationPartial(reservationKey, redeemerScript, redeemAmount)
+      .redeemReservationPartial(
+        reservationKey,
+        redeemerScript,
+        redeemAmount,
+        feeFor(gross)
+      )
   }
 
   // Retries a partial redemption via the Bank-balance path after a timeout
@@ -476,6 +490,94 @@ describe("Bridge - Reservation partial redemption", () => {
       await expect(
         requestPartial(reservationKey, randomRedeemerScript(), redeemAmount)
       ).to.be.revertedWith("Remainder below the dust floor")
+    })
+  })
+
+  describe("partial redemption fee slippage", () => {
+    const redeemAmount = 1000000
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects a fee update above the owner's quoted bound before transferring TBTC", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      const redeemerScript = randomRedeemerScript()
+      const gross = grossFor(redeemAmount)
+      const quotedFee = feeFor(gross)
+
+      // A broad allowance must not turn a governance fee update into an
+      // authorization to charge more than the owner quoted.
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, ethers.constants.MaxUint256)
+      const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+      const reserveBefore = await tbtc.balanceOf(reservationVault.address)
+
+      await reservationVault.connect(governance).updateFees(40, 20, 500)
+
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .redeemReservationPartial(
+            reservationKey,
+            redeemerScript,
+            redeemAmount,
+            quotedFee
+          )
+      ).to.be.revertedWith("Fee exceeds the caller's bound")
+
+      expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+        ownerBalanceBefore
+      )
+      expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+        reserveBefore
+      )
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Active
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+    })
+
+    it("accepts the current fee exactly at the owner's bound", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      const redeemerScript = randomRedeemerScript()
+      const gross = grossFor(redeemAmount)
+
+      await reservationVault.connect(governance).updateFees(40, 20, 500)
+      const currentFee = gross.mul(500).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, ethers.constants.MaxUint256)
+
+      const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+      const reserveBefore = await tbtc.balanceOf(reservationVault.address)
+      const tx = await reservationVault
+        .connect(thirdParty)
+        .redeemReservationPartial(
+          reservationKey,
+          redeemerScript,
+          redeemAmount,
+          currentFee
+        )
+
+      await expect(tx)
+        .to.emit(reservationVault, "ReservedRedemptionInitiated")
+        .withArgs(reservationKey, thirdParty.address, gross, currentFee)
+      expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+        ownerBalanceBefore.sub(gross).sub(currentFee)
+      )
+      expect(await tbtc.balanceOf(reservationVault.address)).to.equal(
+        reserveBefore.add(currentFee)
+      )
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.ActionPending
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(redeemAmount)
     })
   })
 

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -951,6 +951,122 @@ describe("Bridge - Reservation partial redemption", () => {
       await restoreSnapshot()
     })
 
+    it("restores a whole retry credit when a late re-anchor supersedes its retry", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      // Fund the owner with enough TBTC to cover the whole redemption fee.
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestWholeRedemption(reservationKey, redeemerScript)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The timeout mints a credit sourced from the fee-paid redemption at
+      // generation 2 and moves the wallet into MovingFunds.
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.MovingFunds
+      )
+
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const minerFee = 800
+      const writtenDownAmount = anchorAmount.sub(minerFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: writtenDownAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      // Generation 3 times out without consuming the redemption credit.
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+
+      // Generation 4 consumes the credit and escrows the timeout refund.
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, anchorAmount)
+      await reservationVault
+        .connect(thirdParty)
+        .retryRedeemReservation(reservationKey, redeemerScript)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+      expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
+
+      // The already-confirmed generation-3 transaction consumes the anchor
+      // generation 4 expected. The retry is superseded and refunded.
+      const lateReanchor = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+      await expect(lateReanchor)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 4)
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 4)).state
+      ).to.equal(ActionState.Superseded)
+      const reanchored = await bridge.reservations(reservationKey)
+      expect(reanchored.state).to.equal(ReservationState.Active)
+      expect(reanchored.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(reanchored.mintedAmount).to.equal(writtenDownAmount)
+      expect(reanchored.retryCredit).to.be.true
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(anchorAmount)
+
+      // The restored credit remains bound to the paid generation's whole
+      // shape; it cannot subsidize an unrelated partial redemption.
+      const partialAmount = 1000000
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, partialAmount)
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservationPartial(
+            reservationKey,
+            randomRedeemerScript(),
+            partialAmount
+          )
+      ).to.be.revertedWith("Retry entitlement does not match redemption")
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+
+      // The current written-down whole claim can consume the restored credit.
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, writtenDownAmount)
+      await reservationVault
+        .connect(thirdParty)
+        .retryRedeemReservation(reservationKey, redeemerScript)
+
+      const secondRetry = await bridge.reservationActions(reservationKey, 5)
+      expect(secondRetry.state).to.equal(ActionState.Pending)
+      expect(secondRetry.amount).to.equal(writtenDownAmount)
+      expect(secondRetry.isPartial).to.be.false
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(minerFee)
+    })
+
     it("preserves the fee-free whole retry after a re-anchor write-down", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
       // Fund the owner with enough TBTC to cover the whole redemption fee.

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -89,6 +89,7 @@ describe("Bridge - Reservation partial redemption", () => {
   let bridgeGovernanceSigner: SignerWithAddress
 
   const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+  const secondWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
   const blindingFactor = "0xf9f0c90d00039523"
   const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
   const refundLocktime = "0x60bcea61"
@@ -938,6 +939,97 @@ describe("Bridge - Reservation partial redemption", () => {
       const retryAction = await bridge.reservationActions(reservationKey, 4)
       expect(retryAction.state).to.equal(ActionState.Pending)
       expect(retryAction.amount).to.equal(failedAmount)
+    })
+  })
+
+  describe("whole redemption retry credit", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("preserves the fee-free whole retry after a re-anchor write-down", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      // Fund the owner with enough TBTC to cover the whole redemption fee.
+      await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestWholeRedemption(reservationKey, redeemerScript)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+      expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+        walletState.MovingFunds
+      )
+
+      // MovingFunds re-anchors are permissionless. Settle one with a miner
+      // fee so both the anchor and the full minted claim are written down.
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const minerFee = 800
+      const writtenDownAmount = anchorAmount.sub(minerFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: writtenDownAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+
+      const writtenDown = await bridge.reservations(reservationKey)
+      expect(writtenDown.mintedAmount).to.equal(writtenDownAmount)
+      expect(writtenDown.retryCredit).to.be.true
+
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, writtenDownAmount)
+      const retryTx = await reservationVault
+        .connect(thirdParty)
+        .retryRedeemReservation(reservationKey, redeemerScript)
+
+      await expect(retryTx)
+        .to.emit(bridge, "ReservedRedemptionRequested")
+        .withArgs(
+          reservationKey,
+          4,
+          thirdParty.address,
+          redeemerScript,
+          writtenDownAmount,
+          RESERVATION_TX_MAX_FEE,
+          false
+        )
+
+      const retryAction = await bridge.reservationActions(reservationKey, 4)
+      expect(retryAction.amount).to.equal(writtenDownAmount)
+      expect(retryAction.isPartial).to.be.false
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+      // The timeout refunded the old full claim. Only the current, smaller
+      // claim is escrowed by the retry.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(minerFee)
     })
   })
 

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -1058,6 +1058,85 @@ describe("Bridge - Reservation partial redemption", () => {
       expect(retryAction.state).to.equal(ActionState.Pending)
       expect(retryAction.amount).to.equal(failedAmount)
     })
+
+    it("restores a newer generation's consumed credit when an older partial supersedes its retry", async () => {
+      const oldPartialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        failedAmount - 800,
+        anchorAmount.sub(failedAmount)
+      )
+
+      // Generation 3 pays independently for a different partial and times
+      // out, replacing generation 2's entitlement with one bound to the
+      // newer generation and its larger amount.
+      const newerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, newerScript, largerAmount)
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // Generation 4 consumes generation 3's credit while both Bitcoin
+      // transactions still target the original anchor.
+      await retryPartial(reservationKey, newerScript, largerAmount)
+      const pendingRetry = await bridge.reservationActions(reservationKey, 4)
+      expect(pendingRetry.usedRetryCredit).to.be.true
+      expect(pendingRetry.retryCreditSourceNonce).to.equal(3)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+
+      const pendingRetryTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        newerScript,
+        largerAmount - 800,
+        anchorAmount.sub(largerAmount)
+      )
+      const ownerBalanceBefore = await bank.balanceOf(thirdParty.address)
+
+      // The older transaction lands first. It makes generation 4
+      // impossible, so that retry is superseded and refunded. Its consumed
+      // source is generation 3, not the generation 2 settling below, and
+      // therefore must remain available.
+      const tx = await proveRedemption(oldPartialTx, reservationKey, 2)
+      await expect(tx)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 4)
+      await expect(tx)
+        .to.emit(bridge, "ReservationRetryCreditMinted")
+        .withArgs(reservationKey)
+
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        ownerBalanceBefore.add(largerAmount)
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      // Supersession is terminal: replay cannot refund the escrow twice or
+      // consume the restored entitlement.
+      const ownerBalanceAfter = await bank.balanceOf(thirdParty.address)
+      await expect(
+        proveRedemption(pendingRetryTx, reservationKey, 4)
+      ).to.be.revertedWith("Action is not settleable")
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        ownerBalanceAfter
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+
+      // The restored entitlement retains generation 3's exact amount and
+      // provenance and remains single-use.
+      await retryPartial(reservationKey, newerScript, largerAmount)
+      const nextRetry = await bridge.reservationActions(reservationKey, 5)
+      expect(nextRetry.usedRetryCredit).to.be.true
+      expect(nextRetry.amount).to.equal(largerAmount)
+      expect(nextRetry.retryCreditSourceNonce).to.equal(3)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+    })
   })
 
   describe("whole redemption retry credit", () => {
@@ -1417,6 +1496,13 @@ describe("Bridge - Reservation partial redemption", () => {
       const otherScript = randomRedeemerScript()
       await retryPartial(reservationKey, otherScript, redeemAmount)
       expect(await bank.balanceOf(bridge.address)).to.equal(redeemAmount)
+      const retryTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        otherScript,
+        redeemerValue,
+        remainderValue
+      )
 
       // The late proof of generation 2 settles; generation 3 can never
       // settle (its anchor is gone), so it is unwound and its escrow
@@ -1429,6 +1515,9 @@ describe("Bridge - Reservation partial redemption", () => {
       await expect(tx)
         .to.emit(bridge, "ReservationLateSettled")
         .withArgs(reservationKey, 2, ActionType.Redemption)
+      await expect(tx)
+        .to.emit(bridge, "ReservationRetryCreditMinted")
+        .withArgs(reservationKey)
 
       expect(
         (await bridge.reservationActions(reservationKey, 3)).state
@@ -1441,6 +1530,19 @@ describe("Bridge - Reservation partial redemption", () => {
       const reservation = await bridge.reservations(reservationKey)
       expect(reservation.state).to.equal(ReservationState.Active)
       expect(reservation.mintedAmount).to.equal(remainderValue)
+      // The superseded retry temporarily restores generation 2's source,
+      // then settlement of that same source retires it.
+      expect(reservation.retryCredit).to.be.false
+
+      // Supersession is terminal and its escrow refund cannot be replayed.
+      const ownerBalanceAfter = await bank.balanceOf(thirdParty.address)
+      await expect(
+        proveRedemption(retryTx, reservationKey, 3)
+      ).to.be.revertedWith("Action is not settleable")
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        ownerBalanceAfter
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
     })
   })
 })

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -1,0 +1,969 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+// Tests for partial reserved redemption: the two-output settlement that pays
+// the requested redeemer script and re-anchors the surviving remainder to the
+// custodying wallet, the request-time and proof-time bounds, sequential
+// partials, partial-then-whole, the partial timeout (which returns the full
+// anchor), and the late-partial settlement matrix against a newer generation.
+
+import { ethers, helpers, waffle } from "hardhat"
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
+import { BigNumber, Contract } from "ethers"
+import chai, { expect } from "chai"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+import type {
+  Bank,
+  BankStub,
+  Bridge,
+  BridgeStub,
+  IRelay,
+  ReservationRouter,
+  ReservationVault,
+  TBTCVault,
+  TBTC,
+} from "../../typechain"
+import bridgeFixture from "../fixtures/bridge"
+import { walletState } from "../fixtures"
+
+chai.use(smock.matchers)
+
+const { createSnapshot, restoreSnapshot } = helpers.snapshot
+const { lastBlockTime, increaseTime } = helpers.time
+
+const ZERO_BYTES32 = ethers.constants.HashZero
+
+const RESERVATION_TERM = 31536000 // 365 days
+const RESERVATION_GRACE = 2592000 // 30 days
+const RESERVATION_MIN_AMOUNT = 10000
+const RESERVATION_TX_MAX_FEE = 2000
+const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
+const MAX_RESERVATIONS_PER_WALLET = 10
+const RESERVATION_ACTION_TIMEOUT = 172800 // 48 hours
+const RESERVATION_RENEWAL_WINDOW = 2592000 // 30 days
+
+const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
+const REDEMPTION_FEE_BPS = 20
+
+const ReservationState = {
+  Unknown: 0,
+  Active: 1,
+  ActionPending: 2,
+  Closed: 3,
+  Stranded: 4,
+}
+
+const ActionType = {
+  None: 0,
+  Acceptance: 1,
+  Redemption: 2,
+  Reanchor: 3,
+  Dissolution: 4,
+}
+
+const ActionState = {
+  Unknown: 0,
+  Pending: 1,
+  Settled: 2,
+  TimedOut: 3,
+  Vetoed: 4,
+  Superseded: 5,
+}
+
+const ProofType = {
+  Acceptance: 0,
+  Redemption: 1,
+  Reanchor: 2,
+  Dissolution: 3,
+}
+
+describe("Bridge - Reservation partial redemption", () => {
+  let spvMaintainer: SignerWithAddress
+  let thirdParty: SignerWithAddress
+
+  let bank: Bank & BankStub
+  let relay: FakeContract<IRelay>
+  let bridge: Bridge & BridgeStub & ReservationRouter
+  let tbtc: TBTC & Contract
+  let tbtcVault: TBTCVault & Contract
+  let reservationVault: ReservationVault
+  let bridgeGovernanceSigner: SignerWithAddress
+
+  const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+  const blindingFactor = "0xf9f0c90d00039523"
+  const refundPubKeyHash = "0x28e081f285138ccbe389c1eb8985716230129f89"
+  const refundLocktime = "0x60bcea61"
+  const NO_MAIN_UTXO_PARAM = {
+    txHash: ZERO_BYTES32,
+    txOutputIndex: 0,
+    txOutputValue: 0,
+  }
+
+  const depositAmount = BigNumber.from(3000000)
+  const anchorFee = 1500
+  const anchorAmount = depositAmount.sub(anchorFee) // 2998500
+
+  before(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-extra-semi
+    ;({ spvMaintainer, thirdParty, bank, relay, bridge, tbtc, tbtcVault } =
+      await waffle.loadFixture(bridgeFixture))
+
+    reservationVault = await helpers.contracts.getContract("ReservationVault")
+    bridgeGovernanceSigner = await impersonateContract(
+      await bridge.governance()
+    )
+
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .setVaultStatus(reservationVault.address, true)
+    await bridge
+      .connect(bridgeGovernanceSigner)
+      .updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        RESERVATION_ACTION_TIMEOUT,
+        RESERVATION_RENEWAL_WINDOW
+      )
+
+    relay.getCurrentEpochDifficulty.returns(0)
+    relay.getPrevEpochDifficulty.returns(0)
+
+    await bridge.setDepositDustThreshold(10000)
+    await bridge.setDepositTxMaxFee(2000)
+    await bridge.setDepositRevealAheadPeriod(0)
+    await liveWallet(walletPubKeyHash)
+    await bridge.setLiveWalletsCount(10)
+
+    const tbtcOwner = await impersonateContract(await tbtc.owner())
+    await tbtc.connect(tbtcOwner).transferOwnership(tbtcVault.address)
+  })
+
+  async function impersonateContract(
+    address: string
+  ): Promise<SignerWithAddress> {
+    await ethers.provider.send("hardhat_impersonateAccount", [address])
+    await ethers.provider.send("hardhat_setBalance", [
+      address,
+      "0x8AC7230489E80000",
+    ])
+    return ethers.getSigner(address)
+  }
+
+  async function liveWallet(pkh: string) {
+    await bridge.setWallet(pkh, {
+      ecdsaWalletID: ethers.utils.randomBytes(32),
+      mainUtxoHash: ZERO_BYTES32,
+      pendingRedemptionsValue: 0,
+      createdAt: await lastBlockTime(),
+      movingFundsRequestedAt: 0,
+      closingStartedAt: 0,
+      pendingMovedFundsSweepRequestsCount: 0,
+      state: walletState.Live,
+      movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+    })
+  }
+
+  // ---- Bitcoin fixture crafting (regtest-style difficulty) ----
+
+  const REGTEST_BITS_LE = "ffff7f20"
+  const REGTEST_TARGET = BigNumber.from("0x7fffff").mul(
+    BigNumber.from(2).pow(8 * (0x20 - 3))
+  )
+
+  const reverseHex = (hex: string): string =>
+    hex.replace(/^0x/, "").match(/../g)!.reverse().join("")
+
+  const hash256 = (hexData: string): string =>
+    ethers.utils.sha256(ethers.utils.sha256(hexData))
+
+  const toLE = (value: number | BigNumber, byteLength: number): string =>
+    reverseHex(
+      BigNumber.from(value)
+        .toHexString()
+        .slice(2)
+        .padStart(byteLength * 2, "0")
+    )
+
+  const compactSize = (n: number): string => {
+    if (n >= 0xfd) {
+      throw new Error("compactSize > 252 not supported in fixtures")
+    }
+    return n.toString(16).padStart(2, "0")
+  }
+
+  function buildTx(
+    inputs: { txHash: string; index: number }[],
+    outputs: { valueSat: BigNumber | number; script: string }[]
+  ) {
+    const inputVector = `0x${compactSize(inputs.length)}${inputs
+      .map((i) => `${i.txHash.slice(2)}${toLE(i.index, 4)}00ffffffff`)
+      .join("")}`
+    const outputVector = `0x${compactSize(outputs.length)}${outputs
+      .map(
+        (o) =>
+          `${toLE(BigNumber.from(o.valueSat), 8)}${compactSize(
+            o.script.length / 2
+          )}${o.script}`
+      )
+      .join("")}`
+    const info = {
+      version: "0x01000000",
+      inputVector,
+      outputVector,
+      locktime: "0x00000000",
+    }
+    const txHash = hash256(
+      `0x01000000${inputVector.slice(2)}${outputVector.slice(2)}00000000`
+    )
+    return { info, txHash }
+  }
+
+  function mineHeader(merkleRoot: string): string {
+    const prevBlock = ethers.utils
+      .hexlify(ethers.utils.randomBytes(32))
+      .slice(2)
+    const base = `20000000${prevBlock}${merkleRoot.slice(
+      2
+    )}662a2c68${REGTEST_BITS_LE}`
+    for (let nonce = 0; ; nonce++) {
+      const header = `0x${base}${toLE(nonce, 4)}`
+      if (
+        BigNumber.from(`0x${reverseHex(hash256(header))}`).lte(REGTEST_TARGET)
+      ) {
+        return header
+      }
+    }
+  }
+
+  function proofFor(txHash: string) {
+    const coinbasePreimage = ethers.utils.sha256(ethers.utils.randomBytes(32))
+    const coinbaseTxId = ethers.utils.sha256(coinbasePreimage)
+    const merkleRoot = hash256(`0x${coinbaseTxId.slice(2)}${txHash.slice(2)}`)
+    return {
+      merkleProof: coinbaseTxId,
+      txIndexInBlock: 1,
+      bitcoinHeaders: mineHeader(merkleRoot),
+      coinbasePreimage,
+      coinbaseProof: txHash,
+    }
+  }
+
+  const buildDepositScript = (
+    depositor: string,
+    blinding: string,
+    walletPkh: string,
+    refundPkh: string,
+    locktime: string
+  ): string =>
+    `14${depositor.slice(2)}7508${blinding.slice(2)}7576a914${walletPkh
+      .slice(2)
+      .toLowerCase()}8763ac6776a914${refundPkh.slice(2)}8804${locktime.slice(
+      2
+    )}b175ac68`
+
+  const p2wshScript = (script: string): string =>
+    `0020${ethers.utils.sha256(`0x${script}`).slice(2)}`
+
+  const p2wpkhScript = (pkh: string): string => `0014${pkh.slice(2)}`
+
+  const randomRedeemerScript = (): string =>
+    `0x16${p2wpkhScript(ethers.utils.hexlify(ethers.utils.randomBytes(20)))}`
+
+  // Reveals a fresh reserved deposit, requests acceptance (generation 1) and
+  // proves the anchor. Each acceptance mints `anchorAmount` worth of TBTC to
+  // the depositor, funding the redemption surrenders below.
+  async function makeAcceptedReservation(custodian = walletPubKeyHash) {
+    const fundingTx = buildTx(
+      [
+        {
+          txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+          index: 0,
+        },
+      ],
+      [
+        {
+          valueSat: depositAmount,
+          script: p2wshScript(
+            buildDepositScript(
+              thirdParty.address,
+              blindingFactor,
+              custodian,
+              refundPubKeyHash,
+              refundLocktime
+            )
+          ),
+        },
+      ]
+    )
+
+    await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+      fundingOutputIndex: 0,
+      blindingFactor,
+      walletPubKeyHash: custodian,
+      refundPubKeyHash,
+      refundLocktime,
+      vault: reservationVault.address,
+    })
+
+    const reservationKey = BigNumber.from(
+      ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.txHash, 0]
+      )
+    )
+
+    await bridge
+      .connect(thirdParty)
+      .requestReservationAcceptance(reservationKey, custodian)
+
+    const anchorTx = buildTx(
+      [{ txHash: fundingTx.txHash, index: 0 }],
+      [{ valueSat: anchorAmount, script: p2wpkhScript(custodian) }]
+    )
+
+    await bridge
+      .connect(spvMaintainer)
+      .submitReservationProof(
+        ProofType.Acceptance,
+        anchorTx.info,
+        proofFor(anchorTx.txHash),
+        NO_MAIN_UTXO_PARAM,
+        reservationKey,
+        1
+      )
+
+    return { fundingTx, anchorTx, reservationKey }
+  }
+
+  // ---- Partial-redemption helpers ----
+
+  const grossFor = (satoshi: BigNumber | number): BigNumber =>
+    BigNumber.from(satoshi).mul(SATOSHI_MULTIPLIER)
+
+  const feeFor = (gross: BigNumber): BigNumber =>
+    gross.mul(REDEMPTION_FEE_BPS).div(10000)
+
+  // Requests a partial in-kind redemption via the real vault flow (fee paid
+  // in TBTC). The owner must already hold enough TBTC for the surrender.
+  async function requestPartial(
+    reservationKey: BigNumber,
+    redeemerScript: string,
+    redeemAmount: number
+  ) {
+    const gross = grossFor(redeemAmount)
+    await tbtc
+      .connect(thirdParty)
+      .approve(reservationVault.address, gross.add(feeFor(gross)))
+    await reservationVault
+      .connect(thirdParty)
+      .redeemReservationPartial(reservationKey, redeemerScript, redeemAmount)
+  }
+
+  // Retries a partial redemption via the Bank-balance path after a timeout
+  // refund (consumes the retry entitlement instead of paying a fee).
+  async function retryPartial(
+    reservationKey: BigNumber,
+    redeemerScript: string,
+    redeemAmount: number
+  ) {
+    await bank
+      .connect(thirdParty)
+      .approveBalance(reservationVault.address, redeemAmount)
+    await reservationVault
+      .connect(thirdParty)
+      .retryRedeemReservationPartial(
+        reservationKey,
+        redeemerScript,
+        redeemAmount
+      )
+  }
+
+  // Requests a whole redemption of the position's current claim.
+  async function requestWholeRedemption(
+    reservationKey: BigNumber,
+    redeemerScript: string
+  ) {
+    const minted = (await bridge.reservations(reservationKey)).mintedAmount
+    const gross = grossFor(minted)
+    await tbtc
+      .connect(thirdParty)
+      .approve(reservationVault.address, gross.add(feeFor(gross)))
+    await reservationVault
+      .connect(thirdParty)
+      .redeemReservation(reservationKey, redeemerScript)
+  }
+
+  // Builds a two-output partial-redemption transaction: output 0 pays the
+  // redeemer script (bearing the miner fee), output 1 re-anchors the
+  // remainder to the custodying wallet.
+  function buildPartialTx(
+    anchorTxHash: string,
+    anchorIndex: number,
+    redeemerScript: string,
+    redeemerValue: BigNumber | number,
+    remainderValue: BigNumber | number,
+    remainderPkh: string = walletPubKeyHash
+  ) {
+    return buildTx(
+      [{ txHash: anchorTxHash, index: anchorIndex }],
+      [
+        { valueSat: redeemerValue, script: redeemerScript.slice(4) },
+        { valueSat: remainderValue, script: p2wpkhScript(remainderPkh) },
+      ]
+    )
+  }
+
+  function proveRedemption(
+    tx: { info: unknown; txHash: string },
+    reservationKey: BigNumber,
+    requestNonce: number
+  ) {
+    return bridge
+      .connect(spvMaintainer)
+      .submitReservationProof(
+        ProofType.Redemption,
+        tx.info as never,
+        proofFor(tx.txHash),
+        NO_MAIN_UTXO_PARAM,
+        reservationKey,
+        requestNonce
+      )
+  }
+
+  describe("request-time validation", () => {
+    let reservationKey: BigNumber
+
+    before(async () => {
+      await createSnapshot()
+      // Two acceptances so the owner can afford a surrender up to the full
+      // claim (the "use the whole path" bound is reached with funds to spare).
+      ;({ reservationKey } = await makeAcceptedReservation())
+      await makeAcceptedReservation()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects a redeemed amount at or below the dust floor", async () => {
+      await expect(
+        requestPartial(
+          reservationKey,
+          randomRedeemerScript(),
+          RESERVATION_TX_MAX_FEE
+        )
+      ).to.be.revertedWith("Redeemed amount below the dust floor")
+    })
+
+    it("rejects a redeemed amount equal to the whole claim", async () => {
+      await expect(
+        requestPartial(
+          reservationKey,
+          randomRedeemerScript(),
+          anchorAmount.toNumber()
+        )
+      ).to.be.revertedWith("Use the whole redemption path for a full claim")
+    })
+
+    it("rejects a remainder at or below the dust floor", async () => {
+      // Remainder = mintedAmount - redeemAmount must exceed the fee floor.
+      const redeemAmount = anchorAmount.toNumber() - RESERVATION_TX_MAX_FEE
+      await expect(
+        requestPartial(reservationKey, randomRedeemerScript(), redeemAmount)
+      ).to.be.revertedWith("Remainder below the dust floor")
+    })
+  })
+
+  describe("happy-path settlement", () => {
+    const redeemAmount = 1000000
+    const minerFee = 800
+    const redeemerValue = redeemAmount - minerFee // 999200
+    const remainderValue = anchorAmount.sub(redeemAmount) // 1998500
+
+    let reservationKey: BigNumber
+    let anchorTx: { txHash: string }
+    let redeemerScript: string
+
+    before(async () => {
+      await createSnapshot()
+      ;({ anchorTx, reservationKey } = await makeAcceptedReservation())
+      redeemerScript = randomRedeemerScript()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("escrows the redeemed portion and opens a partial generation", async () => {
+      await requestPartial(reservationKey, redeemerScript, redeemAmount)
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.ActionPending)
+
+      const action = await bridge.reservationActions(reservationKey, 2)
+      expect(action.actionType).to.equal(ActionType.Redemption)
+      expect(action.state).to.equal(ActionState.Pending)
+      expect(action.isPartial).to.be.true
+      expect(action.amount).to.equal(redeemAmount)
+
+      // The Bridge holds exactly the redeemed portion in escrow.
+      expect(await bank.balanceOf(bridge.address)).to.equal(redeemAmount)
+    })
+
+    it("settles the two outputs, re-anchoring the remainder", async () => {
+      const partialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue
+      )
+
+      const tx = await proveRedemption(partialTx, reservationKey, 2)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationPartiallyRedeemed")
+        .withArgs(
+          reservationKey,
+          2,
+          partialTx.txHash,
+          redeemAmount,
+          remainderValue
+        )
+
+      // The position stays Active and shrinks to the remainder anchor; the
+      // claim still equals the anchor to the satoshi.
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.mintedAmount).to.equal(remainderValue)
+      expect(reservation.anchorAmount).to.equal(remainderValue)
+      expect(reservation.anchorTxHash).to.equal(partialTx.txHash)
+      expect(reservation.anchorTxOutputIndex).to.equal(1)
+
+      // The settled generation is terminal and the escrow was burned.
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.Settled)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      // The consumed anchor is registered as honestly spent.
+      expect(
+        await bridge.spentMainUTXOs(
+          BigNumber.from(
+            ethers.utils.solidityKeccak256(
+              ["bytes32", "uint32"],
+              [anchorTx.txHash, 0]
+            )
+          )
+        )
+      ).to.be.true
+
+      // Reserved capacity dropped by the redeemed portion.
+      const params = await bridge.reservationParameters()
+      expect(params.reservationTotalAmount).to.equal(remainderValue)
+    })
+
+    it("rejects a second settlement of the same generation", async () => {
+      const partialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue
+      )
+      await expect(
+        proveRedemption(partialTx, reservationKey, 2)
+      ).to.be.revertedWith("Action is not settleable")
+    })
+  })
+
+  describe("proof-time output validation", () => {
+    const redeemAmount = 1000000
+    const redeemerValue = redeemAmount - 800 // 999200
+    const remainderValue = anchorAmount.sub(redeemAmount) // 1998500
+
+    let reservationKey: BigNumber
+    let anchorTx: { txHash: string }
+    let redeemerScript: string
+
+    before(async () => {
+      await createSnapshot()
+      ;({ anchorTx, reservationKey } = await makeAcceptedReservation())
+      redeemerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, redeemerScript, redeemAmount)
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("rejects a single-output transaction", async () => {
+      const tx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [{ valueSat: redeemerValue, script: redeemerScript.slice(4) }]
+      )
+      await expect(proveRedemption(tx, reservationKey, 2)).to.be.revertedWith(
+        "Partial redemption must have exactly two outputs"
+      )
+    })
+
+    it("rejects a first output paying the wrong script", async () => {
+      const tx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        randomRedeemerScript(),
+        redeemerValue,
+        remainderValue
+      )
+      await expect(proveRedemption(tx, reservationKey, 2)).to.be.revertedWith(
+        "First output does not pay the requested redeemer script"
+      )
+    })
+
+    it("rejects a first output below the fee-bounded range", async () => {
+      // amount - value must not exceed txMaxFee.
+      const tooLow = redeemAmount - (RESERVATION_TX_MAX_FEE + 1)
+      const tx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        tooLow,
+        remainderValue
+      )
+      await expect(proveRedemption(tx, reservationKey, 2)).to.be.revertedWith(
+        "Redeemer output value is not within the acceptable range"
+      )
+    })
+
+    it("rejects a remainder that does not re-anchor to the wallet", async () => {
+      const tx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue,
+        "0x1111111111111111111111111111111111111111"
+      )
+      await expect(proveRedemption(tx, reservationKey, 2)).to.be.revertedWith(
+        "Second output must re-anchor to the custodying wallet"
+      )
+    })
+
+    it("rejects a remainder value that breaks the claim-equals-anchor rule", async () => {
+      const tx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue.add(1)
+      )
+      await expect(proveRedemption(tx, reservationKey, 2)).to.be.revertedWith(
+        "Remainder value must equal the anchor minus the redeemed amount"
+      )
+    })
+  })
+
+  describe("sequential partials and partial-then-whole", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("chains a second partial onto the remainder anchor", async () => {
+      // Two acceptances fund two surrenders.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      // First partial: redeem 1,000,000 of 2,998,500.
+      const script1 = randomRedeemerScript()
+      await requestPartial(reservationKey, script1, 1000000)
+      const remainder1 = anchorAmount.sub(1000000) // 1998500
+      const partialTx1 = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        script1,
+        1000000 - 800,
+        remainder1
+      )
+      await proveRedemption(partialTx1, reservationKey, 2)
+
+      // Second partial spends the remainder anchor (tx1, index 1).
+      const script2 = randomRedeemerScript()
+      await requestPartial(reservationKey, script2, 500000)
+      const remainder2 = remainder1.sub(500000) // 1498500
+      const partialTx2 = buildPartialTx(
+        partialTx1.txHash,
+        1,
+        script2,
+        500000 - 600,
+        remainder2
+      )
+      const tx = await proveRedemption(partialTx2, reservationKey, 3)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationPartiallyRedeemed")
+        .withArgs(reservationKey, 3, partialTx2.txHash, 500000, remainder2)
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.mintedAmount).to.equal(remainder2)
+      expect(reservation.anchorAmount).to.equal(remainder2)
+      expect(reservation.anchorTxHash).to.equal(partialTx2.txHash)
+      expect(reservation.anchorTxOutputIndex).to.equal(1)
+    })
+
+    it("closes the position when a whole redemption follows a partial", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation()
+
+      const script1 = randomRedeemerScript()
+      await requestPartial(reservationKey, script1, 1000000)
+      const remainder1 = anchorAmount.sub(1000000) // 1998500
+      const partialTx1 = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        script1,
+        1000000 - 800,
+        remainder1
+      )
+      await proveRedemption(partialTx1, reservationKey, 2)
+
+      // Whole redemption of the surviving claim spends the remainder anchor.
+      const script2 = randomRedeemerScript()
+      await requestWholeRedemption(reservationKey, script2)
+      const wholeTx = buildTx(
+        [{ txHash: partialTx1.txHash, index: 1 }],
+        [{ valueSat: remainder1.sub(800), script: script2.slice(4) }]
+      )
+      const tx = await proveRedemption(wholeTx, reservationKey, 3)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionCompleted")
+        .withArgs(reservationKey, 3, wholeTx.txHash)
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(
+        ReservationState.Closed
+      )
+      // Both escrows were burned; the Bridge holds nothing.
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+    })
+  })
+
+  describe("partial redemption timeout", () => {
+    before(async () => {
+      await createSnapshot()
+    })
+
+    after(async () => {
+      await restoreSnapshot()
+    })
+
+    it("returns the full anchor and refunds the escrowed portion", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, redeemerScript, 1000000)
+
+      const redeemerBefore = await bank.balanceOf(thirdParty.address)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The escrowed portion is refunded to the redeemer as Bank balance.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        redeemerBefore.add(1000000)
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      // The position returns to Active with the FULL anchor intact; nothing
+      // was redeemed on-chain.
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.mintedAmount).to.equal(anchorAmount)
+      expect(reservation.anchorAmount).to.equal(anchorAmount)
+      expect(reservation.retryCredit).to.be.true
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 2)).state
+      ).to.equal(ActionState.TimedOut)
+    })
+  })
+
+  describe("late partial settlement matrix", () => {
+    const redeemAmount = 1000000
+    const redeemerValue = redeemAmount - 800 // 999200
+    const remainderValue = anchorAmount.sub(redeemAmount) // 1998500
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("settles a late partial with no newer generation and no second refund", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, redeemerScript, redeemAmount)
+
+      // The wallet's transaction confirms on Bitcoin but the proof is late.
+      const partialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue
+      )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      const redeemerAfterTimeout = await bank.balanceOf(thirdParty.address)
+      const bridgeAfterTimeout = await bank.balanceOf(bridge.address)
+
+      const tx = await proveRedemption(partialTx, reservationKey, 2)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 2, ActionType.Redemption)
+      await expect(tx)
+        .to.emit(bridge, "ReservationPartiallyRedeemed")
+        .withArgs(
+          reservationKey,
+          2,
+          partialTx.txHash,
+          redeemAmount,
+          remainderValue
+        )
+
+      // No Bank movement during the late settlement: the timeout already
+      // refunded the escrow and slashed the wallet.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        redeemerAfterTimeout
+      )
+      expect(await bank.balanceOf(bridge.address)).to.equal(bridgeAfterTimeout)
+
+      // The position reduces to the remainder anchor and stays Active.
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.mintedAmount).to.equal(remainderValue)
+      expect(reservation.anchorTxHash).to.equal(partialTx.txHash)
+      expect(reservation.anchorTxOutputIndex).to.equal(1)
+    })
+
+    it("forces settlement against a matching pending partial generation", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, redeemerScript, redeemAmount)
+
+      const partialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue
+      )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The owner retries the SAME partial (same script, same amount):
+      // generation 3, funded by the timeout refund.
+      await retryPartial(reservationKey, redeemerScript, redeemAmount)
+
+      // The confirmed transaction satisfies both the timed-out generation 2
+      // and the pending generation 3. The late path must refuse to settle
+      // generation 2 (that would lose the burn).
+      await expect(
+        proveRedemption(partialTx, reservationKey, 2)
+      ).to.be.revertedWith("Must settle the pending generation")
+
+      const tx = await proveRedemption(partialTx, reservationKey, 3)
+      await expect(tx)
+        .to.emit(bridge, "ReservationPartiallyRedeemed")
+        .withArgs(
+          reservationKey,
+          3,
+          partialTx.txHash,
+          redeemAmount,
+          remainderValue
+        )
+
+      // Settling the pending generation burned the escrow.
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+      expect((await bridge.reservations(reservationKey)).mintedAmount).to.equal(
+        remainderValue
+      )
+    })
+
+    it("unwinds a non-matching pending generation and refunds its escrow", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      const redeemerScript = randomRedeemerScript()
+      await requestPartial(reservationKey, redeemerScript, redeemAmount)
+
+      const partialTx = buildPartialTx(
+        anchorTx.txHash,
+        0,
+        redeemerScript,
+        redeemerValue,
+        remainderValue
+      )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      // The owner retries toward a DIFFERENT redeemer script (generation 3),
+      // unaware the old transaction confirmed.
+      const otherScript = randomRedeemerScript()
+      await retryPartial(reservationKey, otherScript, redeemAmount)
+      expect(await bank.balanceOf(bridge.address)).to.equal(redeemAmount)
+
+      // The late proof of generation 2 settles; generation 3 can never
+      // settle (its anchor is gone), so it is unwound and its escrow
+      // refunded.
+      const tx = await proveRedemption(partialTx, reservationKey, 2)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 3)
+      await expect(tx)
+        .to.emit(bridge, "ReservationLateSettled")
+        .withArgs(reservationKey, 2, ActionType.Redemption)
+
+      expect(
+        (await bridge.reservationActions(reservationKey, 3)).state
+      ).to.equal(ActionState.Superseded)
+
+      // Generation 3's escrow returned to its redeemer; the Bridge holds
+      // nothing and the position survives as the remainder anchor.
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(redeemAmount)
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(reservation.mintedAmount).to.equal(remainderValue)
+    })
+  })
+})

--- a/solidity/test/bridge/Bridge.ReservationPartial.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationPartial.test.ts
@@ -837,6 +837,124 @@ describe("Bridge - Reservation partial redemption", () => {
         .false
     })
 
+    it("restores the exact partial retry source after a late re-anchor", async () => {
+      // The failed partial at generation 2 moved the source wallet into
+      // MovingFunds and minted a retry credit bound to `failedAmount`.
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge
+        .connect(thirdParty)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const minerFee = 800
+      const writtenDownAmount = anchorAmount.sub(minerFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: writtenDownAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      // Let generation 3 time out, then consume generation 2's credit in
+      // an exact partial retry against the still-current old anchor.
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+      await retryPartial(reservationKey, redeemerScript, failedAmount)
+
+      const firstRetry = await bridge.reservationActions(reservationKey, 4)
+      expect(firstRetry.usedRetryCredit).to.be.true
+      expect(firstRetry.isPartial).to.be.true
+      expect(firstRetry.amount).to.equal(failedAmount)
+      expect(firstRetry.retryCreditSourceNonce).to.equal(2)
+
+      // The late generation-3 proof consumes the anchor expected by the
+      // retry. Supersession must restore the original source binding and
+      // refund the retry escrow exactly once.
+      const lateReanchor = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          3
+        )
+      await expect(lateReanchor)
+        .to.emit(bridge, "ReservationActionSuperseded")
+        .withArgs(reservationKey, 4)
+      await expect(lateReanchor)
+        .to.emit(bridge, "ReservationRetryCreditMinted")
+        .withArgs(reservationKey)
+
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(failedAmount)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            3
+          )
+      ).to.be.revertedWith("Action is not settleable")
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(failedAmount)
+      expect(await bank.balanceOf(bridge.address)).to.equal(0)
+
+      // The restored source remains partial and exact: a whole request and
+      // either adjacent partial amount must fail atomically.
+      await bank.setBalance(thirdParty.address, writtenDownAmount)
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, writtenDownAmount)
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservation(reservationKey, redeemerScript)
+      ).to.be.revertedWith("Retry entitlement does not match redemption")
+      await bank.connect(thirdParty).approveBalance(reservationVault.address, 0)
+
+      const expectWrongPartialRejected = async (wrongAmount: number) => {
+        await bank
+          .connect(thirdParty)
+          .approveBalance(reservationVault.address, wrongAmount)
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .retryRedeemReservationPartial(
+              reservationKey,
+              redeemerScript,
+              wrongAmount
+            )
+        ).to.be.revertedWith("Retry entitlement does not match redemption")
+        await bank
+          .connect(thirdParty)
+          .approveBalance(reservationVault.address, 0)
+      }
+      await expectWrongPartialRejected(failedAmount - 1)
+      await expectWrongPartialRejected(failedAmount + 1)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+
+      await retryPartial(reservationKey, redeemerScript, failedAmount)
+      const secondRetry = await bridge.reservationActions(reservationKey, 5)
+      expect(secondRetry.state).to.equal(ActionState.Pending)
+      expect(secondRetry.usedRetryCredit).to.be.true
+      expect(secondRetry.isPartial).to.be.true
+      expect(secondRetry.amount).to.equal(failedAmount)
+      expect(secondRetry.retryCreditSourceNonce).to.equal(2)
+      expect((await bridge.reservations(reservationKey)).retryCredit).to.be
+        .false
+    })
+
     it("rejects using a small partial timeout credit for a larger partial", async () => {
       // Combine the timeout refund with TBTC from the remaining claim, which
       // is the funding shape that made the unbound boolean exploitable.
@@ -1005,6 +1123,9 @@ describe("Bridge - Reservation partial redemption", () => {
         .retryRedeemReservation(reservationKey, redeemerScript)
       expect((await bridge.reservations(reservationKey)).retryCredit).to.be
         .false
+      const firstRetry = await bridge.reservationActions(reservationKey, 4)
+      expect(firstRetry.usedRetryCredit).to.be.true
+      expect(firstRetry.retryCreditSourceNonce).to.equal(2)
       expect(await bank.balanceOf(bridge.address)).to.equal(anchorAmount)
 
       // The already-confirmed generation-3 transaction consumes the anchor
@@ -1022,6 +1143,9 @@ describe("Bridge - Reservation partial redemption", () => {
       await expect(lateReanchor)
         .to.emit(bridge, "ReservationActionSuperseded")
         .withArgs(reservationKey, 4)
+      await expect(lateReanchor)
+        .to.emit(bridge, "ReservationRetryCreditMinted")
+        .withArgs(reservationKey)
 
       expect(
         (await bridge.reservationActions(reservationKey, 4)).state
@@ -1049,6 +1173,7 @@ describe("Bridge - Reservation partial redemption", () => {
           )
       ).to.be.revertedWith("Retry entitlement does not match redemption")
       expect((await bridge.reservations(reservationKey)).retryCredit).to.be.true
+      await bank.connect(thirdParty).approveBalance(reservationVault.address, 0)
 
       // The current written-down whole claim can consume the restored credit.
       await bank
@@ -1062,6 +1187,8 @@ describe("Bridge - Reservation partial redemption", () => {
       expect(secondRetry.state).to.equal(ActionState.Pending)
       expect(secondRetry.amount).to.equal(writtenDownAmount)
       expect(secondRetry.isPartial).to.be.false
+      expect(secondRetry.usedRetryCredit).to.be.true
+      expect(secondRetry.retryCreditSourceNonce).to.equal(2)
       expect((await bridge.reservations(reservationKey)).retryCredit).to.be
         .false
       expect(await bank.balanceOf(thirdParty.address)).to.equal(minerFee)

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -68,6 +68,11 @@ const ActionState = {
   Superseded: 5,
 }
 
+const MovedFundsSweepRequestState = {
+  Pending: 1,
+  Processed: 2,
+}
+
 const ProofType = {
   Acceptance: 0,
   Redemption: 1,
@@ -176,6 +181,23 @@ describe("Bridge - Reservation settlement", () => {
       pendingMovedFundsSweepRequestsCount: 0,
       state: walletState.Live,
       movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+    })
+  }
+
+  async function setWalletState(pkh: string, state: number) {
+    const wallet = await bridge.wallets(pkh)
+    await bridge.setWallet(pkh, {
+      ecdsaWalletID: wallet.ecdsaWalletID,
+      mainUtxoHash: wallet.mainUtxoHash,
+      pendingRedemptionsValue: wallet.pendingRedemptionsValue,
+      createdAt: wallet.createdAt,
+      movingFundsRequestedAt: wallet.movingFundsRequestedAt,
+      closingStartedAt: wallet.closingStartedAt,
+      pendingMovedFundsSweepRequestsCount:
+        wallet.pendingMovedFundsSweepRequestsCount,
+      state,
+      movingFundsTargetWalletsCommitmentHash:
+        wallet.movingFundsTargetWalletsCommitmentHash,
     })
   }
 
@@ -879,16 +901,54 @@ describe("Bridge - Reservation settlement", () => {
       expect((await bridge.wallets(walletPubKeyHash)).mainUtxoHash).to.equal(
         driftedMainUtxoHash
       )
-      const sweepRequest = await bridge.movedFundsSweepRequests(
-        BigNumber.from(
-          ethers.utils.solidityKeccak256(
-            ["bytes32", "uint32"],
-            [dissolutionTx.txHash, 0]
-          )
+      const sweepRequestKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [dissolutionTx.txHash, 0]
         )
       )
+      const sweepRequest = await bridge.movedFundsSweepRequests(sweepRequestKey)
       expect(sweepRequest.walletPubKeyHash).to.equal(walletPubKeyHash)
       expect(sweepRequest.value).to.equal(anchorAmount.sub(dissolutionFee))
+      expect(sweepRequest.state).to.equal(MovedFundsSweepRequestState.Pending)
+      expect(
+        (await bridge.wallets(walletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(1)
+
+      // The request can be consumed by the standard moved-funds sweep path
+      // without underflowing the pending-request counter.
+      const movedFundsSweepFee = 500
+      const movedFundsSweepTx = buildTx(
+        [
+          { txHash: dissolutionTx.txHash, index: 0 },
+          { txHash: sweepUtxo.txHash, index: sweepUtxo.txOutputIndex },
+        ],
+        [
+          {
+            valueSat: anchorAmount
+              .sub(dissolutionFee)
+              .add(sweepUtxo.txOutputValue)
+              .sub(movedFundsSweepFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitMovedFundsSweepProof(
+          movedFundsSweepTx.info,
+          proofFor(movedFundsSweepTx.txHash),
+          sweepUtxo
+        )
+
+      expect(
+        (await bridge.movedFundsSweepRequests(sweepRequestKey)).state
+      ).to.equal(MovedFundsSweepRequestState.Processed)
+      expect(
+        (await bridge.wallets(walletPubKeyHash))
+          .pendingMovedFundsSweepRequestsCount
+      ).to.equal(0)
     })
   })
 
@@ -1213,6 +1273,267 @@ describe("Bridge - Reservation settlement", () => {
       expect((await bridge.reservations(reservationKey)).state).to.equal(
         ReservationState.Active
       )
+    })
+  })
+
+  describe("late settlement after the target wallet retires", () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+    ;[
+      { targetState: walletState.Closing, stateName: "Closing" },
+      { targetState: walletState.Closed, stateName: "Closed" },
+    ].forEach(({ targetState, stateName }) => {
+      it(`strands a late acceptance whose target became ${stateName}`, async () => {
+        const fundingTx = buildTx(
+          [
+            {
+              txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+              index: 0,
+            },
+          ],
+          [
+            {
+              valueSat: depositAmount,
+              script: p2wshScript(
+                buildDepositScript(
+                  thirdParty.address,
+                  blindingFactor,
+                  walletPubKeyHash,
+                  refundPubKeyHash,
+                  refundLocktime
+                )
+              ),
+            },
+          ]
+        )
+        await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+          fundingOutputIndex: 0,
+          blindingFactor,
+          walletPubKeyHash,
+          refundPubKeyHash,
+          refundLocktime,
+          vault: reservationVault.address,
+        })
+        const reservationKey = BigNumber.from(
+          ethers.utils.solidityKeccak256(
+            ["bytes32", "uint32"],
+            [fundingTx.txHash, 0]
+          )
+        )
+        await bridge
+          .connect(thirdParty)
+          .requestReservationAcceptance(reservationKey, walletPubKeyHash)
+
+        await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+        await bridge
+          .connect(thirdParty)
+          .notifyReservationActionTimeout(reservationKey, [])
+        await setWalletState(walletPubKeyHash, targetState)
+
+        const anchorTx = buildTx(
+          [{ txHash: fundingTx.txHash, index: 0 }],
+          [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+        )
+        const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+        const tx = await bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            1
+          )
+
+        await expect(tx)
+          .to.emit(bridge, "ReservationLateSettled")
+          .withArgs(reservationKey, 1, ActionType.Acceptance)
+        await expect(tx)
+          .to.emit(bridge, "ReservationStranded")
+          .withArgs(
+            reservationKey,
+            walletPubKeyHash,
+            thirdParty.address,
+            anchorAmount
+          )
+
+        expect((await bridge.reservations(reservationKey)).state).to.equal(
+          ReservationState.Stranded
+        )
+        expect(await bridge.walletReservationsCount(walletPubKeyHash)).to.equal(
+          0
+        )
+        expect(
+          await bridge.walletReservationsAmount(walletPubKeyHash)
+        ).to.equal(0)
+        expect(await bridge.walletReservations(walletPubKeyHash)).to.deep.equal(
+          []
+        )
+        expect(
+          (await bridge.reservationParameters()).reservationTotalAmount
+        ).to.equal(0)
+        expect(
+          await bridge.reservationByAnchorUtxo(anchorTx.txHash, 0)
+        ).to.equal(0)
+        const initiationFee = grossTbtc.mul(40).div(10000)
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          ownerBalanceBefore.add(grossTbtc.sub(initiationFee))
+        )
+
+        if (targetState === walletState.Closing) {
+          await expect(
+            bridge
+              .connect(thirdParty)
+              .notifyWalletClosingPeriodElapsed(walletPubKeyHash)
+          ).to.emit(bridge, "WalletClosed")
+          expect((await bridge.wallets(walletPubKeyHash)).state).to.equal(
+            walletState.Closed
+          )
+        }
+      })
+
+      it(`strands a late re-anchor whose target became ${stateName}`, async () => {
+        const { anchorTx, reservationKey } = await makeAcceptedReservation()
+        await liveWallet(secondWalletPubKeyHash)
+        await bridge
+          .connect(bridgeGovernanceSigner)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+        const reanchorFee = 1000
+        const newAnchorAmount = anchorAmount.sub(reanchorFee)
+        const reanchorTx = buildTx(
+          [{ txHash: anchorTx.txHash, index: 0 }],
+          [
+            {
+              valueSat: newAnchorAmount,
+              script: p2wpkhScript(secondWalletPubKeyHash),
+            },
+          ]
+        )
+
+        await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+        await bridge
+          .connect(thirdParty)
+          .notifyReservationActionTimeout(reservationKey, [])
+        await setWalletState(secondWalletPubKeyHash, targetState)
+
+        const tx = await bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            2
+          )
+
+        await expect(tx)
+          .to.emit(bridge, "ReservationLateSettled")
+          .withArgs(reservationKey, 2, ActionType.Reanchor)
+        await expect(tx)
+          .to.emit(bridge, "ReservationStranded")
+          .withArgs(
+            reservationKey,
+            secondWalletPubKeyHash,
+            thirdParty.address,
+            newAnchorAmount
+          )
+
+        const reservation = await bridge.reservations(reservationKey)
+        expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+        expect(reservation.state).to.equal(ReservationState.Stranded)
+        expect(await bridge.walletReservationsCount(walletPubKeyHash)).to.equal(
+          0
+        )
+        expect(
+          await bridge.walletReservationsAmount(walletPubKeyHash)
+        ).to.equal(0)
+        expect(await bridge.walletReservations(walletPubKeyHash)).to.deep.equal(
+          []
+        )
+        expect(
+          await bridge.walletReservationsCount(secondWalletPubKeyHash)
+        ).to.equal(0)
+        expect(
+          await bridge.walletReservationsAmount(secondWalletPubKeyHash)
+        ).to.equal(0)
+        expect(
+          await bridge.walletReservations(secondWalletPubKeyHash)
+        ).to.deep.equal([])
+        expect(
+          (await bridge.reservationParameters()).reservationTotalAmount
+        ).to.equal(0)
+        expect(
+          await bridge.reservationByAnchorUtxo(reanchorTx.txHash, 0)
+        ).to.equal(0)
+
+        if (targetState === walletState.Closing) {
+          await expect(
+            bridge
+              .connect(thirdParty)
+              .notifyWalletClosingPeriodElapsed(secondWalletPubKeyHash)
+          ).to.emit(bridge, "WalletClosed")
+          expect((await bridge.wallets(secondWalletPubKeyHash)).state).to.equal(
+            walletState.Closed
+          )
+        }
+      })
+    })
+
+    it("keeps a late re-anchor active when its target remains Live", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+
+      const reanchorFee = 1000
+      const newAnchorAmount = anchorAmount.sub(reanchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: newAnchorAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await increaseTime(RESERVATION_ACTION_TIMEOUT + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservationActionTimeout(reservationKey, [])
+
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          2
+        )
+
+      const reservation = await bridge.reservations(reservationKey)
+      expect(reservation.walletPubKeyHash).to.equal(secondWalletPubKeyHash)
+      expect(reservation.state).to.equal(ReservationState.Active)
+      expect(
+        await bridge.walletReservationsCount(secondWalletPubKeyHash)
+      ).to.equal(1)
+      expect(
+        await bridge.walletReservationsAmount(secondWalletPubKeyHash)
+      ).to.equal(newAnchorAmount)
+      expect(
+        await bridge.reservationByAnchorUtxo(reanchorTx.txHash, 0)
+      ).to.equal(reservationKey)
     })
   })
 

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -712,6 +712,9 @@ describe("Bridge - Reservation settlement", () => {
       await expect(tx)
         .to.emit(bridge, "ReservationLateSettled")
         .withArgs(reservationKey, 2, ActionType.Redemption)
+      // A whole late redemption closes the position, so its superseded
+      // retry is refunded but does not restore an unusable entitlement.
+      await expect(tx).not.to.emit(bridge, "ReservationRetryCreditMinted")
 
       expect(
         (await bridge.reservationActions(reservationKey, 3)).state

--- a/solidity/test/bridge/ReservationRouter.test.ts
+++ b/solidity/test/bridge/ReservationRouter.test.ts
@@ -3,7 +3,12 @@ import { expect } from "chai"
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 import bridgeFixture from "../fixtures/bridge"
-import type { Bridge, BridgeStub, ReservationRouter } from "../../typechain"
+import type {
+  Bridge,
+  BridgeGovernance,
+  BridgeStub,
+  ReservationRouter,
+} from "../../typechain"
 
 const { createSnapshot, restoreSnapshot } = helpers.snapshot
 
@@ -212,6 +217,53 @@ describe("ReservationRouter", () => {
   })
 
   describe("setReservationRouter", () => {
+    context("when the bridge is governed by BridgeGovernance", () => {
+      let freshBridge: Bridge & BridgeStub & ReservationRouter
+      let localBridgeGovernance: BridgeGovernance
+
+      before(async () => {
+        await createSnapshot()
+        ;[freshBridge] = await deployBridge(1, false)
+
+        const paramsLib = await helpers.contracts.getContract(
+          "BridgeGovernanceParameters"
+        )
+        const govFactory = await ethers.getContractFactory("BridgeGovernance", {
+          libraries: {
+            BridgeGovernanceParameters: paramsLib.address,
+          },
+        })
+        localBridgeGovernance = (await govFactory
+          .connect(governance)
+          .deploy(freshBridge.address, 0)) as BridgeGovernance
+        await localBridgeGovernance.deployed()
+
+        await freshBridge
+          .connect(deployer)
+          .transferGovernance(localBridgeGovernance.address)
+      })
+
+      after(async () => {
+        await restoreSnapshot()
+      })
+
+      it("should reject a non-owner forwarding the router wiring", async () => {
+        await expect(
+          localBridgeGovernance
+            .connect(thirdParty)
+            .setReservationRouter(routerAddress)
+        ).to.be.revertedWith("Ownable: caller is not the owner")
+      })
+
+      it("should let the owner wire the router through governance", async () => {
+        await localBridgeGovernance
+          .connect(governance)
+          .setReservationRouter(routerAddress)
+
+        expect(await freshBridge.reservationRouter()).to.equal(routerAddress)
+      })
+    })
+
     context("when called on a bridge with the router already set", () => {
       it("should revert", async () => {
         // A fresh bridge is governed by the deployer (the main bridge's


### PR DESCRIPTION
## What

Adds **partial reserved redemption** to the UTXO-reservation lane, on the same authorize-then-prove settlement machine the whole redemption already uses. Stacked on `docs/utxo-reservation-release`.

An owner can redeem a `redeemAmount` strictly between the fee floor and the whole claim. That portion is escrowed at request time exactly like a whole redemption — the two paths share one internal request routine, distinguished by an `isPartial` flag on the generation.

## Bitcoin shape

The settlement transaction spends the anchor and pays **two** outputs:

- **output 0** pays the requested redeemer script and **bears the entire miner fee** — its value is `redeemAmount − fee`, `fee ≤ txMaxFee`;
- **output 1** re-anchors the remainder to the custodying wallet PKH, value **exactly** `anchor − redeemAmount`.

So claim-equals-anchor holds across the split to the satoshi, and no foreign sats enter — the remainder is the wallet's own change.

## On-chain effect

On proof the redeemed portion is burned and `mintedAmount`, `anchorAmount`, and the reserved capacity (`reservationTotalAmount`, `walletReservationsAmount`) each drop by `redeemAmount`, while the position stays **Active** on the new remainder outpoint (output index 1). Partials chain — each spends the prior remainder — and a whole redemption closes whatever remains.

Timeout and late-proof handling mirror whole redemption:

- a **timeout** returns the *full* anchor and refunds the escrow (nothing was redeemed on-chain);
- a **late** partial proof settles against the terminal `TimedOut` record with no second burn; against a newer pending generation it follows the same match-or-unwind rule, generalized to compare shape (`isPartial`), redeemer script, redeemed amount, and the snapshotted fee bound — a matching generation must be settled instead (preserving the burn), a non-matching one is unwound and refunded.

## Storage / surface

- `isPartial` is **appended to the end** of the `ReservationAction` struct: no existing field offset changes, no new top-level state, no `__gap` change.
- The existing `validateReservedRedemptionProposal` already covers partials (it validates the pending redemption generation and its fee bound; the two-output shape is enforced at proof time, and keep-core reads `isPartial`/`amount` from the on-chain action).
- New surface: `ReservationVault.redeemReservationPartial` / `retryRedeemReservationPartial`, the router wrapper + interface entry, and the `ReservationPartiallyRedeemed` event.

## Tests / checks

- `Bridge.ReservationPartial.test.ts` — 17 cases: request bounds, happy-path re-anchor, proof-time output validation (output count, redeemer script/value, remainder wallet/value), sequential partials, partial-then-whole, partial timeout returning the full anchor, and the late-partial settlement matrix (no newer gen / matching gen / non-matching gen).
- Full reservation suite green (104 passing); slither 0.9.0 clean (0 results).
- Docs: RFC-13 action model, frozen parameter spec, and the design doc updated to reflect partial redemption shipping in v1.

Opened as a draft.