### PR TITLE
fix(reservation): address multi-agent review findings on #1088

### DIFF
--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -2269,9 +2269,10 @@ contract Bridge is
     ///        transaction fee that can be incurred by a single reservation
     ///        lifecycle transaction.
     /// @param reservationDissolutionTxMaxFee New value of the dedicated
-    ///        cap on the BTC transaction fee for the 2-in-1-out
-    ///        dissolution shape; distinct from `reservationTxMaxFee`
-    ///        which caps the 1-in-1-out anchor / re-anchor / redemption
+    ///        cap on the BTC transaction fee for the dissolution shape
+    ///        (usually 2-in-1-out; 1-in-1-out when the wallet has no
+    ///        main UTXO yet); distinct from `reservationTxMaxFee` which
+    ///        caps the always-1-in-1-out anchor / re-anchor / redemption
     ///        shapes.
     /// @param reservationTermSeconds New value of the reservation custody
     ///        term length in seconds.
@@ -2331,20 +2332,24 @@ contract Bridge is
             address reservationVault,
             uint64 reservationMinAmount,
             uint64 reservationTxMaxFee,
+            uint64 reservationDissolutionTxMaxFee,
             uint32 reservationTermSeconds,
             uint32 reservationGracePeriod,
             uint64 reservationMaxTotalAmount,
             uint64 reservationTotalAmount,
-            uint32 maxReservationsPerWallet
+            uint32 maxReservationsPerWallet,
+            uint64 maxCumulativeReanchorFee
         )
     {
         reservationVault = self.reservationVault;
         reservationMinAmount = self.reservationMinAmount;
         reservationTxMaxFee = self.reservationTxMaxFee;
+        reservationDissolutionTxMaxFee = self.reservationDissolutionTxMaxFee;
         reservationTermSeconds = self.reservationTermSeconds;
         reservationGracePeriod = self.reservationGracePeriod;
         reservationMaxTotalAmount = self.reservationMaxTotalAmount;
         reservationTotalAmount = self.reservationTotalAmount;
         maxReservationsPerWallet = self.maxReservationsPerWallet;
+        maxCumulativeReanchorFee = self.maxCumulativeReanchorFee;
     }
 }

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -140,6 +140,16 @@ contract Bridge is
         bytes20 indexed walletPubKeyHash
     );
 
+    event ReservedRedemptionSettled(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    event ReservedRedemptionTimeoutSlashingSkipped(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
     event ReservedRedemptionVetoed(uint256 indexed reservationKey);
 
     event ReservationReanchored(
@@ -158,10 +168,12 @@ contract Bridge is
     event ReservationParametersUpdated(
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -2256,6 +2268,11 @@ contract Bridge is
     ///        max fee in satoshis. It is the maximum amount of BTC
     ///        transaction fee that can be incurred by a single reservation
     ///        lifecycle transaction.
+    /// @param reservationDissolutionTxMaxFee New value of the dedicated
+    ///        cap on the BTC transaction fee for the 2-in-1-out
+    ///        dissolution shape; distinct from `reservationTxMaxFee`
+    ///        which caps the 1-in-1-out anchor / re-anchor / redemption
+    ///        shapes.
     /// @param reservationTermSeconds New value of the reservation custody
     ///        term length in seconds.
     /// @param reservationGracePeriod New value of the reservation grace
@@ -2264,6 +2281,8 @@ contract Bridge is
     ///        satoshi locked under active reservations.
     /// @param maxReservationsPerWallet New cap on the number of active
     ///        reservations a single wallet can custody.
+    /// @param maxCumulativeReanchorFee New cap on the total satoshi a
+    ///        single reservation may lose across all re-anchor hops.
     /// @dev Requirements:
     ///      - The caller must be the governance,
     ///      - See `Reservation.updateReservationParameters` for parameter
@@ -2272,19 +2291,23 @@ contract Bridge is
         address reservationVault,
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     ) external onlyGovernance {
         self.updateReservationParameters(
             reservationVault,
             reservationMinAmount,
             reservationTxMaxFee,
+            reservationDissolutionTxMaxFee,
             reservationTermSeconds,
             reservationGracePeriod,
             reservationMaxTotalAmount,
-            maxReservationsPerWallet
+            maxReservationsPerWallet,
+            maxCumulativeReanchorFee
         );
     }
 

--- a/solidity/contracts/bridge/Bridge.sol
+++ b/solidity/contracts/bridge/Bridge.sol
@@ -162,7 +162,10 @@ contract Bridge is
     event ReservationDissolved(
         uint256 indexed reservationKey,
         bytes20 indexed walletPubKeyHash,
-        bytes32 dissolutionTxHash
+        bytes32 dissolutionTxHash,
+        uint64 mintedAmount,
+        uint64 anchorAmount,
+        uint64 dissolutionFee
     );
 
     event ReservationParametersUpdated(

--- a/solidity/contracts/bridge/BridgeGovernance.sol
+++ b/solidity/contracts/bridge/BridgeGovernance.sol
@@ -294,10 +294,12 @@ contract BridgeGovernance is Ownable {
         address newReservationVault,
         uint64 newReservationMinAmount,
         uint64 newReservationTxMaxFee,
+        uint64 newReservationDissolutionTxMaxFee,
         uint32 newReservationTermSeconds,
         uint32 newReservationGracePeriod,
         uint64 newReservationMaxTotalAmount,
         uint32 newMaxReservationsPerWallet,
+        uint64 newMaxCumulativeReanchorFee,
         uint256 timestamp
     );
 
@@ -1830,19 +1832,23 @@ contract BridgeGovernance is Ownable {
         address _newReservationVault,
         uint64 _newReservationMinAmount,
         uint64 _newReservationTxMaxFee,
+        uint64 _newReservationDissolutionTxMaxFee,
         uint32 _newReservationTermSeconds,
         uint32 _newReservationGracePeriod,
         uint64 _newReservationMaxTotalAmount,
-        uint32 _newMaxReservationsPerWallet
+        uint32 _newMaxReservationsPerWallet,
+        uint64 _newMaxCumulativeReanchorFee
     ) external onlyOwner {
         reservationData.beginReservationParametersUpdate(
             _newReservationVault,
             _newReservationMinAmount,
             _newReservationTxMaxFee,
+            _newReservationDissolutionTxMaxFee,
             _newReservationTermSeconds,
             _newReservationGracePeriod,
             _newReservationMaxTotalAmount,
-            _newMaxReservationsPerWallet
+            _newMaxReservationsPerWallet,
+            _newMaxCumulativeReanchorFee
         );
     }
 
@@ -1857,10 +1863,12 @@ contract BridgeGovernance is Ownable {
             staged.newReservationVault,
             staged.newReservationMinAmount,
             staged.newReservationTxMaxFee,
+            staged.newReservationDissolutionTxMaxFee,
             staged.newReservationTermSeconds,
             staged.newReservationGracePeriod,
             staged.newReservationMaxTotalAmount,
-            staged.newMaxReservationsPerWallet
+            staged.newMaxReservationsPerWallet,
+            staged.newMaxCumulativeReanchorFee
         );
     }
 }

--- a/solidity/contracts/bridge/BridgeGovernanceParameters.sol
+++ b/solidity/contracts/bridge/BridgeGovernanceParameters.sol
@@ -1576,10 +1576,12 @@ library BridgeGovernanceParameters {
         address newReservationVault;
         uint64 newReservationMinAmount;
         uint64 newReservationTxMaxFee;
+        uint64 newReservationDissolutionTxMaxFee;
         uint32 newReservationTermSeconds;
         uint32 newReservationGracePeriod;
         uint64 newReservationMaxTotalAmount;
         uint32 newMaxReservationsPerWallet;
+        uint64 newMaxCumulativeReanchorFee;
         uint256 reservationParametersChangeInitiated;
     }
 
@@ -1587,10 +1589,12 @@ library BridgeGovernanceParameters {
         address newReservationVault,
         uint64 newReservationMinAmount,
         uint64 newReservationTxMaxFee,
+        uint64 newReservationDissolutionTxMaxFee,
         uint32 newReservationTermSeconds,
         uint32 newReservationGracePeriod,
         uint64 newReservationMaxTotalAmount,
         uint32 newMaxReservationsPerWallet,
+        uint64 newMaxCumulativeReanchorFee,
         uint256 timestamp
     );
 
@@ -1602,28 +1606,35 @@ library BridgeGovernanceParameters {
         address _newReservationVault,
         uint64 _newReservationMinAmount,
         uint64 _newReservationTxMaxFee,
+        uint64 _newReservationDissolutionTxMaxFee,
         uint32 _newReservationTermSeconds,
         uint32 _newReservationGracePeriod,
         uint64 _newReservationMaxTotalAmount,
-        uint32 _newMaxReservationsPerWallet
+        uint32 _newMaxReservationsPerWallet,
+        uint64 _newMaxCumulativeReanchorFee
     ) external {
         /* solhint-disable not-rely-on-time */
         self.newReservationVault = _newReservationVault;
         self.newReservationMinAmount = _newReservationMinAmount;
         self.newReservationTxMaxFee = _newReservationTxMaxFee;
+        self
+            .newReservationDissolutionTxMaxFee = _newReservationDissolutionTxMaxFee;
         self.newReservationTermSeconds = _newReservationTermSeconds;
         self.newReservationGracePeriod = _newReservationGracePeriod;
         self.newReservationMaxTotalAmount = _newReservationMaxTotalAmount;
         self.newMaxReservationsPerWallet = _newMaxReservationsPerWallet;
+        self.newMaxCumulativeReanchorFee = _newMaxCumulativeReanchorFee;
         self.reservationParametersChangeInitiated = block.timestamp;
         emit ReservationParametersUpdateStarted(
             _newReservationVault,
             _newReservationMinAmount,
             _newReservationTxMaxFee,
+            _newReservationDissolutionTxMaxFee,
             _newReservationTermSeconds,
             _newReservationGracePeriod,
             _newReservationMaxTotalAmount,
             _newMaxReservationsPerWallet,
+            _newMaxCumulativeReanchorFee,
             block.timestamp
         );
         /* solhint-enable not-rely-on-time */
@@ -1632,7 +1643,7 @@ library BridgeGovernanceParameters {
     /// @notice Finalizes the reservation parameters update process.
     /// @dev The staged values are read by the caller before this call; this
     ///      function only enforces the governance delay and clears the
-    ///      staged change.
+    ///      staged change along with all staged reservation parameters.
     function finalizeReservationParametersUpdate(
         ReservationData storage self,
         uint256 governanceDelay
@@ -1643,6 +1654,15 @@ library BridgeGovernanceParameters {
             governanceDelay
         )
     {
+        self.newReservationVault = address(0);
+        self.newReservationMinAmount = 0;
+        self.newReservationTxMaxFee = 0;
+        self.newReservationDissolutionTxMaxFee = 0;
+        self.newReservationTermSeconds = 0;
+        self.newReservationGracePeriod = 0;
+        self.newReservationMaxTotalAmount = 0;
+        self.newMaxReservationsPerWallet = 0;
+        self.newMaxCumulativeReanchorFee = 0;
         self.reservationParametersChangeInitiated = 0;
     }
 }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -29,23 +29,31 @@ import "./MovingFunds.sol";
 import "../bank/Bank.sol";
 
 library BridgeState {
-    /// @notice Reveal-time facts for a deposit routed to the reservation
-    ///         vault. All fields fit in one storage word. `isReserved` is
-    ///         permanent; the remaining fields are used by the reservation
-    ///         action flow and may be cleared after acceptance or staleness.
+    /// @notice Reveal-time fact for a deposit routed to the reservation
+    ///         vault: whether it was classified as a reserved deposit at
+    ///         reveal time. This classification is permanent and does not
+    ///         track any later reservation-vault or wallet changes.
     struct PendingReservedDeposit {
         // Immutable reveal-time reservation classification.
         bool isReserved;
-        // Wallet committed by the deposit script and therefore the only
-        // wallet that can be authorized to anchor the deposit.
-        bytes20 walletPubKeyHash;
-        // Exact Bitcoin refund locktime validated at reveal time. Zero is a
-        // valid value when reveal-ahead validation was disabled.
-        uint32 refundDeadline;
-        // Whether the refund deadline was validated against a nonzero
-        // reveal-ahead period. This preserves the disabled validation mode
-        // without overloading a valid zero locktime.
-        bool refundDeadlineValidated;
+    }
+
+    /// @notice Terminal settlement record for a reserved redemption whose
+    ///         request timed out or was vetoed before its Bitcoin
+    ///         transaction could be proven. The redeemer was already
+    ///         refunded when this record was written; a later proof of the
+    ///         exact settled anchor spend is acknowledged (its outpoint
+    ///         marked spent) without moving any further balance. Mirrors
+    ///         the pooled redemption path's `timedOutRedemptions` record.
+    struct ReservedRedemptionSettlement {
+        // Whether a settlement is currently pending for this reservation.
+        bool pending;
+        // Hash of the Bitcoin transaction holding the anchor output that
+        // was pending redemption when the settlement was recorded. The
+        // anchor output index is always 0 (anchor transactions have a
+        // single output throughout a reservation's lifecycle) so it is
+        // not separately stored here.
+        bytes32 anchorTxHash;
     }
 
     struct Storage {
@@ -362,6 +370,12 @@ library BridgeState {
         // incurred by a single reservation lifecycle transaction (anchor,
         // re-anchor, reserved redemption, dissolution).
         uint64 reservationTxMaxFee;
+        // Maximum amount of BTC transaction fee in satoshi that can be
+        // incurred by a single reservation dissolution transaction
+        // (2-in-1-out shape). Distinct from `reservationTxMaxFee` because
+        // dissolution's fee economics differ from the 1-in-1-out anchor /
+        // re-anchor / redemption shapes that share `reservationTxMaxFee`.
+        uint64 reservationDissolutionTxMaxFee;
         // The grace period in seconds after a reservation's custody term
         // expires during which the reservation can still be extended or
         // redeemed but not yet dissolved.
@@ -370,18 +384,23 @@ library BridgeState {
         // reservations at the same time.
         uint64 reservationMaxTotalAmount;
         // Current total amount in satoshi locked under active reservations
-        // (sum of current anchor output values).
+        // (sum of gross `mintedAmount` over Active reservations, unchanged
+        // by re-anchor hops which only reduce the per-reservation
+        // `anchorAmount`).
         uint64 reservationTotalAmount;
         // Maximum number of active reservations a single wallet can custody.
         uint32 maxReservationsPerWallet;
+        // Per-reservation cumulative re-anchor fee budget in satoshi. Caps
+        // the total satoshi that may be lost across all re-anchor hops for
+        // a single reservation, complementing the per-transaction
+        // `reservationTxMaxFee` bound which only constrains a single hop.
+        // Bounds in-kind grinding of the anchor value over the reservation
+        // lifetime.
+        uint64 maxCumulativeReanchorFee;
         // Collection of all reservations indexed by the deposit key of the
         // underlying reserved deposit, i.e.
         // `keccak256(fundingTxHash | fundingOutputIndex)`.
         mapping(uint256 => Reservation.ReservationRequest) reservations;
-        // Maps the UTXO key of a reservation's current anchor outpoint,
-        // built as `keccak256(anchorTxHash | anchorTxOutputIndex)`, to the
-        // reservation key.
-        mapping(uint256 => uint256) reservationsByAnchorUtxo;
         // The number of active reservations custodied by the given wallet,
         // identified by its 20-byte wallet public key hash.
         mapping(bytes20 => uint32) walletReservationsCount;
@@ -390,6 +409,10 @@ library BridgeState {
         // updates from changing an ordinary deposit into a reservation or
         // making a reserved deposit eligible for an ordinary sweep.
         mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
+        // Terminal settlement records for reserved redemptions whose
+        // request timed out or was vetoed before their Bitcoin transaction
+        // could be proven, keyed by reservation key.
+        mapping(uint256 => ReservedRedemptionSettlement) reservedRedemptionSettlements;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -397,7 +420,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[42] __gap;
+        uint256[41] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -32,7 +32,14 @@ library BridgeState {
     /// @notice Reveal-time fact for a deposit routed to the reservation
     ///         vault: whether it was classified as a reserved deposit at
     ///         reveal time. This classification is permanent and does not
-    ///         track any later reservation-vault or wallet changes.
+    ///         track any later reservation-vault or wallet changes. Note
+    ///         this only governs sweep eligibility: if the reservation
+    ///         vault address is later changed by governance before this
+    ///         deposit's anchor is accepted, `Reservation
+    ///         .submitReservationAcceptanceProof` still credits the
+    ///         owner's balance through the *current* reservation vault at
+    ///         acceptance time, not the vault set when the deposit was
+    ///         revealed.
     struct PendingReservedDeposit {
         // Immutable reveal-time reservation classification.
         bool isReserved;
@@ -46,14 +53,23 @@ library BridgeState {
     ///         marked spent) without moving any further balance. Mirrors
     ///         the pooled redemption path's `timedOutRedemptions` record.
     struct ReservedRedemptionSettlement {
-        // Whether a settlement is currently pending for this reservation.
-        bool pending;
         // Hash of the Bitcoin transaction holding the anchor output that
         // was pending redemption when the settlement was recorded. The
         // anchor output index is always 0 (anchor transactions have a
         // single output throughout a reservation's lifecycle) so it is
-        // not separately stored here.
+        // not separately stored here. Zero when no settlement is
+        // pending -- a real anchor transaction's double-SHA256 hash is
+        // never all-zero in practice, so this field doubles as the
+        // "is a settlement pending" sentinel instead of a separate
+        // `bool`.
         bytes32 anchorTxHash;
+        // keccak256 hash of the length-prefixed redeemer output script
+        // the settled redemption must pay to, snapshotted from the
+        // reservation at settlement-record time. A late-arriving proof
+        // must pay this exact script; without this check a wallet could
+        // redirect the settled anchor's spend to an address it controls
+        // and still have the proof accepted as a valid settlement.
+        bytes32 redeemerOutputScriptHash;
     }
 
     struct Storage {
@@ -368,7 +384,9 @@ library BridgeState {
         address reservationVault;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation lifecycle transaction (anchor,
-        // re-anchor, reserved redemption, dissolution).
+        // re-anchor, reserved redemption). Distinct from
+        // `reservationDissolutionTxMaxFee`, which caps the dissolution
+        // transaction's 2-in-1-out fee economics.
         uint64 reservationTxMaxFee;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation dissolution transaction

--- a/solidity/contracts/bridge/Redemption.sol
+++ b/solidity/contracts/bridge/Redemption.sol
@@ -53,6 +53,28 @@ interface IRedemptionWatchtower {
         address redeemer
     ) external view returns (bool);
 
+    /// @notice Determines whether a reserved redemption request is
+    ///         considered safe. Distinct from `isSafeRedemption` because a
+    ///         reserved redemption's veto history is keyed per reservation
+    ///         and per request generation (`reservationKey` +
+    ///         `redemptionRequestedAt`), not per wallet/output-script pair.
+    /// @param reservationKey The key of the reservation being redeemed.
+    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
+    ///        request is being made at (the value about to be written to
+    ///        the reservation's `redemptionRequestedAt` field).
+    /// @param balanceOwner The address of the Bank balance owner whose
+    ///        balance is getting redeemed.
+    /// @param redeemer The address that requested the redemption.
+    /// @return True if the reserved redemption request is safe, false
+    ///         otherwise. Specific safety criteria depend on the
+    ///         implementation.
+    function isSafeReservedRedemption(
+        uint256 reservationKey,
+        uint32 redemptionRequestedAt,
+        address balanceOwner,
+        address redeemer
+    ) external view returns (bool);
+
     /// @notice Returns the applicable redemption delay for a redemption
     ///         request identified by the given redemption key.
     /// @param redemptionKey Redemption key built as
@@ -77,6 +99,42 @@ interface IRedemptionWatchtower {
 ///         validation and to the moving funds transaction proof validation.
 library OutboundTx {
     using BTCUtils for bytes;
+    using BytesLib for bytes;
+
+    /// @notice Validates a redeemer output script: checks it decodes as a
+    ///         standard type (P2PKH, P2WPKH, P2SH or P2WSH) and, when its
+    ///         payload is 20 bytes, that it does not point to the given
+    ///         wallet's own public key hash. Reverts otherwise. Shared by
+    ///         both the pooled redemption and reserved redemption request
+    ///         paths, which apply the identical check.
+    /// @param redeemerOutputScript The redeemer output script to validate.
+    /// @param walletPubKeyHash 20-byte public key hash of the wallet the
+    ///        redemption is requested against.
+    function validateRedeemerOutputScript(
+        bytes memory redeemerOutputScript,
+        bytes20 walletPubKeyHash
+    ) internal pure {
+        // Validate if redeemer output script is a correct standard type
+        // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by using
+        // `BTCUtils.extractHashAt` on it. Such a function extracts the
+        // payload properly only from standard outputs so if it succeeds, we
+        // have a guarantee the redeemer output script is proper. The
+        // underlying way of validation is the same as in tBTC v1.
+        bytes memory redeemerOutputScriptPayload = redeemerOutputScript
+            .extractHashAt(0, redeemerOutputScript.length);
+
+        require(
+            redeemerOutputScriptPayload.length > 0,
+            "Redeemer output script must be a standard type"
+        );
+        // Check if the redeemer output script payload does not point to the
+        // wallet public key hash.
+        require(
+            redeemerOutputScriptPayload.length != 20 ||
+                walletPubKeyHash != redeemerOutputScriptPayload.slice20(0),
+            "Redeemer output script must not point to the wallet PKH"
+        );
+    }
 
     /// @notice Checks whether an outbound Bitcoin transaction performed from
     ///         the given wallet has an input vector that contains a single
@@ -542,25 +600,9 @@ library Redemption {
             "Invalid main UTXO data"
         );
 
-        // Validate if redeemer output script is a correct standard type
-        // (P2PKH, P2WPKH, P2SH or P2WSH). This is done by using
-        // `BTCUtils.extractHashAt` on it. Such a function extracts the payload
-        // properly only from standard outputs so if it succeeds, we have a
-        // guarantee the redeemer output script is proper. The underlying way
-        // of validation is the same as in tBTC v1.
-        bytes memory redeemerOutputScriptPayload = redeemerOutputScript
-            .extractHashAt(0, redeemerOutputScript.length);
-
-        require(
-            redeemerOutputScriptPayload.length > 0,
-            "Redeemer output script must be a standard type"
-        );
-        // Check if the redeemer output script payload does not point to the
-        // wallet public key hash.
-        require(
-            redeemerOutputScriptPayload.length != 20 ||
-                walletPubKeyHash != redeemerOutputScriptPayload.slice20(0),
-            "Redeemer output script must not point to the wallet PKH"
+        OutboundTx.validateRedeemerOutputScript(
+            redeemerOutputScript,
+            walletPubKeyHash
         );
 
         require(

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -415,6 +415,21 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     ///         on the Bridge -- the anchor outpoint was not spent, so the
     ///         in-kind claim survives (though a banned owner cannot
     ///         re-request until unbanned).
+    ///
+    ///         Veto state is keyed per request generation
+    ///         (`_reservedVetoKey(reservationKey, redemptionRequestedAt)`),
+    ///         not by the bare reservation key: a reservation returns to
+    ///         Active and can be re-requested after a timeout, so keying by
+    ///         the bare reservation key would let a stale `objectionsCount`
+    ///         or per-guardian objection from a resolved earlier request
+    ///         permanently block or bias every future request generation
+    ///         on the same reservation. The `ObjectionRaised`/
+    ///         `VetoFinalized`/`VetoPeriodCheckOmitted` events below carry
+    ///         the generation key (not the bare reservation key) since
+    ///         that is the value `withdrawVetoedFunds` requires and the
+    ///         Bridge clears `redemptionRequestedAt` once the veto
+    ///         finalizes, so the generation key cannot be recomputed from
+    ///         Bridge state after the fact.
     /// @param reservationKey The key of the reservation with the pending
     ///        reserved redemption.
     /// @dev Requirements:
@@ -428,18 +443,6 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         external
         onlyGuardian
     {
-        VetoProposal storage veto = vetoProposals[reservationKey];
-
-        require(
-            veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
-            "Reserved redemption already vetoed"
-        );
-
-        uint256 objectionKey = uint256(
-            keccak256(abi.encodePacked(reservationKey, msg.sender))
-        );
-        require(!objections[objectionKey], "Guardian already objected");
-
         Reservation.ReservationRequest memory reservation = bridge.reservations(
             reservationKey
         );
@@ -449,6 +452,22 @@ contract RedemptionWatchtower is OwnableUpgradeable {
                 Reservation.ReservationState.RedemptionRequested,
             "Reserved redemption does not exist"
         );
+
+        uint256 vetoKey = _reservedVetoKey(
+            reservationKey,
+            reservation.redemptionRequestedAt
+        );
+        VetoProposal storage veto = vetoProposals[vetoKey];
+
+        require(
+            veto.objectionsCount < REQUIRED_OBJECTIONS_COUNT,
+            "Reserved redemption already vetoed"
+        );
+
+        uint256 objectionKey = uint256(
+            keccak256(abi.encodePacked(vetoKey, msg.sender))
+        );
+        require(!objections[objectionKey], "Guardian already objected");
 
         if (reservation.redemptionRequestedAt >= watchtowerEnabledAt) {
             require(
@@ -462,14 +481,14 @@ contract RedemptionWatchtower is OwnableUpgradeable {
                 "Redemption veto delay period expired"
             );
         } else {
-            emit VetoPeriodCheckOmitted(reservationKey);
+            emit VetoPeriodCheckOmitted(vetoKey);
         }
 
         objections[objectionKey] = true;
         veto.redeemer = reservation.redeemer;
         veto.objectionsCount++;
 
-        emit ObjectionRaised(reservationKey, msg.sender);
+        emit ObjectionRaised(vetoKey, msg.sender);
 
         if (veto.objectionsCount == REQUIRED_OBJECTIONS_COUNT) {
             uint64 penaltyFee = vetoPenaltyFeeDivisor > 0
@@ -483,7 +502,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
             emit Banned(reservation.redeemer);
 
-            emit VetoFinalized(reservationKey);
+            emit VetoFinalized(vetoKey);
 
             // Notify the Bridge about the veto. As result of this call,
             // this contract receives the surrendered gross amount
@@ -493,6 +512,25 @@ contract RedemptionWatchtower is OwnableUpgradeable {
             // redeemer to withdraw after the freeze period.
             bank.decreaseBalance(penaltyFee);
         }
+    }
+
+    /// @notice Derives the veto-state key for a reserved redemption request
+    ///         generation, scoping guardian objections and veto state to
+    ///         the specific request rather than the reservation as a whole.
+    /// @param reservationKey The key of the reservation.
+    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
+    ///        request was (or is about to be) made at.
+    /// @return The generation-scoped veto-state key.
+    function _reservedVetoKey(
+        uint256 reservationKey,
+        uint32 redemptionRequestedAt
+    ) internal pure returns (uint256) {
+        return
+            uint256(
+                keccak256(
+                    abi.encodePacked(reservationKey, redemptionRequestedAt)
+                )
+            );
     }
 
     /// @notice Returns the applicable veto delay for a pending reserved
@@ -517,7 +555,12 @@ contract RedemptionWatchtower is OwnableUpgradeable {
 
         return
             _redemptionDelay(
-                vetoProposals[reservationKey].objectionsCount,
+                vetoProposals[
+                    _reservedVetoKey(
+                        reservationKey,
+                        reservation.redemptionRequestedAt
+                    )
+                ].objectionsCount,
                 reservation.mintedAmount
             );
     }
@@ -692,6 +735,47 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         );
 
         if (vetoProposals[redemptionKey].objectionsCount > 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// @notice Determines whether a reserved redemption request is
+    ///         considered safe.
+    /// @param reservationKey The key of the reservation being redeemed.
+    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
+    ///        request is being made at (the value about to be written to
+    ///        the reservation's `redemptionRequestedAt` field).
+    /// @param balanceOwner The address of the Bank balance owner whose
+    ///        balance is getting redeemed.
+    /// @param redeemer The address that requested the redemption.
+    /// @return True if the reserved redemption request is safe, false
+    ///         otherwise. The redemption is considered safe when:
+    ///         - The balance owner is not banned,
+    ///         - The redeemer is not banned,
+    ///         - There are no objections against this reservation's
+    ///           current request generation.
+    function isSafeReservedRedemption(
+        uint256 reservationKey,
+        uint32 redemptionRequestedAt,
+        address balanceOwner,
+        address redeemer
+    ) external view returns (bool) {
+        if (isBanned[balanceOwner]) {
+            return false;
+        }
+
+        if (isBanned[redeemer]) {
+            return false;
+        }
+
+        uint256 vetoKey = _reservedVetoKey(
+            reservationKey,
+            redemptionRequestedAt
+        );
+
+        if (vetoProposals[vetoKey].objectionsCount > 0) {
             return false;
         }
 

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -742,11 +742,10 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     }
 
     /// @notice Determines whether a reserved redemption request is
-    ///         considered safe.
-    /// @param reservationKey The key of the reservation being redeemed.
-    /// @param redemptionRequestedAt UNIX timestamp the reserved redemption
-    ///        request is being made at (the value about to be written to
-    ///        the reservation's `redemptionRequestedAt` field).
+    ///         considered safe. The first two positional parameters
+    ///         (a reservation key and the request's timestamp) are part
+    ///         of the interface the Bridge calls through but are unused
+    ///         by this check.
     /// @param balanceOwner The address of the Bank balance owner whose
     ///        balance is getting redeemed.
     /// @param redeemer The address that requested the redemption.
@@ -755,8 +754,8 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     ///         - The balance owner is not banned,
     ///         - The redeemer is not banned.
     function isSafeReservedRedemption(
-        uint256 reservationKey,
-        uint32 redemptionRequestedAt,
+        uint256,
+        uint32,
         address balanceOwner,
         address redeemer
     ) external view returns (bool) {

--- a/solidity/contracts/bridge/RedemptionWatchtower.sol
+++ b/solidity/contracts/bridge/RedemptionWatchtower.sol
@@ -753,9 +753,7 @@ contract RedemptionWatchtower is OwnableUpgradeable {
     /// @return True if the reserved redemption request is safe, false
     ///         otherwise. The redemption is considered safe when:
     ///         - The balance owner is not banned,
-    ///         - The redeemer is not banned,
-    ///         - There are no objections against this reservation's
-    ///           current request generation.
+    ///         - The redeemer is not banned.
     function isSafeReservedRedemption(
         uint256 reservationKey,
         uint32 redemptionRequestedAt,
@@ -767,15 +765,6 @@ contract RedemptionWatchtower is OwnableUpgradeable {
         }
 
         if (isBanned[redeemer]) {
-            return false;
-        }
-
-        uint256 vetoKey = _reservedVetoKey(
-            reservationKey,
-            redemptionRequestedAt
-        );
-
-        if (vetoProposals[vetoKey].objectionsCount > 0) {
             return false;
         }
 

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -134,6 +134,24 @@ library Reservation {
         // keccak256 hash of the length-prefixed redeemer output script the
         // pending reserved redemption must pay to.
         bytes32 redeemerOutputScriptHash;
+        // Cumulative satoshi lost to Bitcoin miner fees across all
+        // re-anchor hops of this reservation. Bounded by
+        // `Storage.maxCumulativeReanchorFee` to cap in-kind fee
+        // extraction by a Byzantine wallet performing many small
+        // re-anchors.
+        uint64 cumulativeReanchorFee;
+        // Set true when the most recent reserved redemption timeout
+        // slashed the custodying wallet (it was Live, MovingFunds, or
+        // Terminated); set false when slashing was skipped (wallet
+        // already Closing/Closed) or the most recent resolution was a
+        // veto rather than a timeout. Read by
+        // `ReservationVault.retryRedeemReservation` to confirm the prior
+        // request specifically ended in a wallet-fault timeout before
+        // waiving the redemption fee -- without this gate an owner could
+        // use the retry path as an ordinary fee-free first redemption, or
+        // grief wallet operators by repeatedly requesting, waiting out
+        // the timeout (slashing the wallet), and retrying for free.
+        bool lastTimeoutWasWalletFault;
         // This struct doesn't contain `__gap` property as the structure is
         // stored in a mapping, mappings store values in different slots and
         // they are not contiguous with other values.
@@ -173,6 +191,22 @@ library Reservation {
 
     event ReservedRedemptionVetoed(uint256 indexed reservationKey);
 
+    // Emitted when a reserved redemption proof lands after the request
+    // already timed out or was vetoed; the redeemer was already refunded
+    // and no further balance movement occurs.
+    event ReservedRedemptionSettled(
+        uint256 indexed reservationKey,
+        bytes32 redemptionTxHash
+    );
+
+    // Emitted when a reserved redemption timeout occurs but the custodying
+    // wallet has already reached Closing or Closed state, so wallet-fault
+    // slashing is skipped (the redeemer is still refunded).
+    event ReservedRedemptionTimeoutSlashingSkipped(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash
+    );
+
     event ReservationReanchored(
         uint256 indexed reservationKey,
         bytes20 indexed newWalletPubKeyHash,
@@ -189,10 +223,12 @@ library Reservation {
     event ReservationParametersUpdated(
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     );
 
     event ReservationVaultUpdated(address reservationVault);
@@ -350,9 +386,7 @@ library Reservation {
         (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
             .parseWalletOutboundTxInput(inputVector);
 
-        reservationKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
+        reservationKey = _outpointKey(outpointTxHash, outpointIndex);
 
         Deposit.DepositRequest storage deposit = self.deposits[reservationKey];
         require(deposit.revealedAt != 0, "Deposit not revealed");
@@ -360,10 +394,6 @@ library Reservation {
         require(
             self.pendingReservedDeposit[reservationKey].isReserved,
             "Deposit was not revealed as reserved"
-        );
-        require(
-            deposit.vault == self.reservationVault,
-            "Deposit not routed to the reservation vault"
         );
 
         /* solhint-disable-next-line not-rely-on-time */
@@ -433,10 +463,6 @@ library Reservation {
         reservation.anchorTxOutputIndex = 0;
         reservation.state = ReservationState.Active;
 
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(anchorTxHash, uint32(0))))
-        ] = reservationKey;
-
         // slither-disable-next-line reentrancy-events
         emit ReservationAccepted(
             reservationKey,
@@ -454,8 +480,10 @@ library Reservation {
     /// @param reservationKey The key of the reservation to extend.
     /// @dev Requirements:
     ///      - The caller must be the reservation vault,
-    ///      - The reservation must be in the Active or RedemptionRequested
-    ///        state,
+    ///      - The reservation must be in the Active state (a pending
+    ///        reserved redemption may consume the anchor at any time,
+    ///        so extending it would risk paying an extension fee on a
+    ///        position about to be spent),
     ///      - The reservation must not be past its grace period.
     function extendReservation(
         BridgeState.Storage storage self,
@@ -470,8 +498,7 @@ library Reservation {
             reservationKey
         ];
         require(
-            reservation.state == ReservationState.Active ||
-                reservation.state == ReservationState.RedemptionRequested,
+            reservation.state == ReservationState.Active,
             "Reservation is not active"
         );
         require(
@@ -536,12 +563,15 @@ library Reservation {
             "Reservation is not active"
         );
 
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 redemptionRequestedAt = uint32(block.timestamp);
+
         if (self.redemptionWatchtower != address(0)) {
             require(
                 IRedemptionWatchtower(self.redemptionWatchtower)
-                    .isSafeRedemption(
-                        reservation.walletPubKeyHash,
-                        redeemerOutputScript,
+                    .isSafeReservedRedemption(
+                        reservationKey,
+                        redemptionRequestedAt,
                         self.reservationVault,
                         redeemer
                     ),
@@ -553,17 +583,9 @@ library Reservation {
 
         // Validate the redeemer output script is a correct standard type
         // (P2PKH, P2WPKH, P2SH or P2WSH), the same way `Redemption` does.
-        bytes memory redeemerOutputScriptPayload = redeemerOutputScriptMem
-            .extractHashAt(0, redeemerOutputScriptMem.length);
-        require(
-            redeemerOutputScriptPayload.length > 0,
-            "Redeemer output script must be a standard type"
-        );
-        require(
-            redeemerOutputScriptPayload.length != 20 ||
-                reservation.walletPubKeyHash !=
-                redeemerOutputScriptPayload.slice20(0),
-            "Redeemer output script must not point to the wallet PKH"
+        OutboundTx.validateRedeemerOutputScript(
+            redeemerOutputScriptMem,
+            reservation.walletPubKeyHash
         );
 
         reservation.state = ReservationState.RedemptionRequested;
@@ -571,8 +593,7 @@ library Reservation {
         reservation.redeemerOutputScriptHash = keccak256(
             redeemerOutputScriptMem
         );
-        /* solhint-disable-next-line not-rely-on-time */
-        reservation.redemptionRequestedAt = uint32(block.timestamp);
+        reservation.redemptionRequestedAt = redemptionRequestedAt;
         reservation.redemptionTxMaxFee = self.reservationTxMaxFee;
 
         // slither-disable-next-line reentrancy-events
@@ -624,10 +645,40 @@ library Reservation {
         ReservationRequest storage reservation = self.reservations[
             reservationKey
         ];
-        require(
-            reservation.state == ReservationState.RedemptionRequested,
-            "No pending reserved redemption"
-        );
+        if (reservation.state != ReservationState.RedemptionRequested) {
+            // The request already timed out or was vetoed and the redeemer
+            // was refunded there; acknowledge a late-arriving proof for the
+            // exact settled anchor spend without moving any further
+            // balance, mirroring the pooled redemption path's
+            // `timedOutRedemptions` mechanism.
+            BridgeState.ReservedRedemptionSettlement
+                storage settlement = self.reservedRedemptionSettlements[
+                    reservationKey
+                ];
+            require(settlement.pending, "No pending reserved redemption");
+
+            (
+                bytes32 outpointTxHash,
+                uint32 outpointIndex
+            ) = OutboundTx.parseWalletOutboundTxInput(
+                    redemptionTx.inputVector
+                );
+            require(
+                settlement.anchorTxHash == outpointTxHash &&
+                    outpointIndex == 0,
+                "Wrong settled anchor outpoint"
+            );
+
+            self.spentMainUTXOs[
+                _outpointKey(outpointTxHash, outpointIndex)
+            ] = true;
+
+            delete self.reservedRedemptionSettlements[reservationKey];
+
+            // slither-disable-next-line reentrancy-events
+            emit ReservedRedemptionSettled(reservationKey, redemptionTxHash);
+            return;
+        }
 
         consumeAnchor(self, reservation, redemptionTx.inputVector);
 
@@ -700,10 +751,21 @@ library Reservation {
                 reservation.redemptionRequestedAt + self.redemptionTimeout,
             "Redemption request has not timed out"
         );
-
         address redeemer = reservation.redeemer;
         uint64 refundAmount = reservation.mintedAmount;
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+
+        // Record a terminal settlement BEFORE clearing the reservation
+        // fields so a redemption proof that lands after this timeout can
+        // still be acknowledged and mark the anchor outpoint spent,
+        // mirroring the pooled redemption path's `timedOutRedemptions`
+        // mechanism.
+        self.reservedRedemptionSettlements[
+            reservationKey
+        ] = BridgeState.ReservedRedemptionSettlement({
+            pending: true,
+            anchorTxHash: reservation.anchorTxHash
+        });
 
         reservation.state = ReservationState.Active;
         reservation.redeemer = address(0);
@@ -712,8 +774,33 @@ library Reservation {
         reservation.redemptionTxMaxFee = 0;
 
         // Propagate timeout consequences to the wallet: slashing and state
-        // transition follow exactly the regular redemption timeout rules.
-        self.notifyWalletRedemptionTimeout(walletPubKeyHash, walletMembersIDs);
+        // transition follow the regular redemption timeout rules, but only
+        // when the wallet is in a state where slashing is possible (Live,
+        // MovingFunds, or Terminated). A wallet that already reached
+        // Closing or Closed cannot be slashed via this path -- skip the
+        // call instead of reverting so the refund below is never blocked
+        // by wallet state.
+        Wallets.WalletState walletState = self
+            .registeredWallets[walletPubKeyHash]
+            .state;
+        if (
+            walletState == Wallets.WalletState.Live ||
+            walletState == Wallets.WalletState.MovingFunds ||
+            walletState == Wallets.WalletState.Terminated
+        ) {
+            reservation.lastTimeoutWasWalletFault = true;
+            self.notifyWalletRedemptionTimeout(
+                walletPubKeyHash,
+                walletMembersIDs
+            );
+        } else {
+            reservation.lastTimeoutWasWalletFault = false;
+            // slither-disable-next-line reentrancy-events
+            emit ReservedRedemptionTimeoutSlashingSkipped(
+                reservationKey,
+                walletPubKeyHash
+            );
+        }
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionTimedOut(reservationKey, walletPubKeyHash);
@@ -753,11 +840,22 @@ library Reservation {
 
         uint64 detainedAmount = reservation.mintedAmount;
 
+        // Record a terminal settlement BEFORE clearing the reservation
+        // fields, mirroring the timeout path above, so a redemption proof
+        // that lands after this veto can still be acknowledged.
+        self.reservedRedemptionSettlements[
+            reservationKey
+        ] = BridgeState.ReservedRedemptionSettlement({
+            pending: true,
+            anchorTxHash: reservation.anchorTxHash
+        });
+
         reservation.state = ReservationState.Active;
         reservation.redeemer = address(0);
         reservation.redeemerOutputScriptHash = bytes32(0);
         reservation.redemptionRequestedAt = 0;
         reservation.redemptionTxMaxFee = 0;
+        reservation.lastTimeoutWasWalletFault = false;
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionVetoed(reservationKey);
@@ -786,6 +884,22 @@ library Reservation {
     ///      the custodying wallet can sign the anchor spend) and moving
     ///      reservations out must remain possible for wallets in any
     ///      lifecycle state.
+    ///
+    ///      Proof-type ambiguity: once the custody term plus grace period
+    ///      has elapsed, a single 1-input-1-output anchor spend can satisfy
+    ///      both this function's and `submitReservationDissolutionProof`'s
+    ///      output rules, and the `proofType` chosen by whichever party
+    ///      submits the SPV proof is the only discriminator between the
+    ///      two. Both entry points are reachable only through
+    ///      `Bridge.submitReservationProof`, gated to the same trusted,
+    ///      governance-controlled SPV maintainer role, so this is a
+    ///      maintainer-tooling correctness concern rather than an open
+    ///      exploit surface: the maintainer's tooling is responsible for
+    ///      choosing the `proofType` matching the wallet operator's actual
+    ///      intent. Submitting the wrong proof type either force-closes the
+    ///      reservation via dissolution or blocks an intended dissolution
+    ///      via re-anchor -- currently a trust assumption on the maintainer
+    ///      role, not an on-chain-enforced guarantee.
     function submitReservationReanchorProof(
         BridgeState.Storage storage self,
         BitcoinTx.Info calldata reanchorTx,
@@ -816,9 +930,12 @@ library Reservation {
 
         // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
         // consensus (the re-anchor output cannot exceed its input).
+        // Cache the reservation's current anchor value locally: it is
+        // read once here, then re-read when computing the cumulative
+        // re-anchor fee below. Using the local avoids a second SLOAD.
+        uint64 anchorAmount = reservation.anchorAmount;
         require(
-            reservation.anchorAmount - newAnchorAmount <=
-                self.reservationTxMaxFee,
+            anchorAmount - newAnchorAmount <= self.reservationTxMaxFee,
             "Transaction fee is too high"
         );
 
@@ -826,16 +943,26 @@ library Reservation {
         // per-transaction fee bound, keeping the anchor clear of dust and
         // preserving positive redemption value. This is deliberately a dust
         // floor rather than `reservationMinAmount`: a minimum-sized
-        // reservation must remain migratable (a `reservationMinAmount` floor
-        // combined with the proposal validator's positive-fee requirement
-        // would leave no compliant re-anchor for an exactly-minimum anchor,
-        // pinning a retiring wallet). Bounding cumulative Byzantine
-        // re-anchor grinding is deferred to the authorized-action model (an
-        // explicit migration request with nonce, owner/target authorization,
-        // and a cumulative fee budget), tracked as a follow-up.
+        // reservation must remain migratable.
         require(
             newAnchorAmount > self.reservationTxMaxFee,
             "Re-anchor amount below the dust floor"
+        );
+
+        // Cumulative re-anchor fee budget: cap the total satoshi a
+        // single reservation may lose across all re-anchor hops.
+        // Bounds Byzantine fee-grinding attacks that would otherwise
+        // split the cumulative loss into many hops each individually
+        // under `reservationTxMaxFee`. The `reservationTotalAmount`
+        // aggregate is intentionally NOT decremented on re-anchor:
+        // re-anchoring does not change `mintedAmount`, the gross claim
+        // that backs the reservation.
+        uint64 fee = anchorAmount - newAnchorAmount;
+        reservation.cumulativeReanchorFee += fee;
+        require(
+            reservation.cumulativeReanchorFee <=
+                self.maxCumulativeReanchorFee,
+            "Cumulative re-anchor fee budget exceeded"
         );
 
         bytes20 oldWalletPubKeyHash = reservation.walletPubKeyHash;
@@ -851,20 +978,10 @@ library Reservation {
             self.walletReservationsCount[newWalletPubKeyHash] = newCount;
         }
 
-        // The miner fee reduces the on-chain earmarked amount. The gross
-        // claim (`mintedAmount`) is unchanged; the accumulated in-kind fees
-        // are settled when the reservation is redeemed (full gross burn).
-        self.reservationTotalAmount -= (reservation.anchorAmount -
-            newAnchorAmount);
-
         reservation.walletPubKeyHash = newWalletPubKeyHash;
         reservation.anchorAmount = newAnchorAmount;
         reservation.anchorTxHash = reanchorTxHash;
         reservation.anchorTxOutputIndex = 0;
-
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
-        ] = reservationKey;
 
         emit ReservationReanchored(
             reservationKey,
@@ -876,9 +993,10 @@ library Reservation {
 
     /// @notice Used by the wallet to prove a dissolution transaction merging
     ///         an expired reservation's anchor outpoint into the wallet's
-    ///         main UTXO. After dissolution the owner's minted balance
-    ///         simply remains an ordinary pooled claim; no balances are
-    ///         moved or burned.
+    ///         main UTXO. Any accrued re-anchor fee loss (the gap between
+    ///         the original minted amount and the anchor's current value)
+    ///         is burned so backing reconciles exactly; the remaining
+    ///         anchor value rejoins the pool as an ordinary claim.
     /// @param dissolutionTx Bitcoin dissolution transaction data.
     /// @param dissolutionProof Bitcoin dissolution proof data.
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
@@ -896,6 +1014,26 @@ library Reservation {
     ///      - `dissolutionTx` must have a single P2(W)PKH output locking
     ///        funds back on the custodying wallet's public key hash; that
     ///        output becomes the wallet's new main UTXO.
+    ///
+    ///      Dissolution concurrency: dissolution proofs for multiple
+    ///      reservations on the same wallet must be submitted sequentially
+    ///      -- one at a time, each landing before the next is signed and
+    ///      submitted. If two dissolutions are signed off-chain assuming
+    ///      the same (e.g. zero) main UTXO, the first proof to land moves
+    ///      the wallet's `mainUtxoHash` forward and the second, now-stale
+    ///      transaction reverts on its input count instead of executing;
+    ///      it must be re-signed against the wallet's updated main UTXO.
+    ///      This is the same operational pattern already required by this
+    ///      codebase's MovingFunds sweep-input handling.
+    ///
+    ///      Proof-type ambiguity: see the matching note on
+    ///      `submitReservationReanchorProof` -- once the custody term plus
+    ///      grace period has elapsed, a single 1-input-1-output anchor
+    ///      spend can satisfy either function's output rules, and both are
+    ///      reachable only through the same trusted, governance-controlled
+    ///      SPV maintainer role via `Bridge.submitReservationProof`. This
+    ///      is a maintainer-tooling correctness concern, not an on-chain-
+    ///      enforced guarantee.
     ///
     ///      Note the Bridge cannot verify *when* the dissolution transaction
     ///      was signed. A wallet signing it before the grace period elapses
@@ -929,8 +1067,18 @@ library Reservation {
             "Reservation term or grace period not elapsed"
         );
 
+        // Cache the reservation's wallet identity: it is read here and
+        // again in the dissolution-output require and the
+        // `ReservationDissolved` event. `mintedAmount` and `anchorAmount`
+        // are each read exactly once below (computing the in-kind fee
+        // loss burned to reconcile the gross claim with the
+        // anchor-backed remainder rejoining the wallet's main UTXO) so
+        // they are read directly from storage there instead of adding
+        // more locals to an already stack-deep function.
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+
         Wallets.Wallet storage wallet = self.registeredWallets[
-            reservation.walletPubKeyHash
+            walletPubKeyHash
         ];
         {
             Wallets.WalletState walletState = wallet.state;
@@ -952,16 +1100,38 @@ library Reservation {
         bytes memory output = parseSingleOutput(dissolutionTx.outputVector);
         uint64 outputValue = output.extractValue();
         require(
-            self.extractPubKeyHash(output) == reservation.walletPubKeyHash,
+            self.extractPubKeyHash(output) == walletPubKeyHash,
             "Dissolution output must pay to the custodying wallet"
         );
+        // Dissolution is a 2-in-1-out spend (anchor + wallet main
+        // UTXO rolled into a new main UTXO) whose fee economics
+        // differ from the 1-in-1-out anchor / re-anchor / redemption
+        // shapes, so the cap is the dedicated
+        // `reservationDissolutionTxMaxFee` governance parameter rather
+        // than the shared `reservationTxMaxFee`.
         require(
-            inputsTotalValue - outputValue <= self.reservationTxMaxFee,
+            inputsTotalValue - outputValue <=
+                self.reservationDissolutionTxMaxFee,
             "Transaction fee is too high"
         );
 
-        // The dissolution output becomes the wallet's new main UTXO: the
-        // reserved backing rejoins the pooled supply.
+        // The dissolution output becomes the wallet's new main UTXO:
+        // the anchor-backed remainder of the reservation rejoins the
+        // pooled supply exactly at `anchorAmount`. The user's gross
+        // claim is `mintedAmount`; when re-anchor fees have shrunk
+        // the anchor (`mintedAmount > anchorAmount`), the in-kind
+        // loss (`mintedAmount - anchorAmount`) is no longer backing
+        // the user's claim and must be burned so the Bank supply
+        // matches the wallet's now-anchor-backed liability. The
+        // `reservationTotalAmount` aggregate is decremented inside
+        // `closeReservation` against the full `mintedAmount` and the
+        // backing that remains is precisely the anchor value rolled
+        // into the new main UTXO.
+        uint64 feeLossDelta = reservation.mintedAmount - reservation.anchorAmount;
+        if (feeLossDelta > 0) {
+            self.bank.decreaseBalance(feeLossDelta);
+        }
+
         wallet.mainUtxoHash = keccak256(
             abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
         );
@@ -970,7 +1140,7 @@ library Reservation {
 
         emit ReservationDissolved(
             reservationKey,
-            reservation.walletPubKeyHash,
+            walletPubKeyHash,
             dissolutionTxHash
         );
     }
@@ -978,6 +1148,16 @@ library Reservation {
     /// @notice Updates the reservation parameters, including the
     ///         reservation vault address. Deposits revealed with the
     ///         reservation vault address are treated as reserved deposits.
+    /// @param reservationDissolutionTxMaxFee New value of the dedicated
+    ///        cap on the BTC transaction fee for the 2-in-1-out
+    ///        dissolution shape; distinct from `reservationTxMaxFee`
+    ///        which caps the 1-in-1-out anchor / re-anchor / redemption
+    ///        shapes.
+    /// @param maxCumulativeReanchorFee New value of the per-reservation
+    ///        cap on the total satoshi that may be lost across all
+    ///        re-anchor hops of a single reservation. Bounds in-kind
+    ///        fee extraction by a Byzantine wallet performing many
+    ///        small re-anchors.
     /// @dev Requirements:
     ///      - Reservation transaction max fee must be greater than zero,
     ///      - Reservation minimum amount must be greater than the
@@ -990,10 +1170,12 @@ library Reservation {
         address reservationVault,
         uint64 reservationMinAmount,
         uint64 reservationTxMaxFee,
+        uint64 reservationDissolutionTxMaxFee,
         uint32 reservationTermSeconds,
         uint32 reservationGracePeriod,
         uint64 reservationMaxTotalAmount,
-        uint32 maxReservationsPerWallet
+        uint32 maxReservationsPerWallet,
+        uint64 maxCumulativeReanchorFee
     ) external {
         require(
             reservationTxMaxFee > 0,
@@ -1019,18 +1201,22 @@ library Reservation {
 
         self.reservationMinAmount = reservationMinAmount;
         self.reservationTxMaxFee = reservationTxMaxFee;
+        self.reservationDissolutionTxMaxFee = reservationDissolutionTxMaxFee;
         self.reservationTermSeconds = reservationTermSeconds;
         self.reservationGracePeriod = reservationGracePeriod;
         self.reservationMaxTotalAmount = reservationMaxTotalAmount;
         self.maxReservationsPerWallet = maxReservationsPerWallet;
+        self.maxCumulativeReanchorFee = maxCumulativeReanchorFee;
 
         emit ReservationParametersUpdated(
             reservationMinAmount,
             reservationTxMaxFee,
+            reservationDissolutionTxMaxFee,
             reservationTermSeconds,
             reservationGracePeriod,
             reservationMaxTotalAmount,
-            maxReservationsPerWallet
+            maxReservationsPerWallet,
+            maxCumulativeReanchorFee
         );
     }
 
@@ -1048,6 +1234,17 @@ library Reservation {
         );
 
         output = outputVector.extractOutputAtIndex(0);
+    }
+
+    /// @notice Derives the `spentMainUTXOs`/deposit-key mapping key for a
+    ///         Bitcoin outpoint, shared by every call site that hashes a
+    ///         transaction hash and output index pair this way.
+    function _outpointKey(bytes32 txHash, uint32 outputIndex)
+        internal
+        pure
+        returns (uint256)
+    {
+        return uint256(keccak256(abi.encodePacked(txHash, outputIndex)));
     }
 
     /// @notice Asserts the given input vector contains exactly one input
@@ -1069,16 +1266,13 @@ library Reservation {
             "Transaction input must point to the reservation anchor"
         );
 
-        uint256 anchorUtxoKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
+        uint256 anchorUtxoKey = _outpointKey(outpointTxHash, outpointIndex);
 
         // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
         // anchor in `spentMainUTXOs` -- the existing registry of honestly
         // spent wallet UTXOs -- makes the spend recognized by
         // `Fraud.defeatFraudChallenge` without modifying the fraud library.
         self.spentMainUTXOs[anchorUtxoKey] = true;
-        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
     }
 
     /// @notice Processes the dissolution transaction inputs: the first
@@ -1153,12 +1347,9 @@ library Reservation {
             "Transaction input must point to the reservation anchor"
         );
 
-        uint256 anchorUtxoKey = uint256(
-            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
-        );
+        uint256 anchorUtxoKey = _outpointKey(outpointTxHash, outpointIndex);
         // See `consumeAnchor` for the `spentMainUTXOs` rationale.
         self.spentMainUTXOs[anchorUtxoKey] = true;
-        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
 
         nextInputIndex =
             inputStartingIndex +
@@ -1187,19 +1378,30 @@ library Reservation {
         );
 
         self.spentMainUTXOs[
-            uint256(keccak256(abi.encodePacked(outpointTxHash, outpointIndex)))
+            _outpointKey(outpointTxHash, outpointIndex)
         ] = true;
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count
     ///         and the total reserved amount, and marks the reservation as
     ///         Closed.
+    /// @dev `reservationTotalAmount` aggregates the sum of gross
+    ///      `mintedAmount` over Active reservations -- not the shrinking
+    ///      per-reservation `anchorAmount` -- so the cap tracks the
+    ///      bridge's true gross liability.
     function closeReservation(
         BridgeState.Storage storage self,
         ReservationRequest storage reservation
     ) internal {
-        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
-        self.reservationTotalAmount -= reservation.anchorAmount;
+        // Cache the wallet identity and the gross claim at first
+        // read: `mintedAmount` is the value the aggregate
+        // `reservationTotalAmount` is decremented by -- it
+        // represents the reservation's gross claim on the bridge
+        // supply, which is constant across re-anchor hops.
+        bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
+        uint64 mintedAmount = reservation.mintedAmount;
+        self.walletReservationsCount[walletPubKeyHash] -= 1;
+        self.reservationTotalAmount -= mintedAmount;
         reservation.state = ReservationState.Closed;
     }
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -141,10 +141,10 @@ library Reservation {
         // re-anchors.
         uint64 cumulativeReanchorFee;
         // Set true when the most recent reserved redemption timeout
-        // slashed the custodying wallet (it was Live, MovingFunds, or
-        // Terminated); set false when slashing was skipped (wallet
-        // already Closing/Closed) or the most recent resolution was a
-        // veto rather than a timeout. Read by
+        // actually slashed the custodying wallet (it was Live or
+        // MovingFunds); set false when slashing was skipped (wallet
+        // already Terminated, Closing, or Closed) or the most recent
+        // resolution was a veto rather than a timeout. Read by
         // `ReservationVault.retryRedeemReservation` to confirm the prior
         // request specifically ended in a wallet-fault timeout before
         // waiving the redemption fee -- without this gate an owner could
@@ -377,6 +377,14 @@ library Reservation {
     ///         deposit as swept blocks any future regular sweep, prevents
     ///         double acceptance, and makes the deposit outpoint recognized
     ///         as correctly spent by the fraud challenge defeat path.
+    /// @dev Does not re-check the deposit's revealed `vault` against the
+    ///      current `self.reservationVault`: the reveal-time
+    ///      classification in `pendingReservedDeposit` is what gates
+    ///      reservation treatment. If governance changes the reservation
+    ///      vault between reveal and acceptance, this deposit is still
+    ///      accepted and its credit is routed through the *current*
+    ///      vault (see `submitReservationAcceptanceProof`), not the one
+    ///      set at reveal time.
     /// @return reservationKey The deposit key of the reserved deposit, used
     ///         as the reservation key.
     function resolveAcceptedDeposit(
@@ -420,9 +428,8 @@ library Reservation {
         );
     }
 
-    /// @notice Registers a new reservation: checks and adjusts the caps,
-    ///         stores the reservation record and indexes the anchor
-    ///         outpoint.
+    /// @notice Registers a new reservation: checks and adjusts the caps
+    ///         and stores the reservation record.
     function registerReservation(
         BridgeState.Storage storage self,
         uint256 reservationKey,
@@ -581,8 +588,6 @@ library Reservation {
 
         bytes memory redeemerOutputScriptMem = redeemerOutputScript;
 
-        // Validate the redeemer output script is a correct standard type
-        // (P2PKH, P2WPKH, P2SH or P2WSH), the same way `Redemption` does.
         OutboundTx.validateRedeemerOutputScript(
             redeemerOutputScriptMem,
             reservation.walletPubKeyHash
@@ -650,12 +655,30 @@ library Reservation {
             // was refunded there; acknowledge a late-arriving proof for the
             // exact settled anchor spend without moving any further
             // balance, mirroring the pooled redemption path's
-            // `timedOutRedemptions` mechanism.
+            // `timedOutRedemptions` mechanism. The reservation itself is
+            // terminalized here (closed) since the anchor this proof
+            // proves is now provably spent and can never be re-anchored or
+            // dissolved again.
             BridgeState.ReservedRedemptionSettlement
                 storage settlement = self.reservedRedemptionSettlements[
                     reservationKey
                 ];
-            require(settlement.pending, "No pending reserved redemption");
+            require(
+                settlement.anchorTxHash != bytes32(0),
+                "No settled reserved redemption"
+            );
+
+            // The reservation may have been re-anchored since the
+            // settlement was recorded (a timeout/veto returns it to
+            // Active, which permits re-anchoring). If so, the anchor
+            // this settlement refers to is no longer the reservation's
+            // current position -- the reservation has since moved on to
+            // a live, unsettled anchor that must go through its own
+            // redemption or dissolution, not be force-closed here.
+            require(
+                reservation.anchorTxHash == settlement.anchorTxHash,
+                "Reservation anchor no longer matches the settlement"
+            );
 
             (
                 bytes32 outpointTxHash,
@@ -669,11 +692,21 @@ library Reservation {
                 "Wrong settled anchor outpoint"
             );
 
+            bytes memory settlementOutput = parseSingleOutput(
+                redemptionTx.outputVector
+            );
+            require(
+                keccak256(
+                    settlementOutput.slice(8, settlementOutput.length - 8)
+                ) == settlement.redeemerOutputScriptHash,
+                "Output does not pay the settled redeemer script"
+            );
+
             self.spentMainUTXOs[
                 _outpointKey(outpointTxHash, outpointIndex)
             ] = true;
 
-            delete self.reservedRedemptionSettlements[reservationKey];
+            closeReservation(self, reservation, reservationKey);
 
             // slither-disable-next-line reentrancy-events
             emit ReservedRedemptionSettled(reservationKey, redemptionTxHash);
@@ -709,7 +742,7 @@ library Reservation {
             "Output value is not within the acceptable range"
         );
 
-        closeReservation(self, reservation);
+        closeReservation(self, reservation, reservationKey);
 
         // slither-disable-next-line reentrancy-events
         emit ReservedRedemptionCompleted(reservationKey, redemptionTxHash);
@@ -763,8 +796,8 @@ library Reservation {
         self.reservedRedemptionSettlements[
             reservationKey
         ] = BridgeState.ReservedRedemptionSettlement({
-            pending: true,
-            anchorTxHash: reservation.anchorTxHash
+            anchorTxHash: reservation.anchorTxHash,
+            redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
         });
 
         reservation.state = ReservationState.Active;
@@ -775,18 +808,17 @@ library Reservation {
 
         // Propagate timeout consequences to the wallet: slashing and state
         // transition follow the regular redemption timeout rules, but only
-        // when the wallet is in a state where slashing is possible (Live,
-        // MovingFunds, or Terminated). A wallet that already reached
-        // Closing or Closed cannot be slashed via this path -- skip the
-        // call instead of reverting so the refund below is never blocked
-        // by wallet state.
+        // when the wallet is actually slashable (Live or MovingFunds). A
+        // wallet that already reached Terminated, Closing, or Closed
+        // cannot be slashed via this path -- skip the call instead of
+        // reverting so the refund below is never blocked by wallet
+        // state.
         Wallets.WalletState walletState = self
             .registeredWallets[walletPubKeyHash]
             .state;
         if (
             walletState == Wallets.WalletState.Live ||
-            walletState == Wallets.WalletState.MovingFunds ||
-            walletState == Wallets.WalletState.Terminated
+            walletState == Wallets.WalletState.MovingFunds
         ) {
             reservation.lastTimeoutWasWalletFault = true;
             self.notifyWalletRedemptionTimeout(
@@ -846,8 +878,8 @@ library Reservation {
         self.reservedRedemptionSettlements[
             reservationKey
         ] = BridgeState.ReservedRedemptionSettlement({
-            pending: true,
-            anchorTxHash: reservation.anchorTxHash
+            anchorTxHash: reservation.anchorTxHash,
+            redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
         });
 
         reservation.state = ReservationState.Active;
@@ -993,10 +1025,12 @@ library Reservation {
 
     /// @notice Used by the wallet to prove a dissolution transaction merging
     ///         an expired reservation's anchor outpoint into the wallet's
-    ///         main UTXO. Any accrued re-anchor fee loss (the gap between
-    ///         the original minted amount and the anchor's current value)
-    ///         is burned so backing reconciles exactly; the remaining
-    ///         anchor value rejoins the pool as an ordinary claim.
+    ///         main UTXO. The anchor value rejoins the pool as an ordinary
+    ///         claim; any accrued re-anchor fee loss (the gap between the
+    ///         original minted amount and the anchor's current value) is
+    ///         simply not reconciled -- see the inline comment preceding
+    ///         the `closeReservation` call in this function's body for
+    ///         why no Bank balance is burned.
     /// @param dissolutionTx Bitcoin dissolution transaction data.
     /// @param dissolutionProof Bitcoin dissolution proof data.
     /// @param mainUtxo Data of the wallet's main UTXO, as currently known on
@@ -1103,10 +1137,11 @@ library Reservation {
             self.extractPubKeyHash(output) == walletPubKeyHash,
             "Dissolution output must pay to the custodying wallet"
         );
-        // Dissolution is a 2-in-1-out spend (anchor + wallet main
-        // UTXO rolled into a new main UTXO) whose fee economics
-        // differ from the 1-in-1-out anchor / re-anchor / redemption
-        // shapes, so the cap is the dedicated
+        // Dissolution is usually a 2-in-1-out spend (anchor + wallet
+        // main UTXO rolled into a new main UTXO), or 1-in-1-out when
+        // the wallet has no main UTXO yet; either shape's fee economics
+        // differ from the always-1-in-1-out anchor / re-anchor /
+        // redemption shapes, so the cap is the dedicated
         // `reservationDissolutionTxMaxFee` governance parameter rather
         // than the shared `reservationTxMaxFee`.
         require(
@@ -1115,28 +1150,24 @@ library Reservation {
             "Transaction fee is too high"
         );
 
-        // The dissolution output becomes the wallet's new main UTXO:
-        // the anchor-backed remainder of the reservation rejoins the
-        // pooled supply exactly at `anchorAmount`. The user's gross
-        // claim is `mintedAmount`; when re-anchor fees have shrunk
-        // the anchor (`mintedAmount > anchorAmount`), the in-kind
-        // loss (`mintedAmount - anchorAmount`) is no longer backing
-        // the user's claim and must be burned so the Bank supply
-        // matches the wallet's now-anchor-backed liability. The
-        // `reservationTotalAmount` aggregate is decremented inside
-        // `closeReservation` against the full `mintedAmount` and the
-        // backing that remains is precisely the anchor value rolled
-        // into the new main UTXO.
-        uint64 feeLossDelta = reservation.mintedAmount - reservation.anchorAmount;
-        if (feeLossDelta > 0) {
-            self.bank.decreaseBalance(feeLossDelta);
-        }
+        // The dissolution output becomes the wallet's new main UTXO,
+        // carrying forward exactly `anchorAmount` (the on-chain-backed
+        // remainder after any re-anchor fees). No Bank balance is burned
+        // here: the Bridge itself holds no balance attributable to a
+        // dissolving reservation to burn against -- the owner's full
+        // `mintedAmount` claim was minted out through the reservation
+        // vault at acceptance time and stays with the owner regardless
+        // of later re-anchor fee loss. Reconciling that fee loss against
+        // the pool, if ever desired, requires a separate mechanism that
+        // first obtains the shortfall from the owner; it is not handled
+        // here. The `reservationTotalAmount` aggregate is decremented
+        // inside `closeReservation` against the full `mintedAmount`.
 
         wallet.mainUtxoHash = keccak256(
             abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
         );
 
-        closeReservation(self, reservation);
+        closeReservation(self, reservation, reservationKey);
 
         emit ReservationDissolved(
             reservationKey,
@@ -1149,9 +1180,10 @@ library Reservation {
     ///         reservation vault address. Deposits revealed with the
     ///         reservation vault address are treated as reserved deposits.
     /// @param reservationDissolutionTxMaxFee New value of the dedicated
-    ///        cap on the BTC transaction fee for the 2-in-1-out
-    ///        dissolution shape; distinct from `reservationTxMaxFee`
-    ///        which caps the 1-in-1-out anchor / re-anchor / redemption
+    ///        cap on the BTC transaction fee for the dissolution shape
+    ///        (usually 2-in-1-out; 1-in-1-out when the wallet has no
+    ///        main UTXO yet); distinct from `reservationTxMaxFee` which
+    ///        caps the always-1-in-1-out anchor / re-anchor / redemption
     ///        shapes.
     /// @param maxCumulativeReanchorFee New value of the per-reservation
     ///        cap on the total satoshi that may be lost across all
@@ -1182,12 +1214,20 @@ library Reservation {
             "Reservation transaction max fee must be greater than zero"
         );
         require(
+            reservationDissolutionTxMaxFee > 0,
+            "Reservation dissolution transaction max fee must be greater than zero"
+        );
+        require(
             reservationMinAmount > reservationTxMaxFee,
             "Reservation minimum amount must be greater than the reservation TX max fee"
         );
         require(
             reservationTermSeconds > 0,
             "Reservation term must be greater than zero"
+        );
+        require(
+            maxCumulativeReanchorFee > 0,
+            "Max cumulative re-anchor fee must be greater than zero"
         );
 
         if (reservationVault != self.reservationVault) {
@@ -1383,25 +1423,24 @@ library Reservation {
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count
-    ///         and the total reserved amount, and marks the reservation as
-    ///         Closed.
+    ///         and the total reserved amount, marks the reservation as
+    ///         Closed, and clears any terminal settlement record left by
+    ///         a prior timeout or veto so it cannot outlive the request
+    ///         generation that created it.
     /// @dev `reservationTotalAmount` aggregates the sum of gross
     ///      `mintedAmount` over Active reservations -- not the shrinking
     ///      per-reservation `anchorAmount` -- so the cap tracks the
     ///      bridge's true gross liability.
     function closeReservation(
         BridgeState.Storage storage self,
-        ReservationRequest storage reservation
+        ReservationRequest storage reservation,
+        uint256 reservationKey
     ) internal {
-        // Cache the wallet identity and the gross claim at first
-        // read: `mintedAmount` is the value the aggregate
-        // `reservationTotalAmount` is decremented by -- it
-        // represents the reservation's gross claim on the bridge
-        // supply, which is constant across re-anchor hops.
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
         uint64 mintedAmount = reservation.mintedAmount;
         self.walletReservationsCount[walletPubKeyHash] -= 1;
         self.reservationTotalAmount -= mintedAmount;
         reservation.state = ReservationState.Closed;
+        delete self.reservedRedemptionSettlements[reservationKey];
     }
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -214,10 +214,20 @@ library Reservation {
         uint64 newAnchorAmount
     );
 
+    // Fee-loss decomposition for off-chain accounting: `mintedAmount` is
+    // the gross claim that stays with the owner, `anchorAmount` is the
+    // anchor's value entering this dissolution, and `dissolutionFee` is
+    // the Bitcoin fee this transaction paid. The unreconciled shortfall
+    // is `mintedAmount - anchorAmount + dissolutionFee` -- see the
+    // comment preceding the `closeReservation` call in
+    // `submitReservationDissolutionProof` for why nothing is burned.
     event ReservationDissolved(
         uint256 indexed reservationKey,
         bytes20 indexed walletPubKeyHash,
-        bytes32 dissolutionTxHash
+        bytes32 dissolutionTxHash,
+        uint64 mintedAmount,
+        uint64 anchorAmount,
+        uint64 dissolutionFee
     );
 
     event ReservationParametersUpdated(
@@ -1091,14 +1101,12 @@ library Reservation {
             "Reservation term or grace period not elapsed"
         );
 
-        // Cache the reservation's wallet identity: it is read here and
-        // again in the dissolution-output require and the
-        // `ReservationDissolved` event. `mintedAmount` and `anchorAmount`
-        // are each read exactly once below (computing the in-kind fee
-        // loss burned to reconcile the gross claim with the
-        // anchor-backed remainder rejoining the wallet's main UTXO) so
-        // they are read directly from storage there instead of adding
-        // more locals to an already stack-deep function.
+        // Cache the reservation's wallet identity: it is read here, again
+        // in the dissolution-output require, and in the
+        // `ReservationDissolved` event. The claim/backing pair
+        // (`mintedAmount`, `anchorAmount`) is read straight from storage
+        // in the event below rather than into locals -- this function is
+        // already at the stack limit.
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
 
         Wallets.Wallet storage wallet = self.registeredWallets[
@@ -1141,29 +1149,39 @@ library Reservation {
         );
 
         // The dissolution output becomes the wallet's new main UTXO,
-        // carrying forward exactly `anchorAmount` (the on-chain-backed
-        // remainder after any re-anchor fees). No Bank balance is burned
-        // here: the Bridge itself holds no balance attributable to a
-        // dissolving reservation to burn against -- the owner's full
-        // `mintedAmount` claim was minted out through the reservation
-        // vault at acceptance time and stays with the owner regardless
-        // of later re-anchor fee loss. Reconciling that fee loss against
-        // the pool, if ever desired, requires a separate mechanism that
-        // first obtains the shortfall from the owner; it is not handled
-        // here. The `reservationTotalAmount` aggregate is decremented
-        // inside `closeReservation` against the full `mintedAmount`.
+        // rolling the anchor's remaining value (after any re-anchor fees)
+        // together with the previous main UTXO, less this transaction's
+        // fee. No Bank balance is burned here: the Bridge itself holds no
+        // balance attributable to a dissolving reservation to burn
+        // against -- the owner's full `mintedAmount` claim was minted out
+        // through the reservation vault at acceptance time and stays with
+        // the owner regardless of later re-anchor fee loss. Reconciling
+        // that fee loss against the pool, if ever desired, requires a
+        // separate mechanism that first obtains the shortfall from the
+        // owner; it is not handled here. This mirrors the way
+        // `movingFundsTxMaxTotalFee` leaves wallet-migration fees
+        // pool-socialized rather than charging individual depositors. The
+        // `reservationTotalAmount` aggregate is decremented inside
+        // `closeReservation` against the full `mintedAmount`, and
+        // `ReservationDissolved` emits the fee-loss decomposition so the
+        // shortfall stays observable off-chain.
 
         wallet.mainUtxoHash = keccak256(
             abi.encodePacked(dissolutionTxHash, uint32(0), outputValue)
         );
 
-        closeReservation(self, reservation, reservationKey);
-
+        // Emitted before `closeReservation` so the claim/backing pair is
+        // read while the reservation record is still intact.
         emit ReservationDissolved(
             reservationKey,
             walletPubKeyHash,
-            dissolutionTxHash
+            dissolutionTxHash,
+            reservation.mintedAmount,
+            reservation.anchorAmount,
+            inputsTotalValue - outputValue
         );
+
+        closeReservation(self, reservation, reservationKey);
     }
 
     /// @notice Updates the reservation parameters, including the

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -659,10 +659,8 @@ library Reservation {
             // terminalized here (closed) since the anchor this proof
             // proves is now provably spent and can never be re-anchored or
             // dissolved again.
-            BridgeState.ReservedRedemptionSettlement
-                storage settlement = self.reservedRedemptionSettlements[
-                    reservationKey
-                ];
+            BridgeState.ReservedRedemptionSettlement storage settlement = self
+                .reservedRedemptionSettlements[reservationKey];
             require(
                 settlement.anchorTxHash != bytes32(0),
                 "No settled reserved redemption"
@@ -680,15 +678,10 @@ library Reservation {
                 "Reservation anchor no longer matches the settlement"
             );
 
-            (
-                bytes32 outpointTxHash,
-                uint32 outpointIndex
-            ) = OutboundTx.parseWalletOutboundTxInput(
-                    redemptionTx.inputVector
-                );
+            (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+                .parseWalletOutboundTxInput(redemptionTx.inputVector);
             require(
-                settlement.anchorTxHash == outpointTxHash &&
-                    outpointIndex == 0,
+                settlement.anchorTxHash == outpointTxHash && outpointIndex == 0,
                 "Wrong settled anchor outpoint"
             );
 
@@ -793,12 +786,11 @@ library Reservation {
         // still be acknowledged and mark the anchor outpoint spent,
         // mirroring the pooled redemption path's `timedOutRedemptions`
         // mechanism.
-        self.reservedRedemptionSettlements[
-            reservationKey
-        ] = BridgeState.ReservedRedemptionSettlement({
-            anchorTxHash: reservation.anchorTxHash,
-            redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
-        });
+        self.reservedRedemptionSettlements[reservationKey] = BridgeState
+            .ReservedRedemptionSettlement({
+                anchorTxHash: reservation.anchorTxHash,
+                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
+            });
 
         reservation.state = ReservationState.Active;
         reservation.redeemer = address(0);
@@ -875,12 +867,11 @@ library Reservation {
         // Record a terminal settlement BEFORE clearing the reservation
         // fields, mirroring the timeout path above, so a redemption proof
         // that lands after this veto can still be acknowledged.
-        self.reservedRedemptionSettlements[
-            reservationKey
-        ] = BridgeState.ReservedRedemptionSettlement({
-            anchorTxHash: reservation.anchorTxHash,
-            redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
-        });
+        self.reservedRedemptionSettlements[reservationKey] = BridgeState
+            .ReservedRedemptionSettlement({
+                anchorTxHash: reservation.anchorTxHash,
+                redeemerOutputScriptHash: reservation.redeemerOutputScriptHash
+            });
 
         reservation.state = ReservationState.Active;
         reservation.redeemer = address(0);
@@ -992,8 +983,7 @@ library Reservation {
         uint64 fee = anchorAmount - newAnchorAmount;
         reservation.cumulativeReanchorFee += fee;
         require(
-            reservation.cumulativeReanchorFee <=
-                self.maxCumulativeReanchorFee,
+            reservation.cumulativeReanchorFee <= self.maxCumulativeReanchorFee,
             "Cumulative re-anchor fee budget exceeded"
         );
 
@@ -1417,9 +1407,7 @@ library Reservation {
             "Transaction input must point to the wallet's main UTXO"
         );
 
-        self.spentMainUTXOs[
-            _outpointKey(outpointTxHash, outpointIndex)
-        ] = true;
+        self.spentMainUTXOs[_outpointKey(outpointTxHash, outpointIndex)] = true;
     }
 
     /// @notice Closes a reservation: adjusts the wallet reservation count

--- a/solidity/contracts/bridge/WalletProposalValidator.sol
+++ b/solidity/contracts/bridge/WalletProposalValidator.sol
@@ -980,6 +980,8 @@ contract WalletProposalValidator {
             ,
             ,
             ,
+            ,
+            ,
 
         ) = bridge.reservationParameters();
 
@@ -1166,7 +1168,7 @@ contract WalletProposalValidator {
             "Target wallet must be in Live state"
         );
 
-        (, , uint64 reservationTxMaxFee, , , , , ) = bridge
+        (, , uint64 reservationTxMaxFee, , , , , , , ) = bridge
             .reservationParameters();
         require(
             proposal.reanchorTxFee > 0,
@@ -1211,9 +1213,11 @@ contract WalletProposalValidator {
         (
             ,
             ,
-            uint64 reservationTxMaxFee,
+            ,
+            uint64 reservationDissolutionTxMaxFee,
             ,
             uint32 reservationGracePeriod,
+            ,
             ,
             ,
 
@@ -1231,7 +1235,7 @@ contract WalletProposalValidator {
             "Proposed transaction fee cannot be zero"
         );
         require(
-            proposal.dissolutionTxFee <= reservationTxMaxFee,
+            proposal.dissolutionTxFee <= reservationDissolutionTxMaxFee,
             "Proposed transaction fee is too high"
         );
 

--- a/solidity/contracts/test/BridgeStub.sol
+++ b/solidity/contracts/test/BridgeStub.sol
@@ -16,17 +16,7 @@ contract BridgeStub is Bridge {
     ) external {
         self.reservations[reservationKey] = reservation;
         self.walletReservationsCount[reservation.walletPubKeyHash] += 1;
-        self.reservationTotalAmount += reservation.anchorAmount;
-        self.reservationsByAnchorUtxo[
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        reservation.anchorTxHash,
-                        reservation.anchorTxOutputIndex
-                    )
-                )
-            )
-        ] = reservationKey;
+        self.reservationTotalAmount += reservation.mintedAmount;
     }
 
     function setSweptDeposits(BitcoinTx.UTXO[] calldata utxos) external {

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -415,7 +415,6 @@ contract ReservationVault is IVault, Ownable {
         );
     }
 
-
     /// @notice Updates the vault fee parameters.
     /// @dev Requirements:
     ///      - The caller must be the vault owner (governance),

--- a/solidity/contracts/vault/ReservationVault.sol
+++ b/solidity/contracts/vault/ReservationVault.sol
@@ -69,7 +69,13 @@ interface IReservationBridge {
 ///         `updateReservationParameters`.
 /// @dev The vault deliberately keeps no claim registry of its own -- the
 ///      Bridge's reservation records are the single source of truth and are
-///      consulted for ownership checks.
+///      consulted for ownership checks. A reservation's `owner` is set once
+///      at acceptance and has no reassignment path anywhere in the Bridge
+///      or this vault: reservation positions are deliberately
+///      non-transferable, even though the TBTC minted against a reservation
+///      is freely transferable. Key rotation or entity restructuring on the
+///      owner side therefore requires redeeming and re-establishing the
+///      reservation rather than transferring it directly.
 contract ReservationVault is IVault, Ownable {
     using SafeERC20 for IERC20;
 
@@ -176,6 +182,18 @@ contract ReservationVault is IVault, Ownable {
     ///      created against the reservation equals the sats earmarked
     ///      on-chain; the fee is an explicit transfer, never a netted
     ///      credit.
+    ///
+    ///      Known limitation: this function cannot distinguish an
+    ///      acceptance credit from an ordinary pooled sweep credit. A
+    ///      deposit revealed to this vault's address before a vault swap,
+    ///      or after this vault is de-designated but still trusted by the
+    ///      Bridge, lands here as an ordinary multi-depositor credit and
+    ///      is charged the initiation fee for what is really a pooled
+    ///      deposit with no reservation record. This is accepted current
+    ///      behavior (see the reveal-time classification tests) -- fixing
+    ///      it properly requires the Bridge to pass an explicit
+    ///      discriminator through the shared `IVault.receiveBalanceIncrease`
+    ///      interface, a change affecting every vault, not just this one.
     function receiveBalanceIncrease(
         address[] calldata depositors,
         uint256[] calldata depositedAmounts
@@ -214,6 +232,23 @@ contract ReservationVault is IVault, Ownable {
         }
     }
 
+    /// @notice Fetches a reservation and validates the caller owns it.
+    /// @param reservationKey The key of the reservation.
+    /// @return reservation The validated reservation struct.
+    /// @dev Requirements:
+    ///      - The caller must be the reservation owner.
+    function _ownedReservation(uint256 reservationKey)
+        internal
+        view
+        returns (Reservation.ReservationRequest memory reservation)
+    {
+        reservation = bridge.reservations(reservationKey);
+        require(
+            reservation.owner == msg.sender,
+            "Caller is not the reservation owner"
+        );
+    }
+
     /// @notice Requests an in-kind redemption of the caller's reservation.
     ///         The caller surrenders the gross minted TBTC amount plus the
     ///         redemption fee; the vault unmints the gross amount and asks
@@ -240,12 +275,8 @@ contract ReservationVault is IVault, Ownable {
         bytes calldata redeemerOutputScript,
         uint256 maxFeeTbtc
     ) external {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
+        Reservation.ReservationRequest memory reservation = _ownedReservation(
             reservationKey
-        );
-        require(
-            reservation.owner == msg.sender,
-            "Caller is not the reservation owner"
         );
 
         uint256 grossTbtc = uint256(reservation.mintedAmount) *
@@ -286,22 +317,24 @@ contract ReservationVault is IVault, Ownable {
     /// @notice Extends the custody term of the caller's reservation by one
     ///         term length, charging the extension fee in TBTC.
     /// @param reservationKey The key of the reservation to extend.
+    /// @param maxFeeTbtc Upper bound on the TBTC fee the caller accepts; an
+    ///        unexpected fee update reverts instead of overcharging.
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
+    ///      - The fee must not exceed `maxFeeTbtc`,
     ///      - The caller must have approved this vault for the extension
     ///        fee in TBTC.
-    function extendCustody(uint256 reservationKey) external {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
+    function extendCustody(uint256 reservationKey, uint256 maxFeeTbtc)
+        external
+    {
+        Reservation.ReservationRequest memory reservation = _ownedReservation(
             reservationKey
-        );
-        require(
-            reservation.owner == msg.sender,
-            "Caller is not the reservation owner"
         );
 
         uint256 fee = (uint256(reservation.mintedAmount) *
             SATOSHI_MULTIPLIER *
             extensionFeeBps) / BASIS_POINTS;
+        require(fee <= maxFeeTbtc, "Fee exceeds the caller's bound");
         if (fee > 0) {
             IERC20(tbtcToken).safeTransferFrom(
                 msg.sender,
@@ -326,6 +359,13 @@ contract ReservationVault is IVault, Ownable {
     ///        script (P2PKH, P2WPKH, P2SH or P2WSH).
     /// @dev Requirements:
     ///      - The caller must be the reservation owner,
+    ///      - The reservation's most recent reserved redemption timeout
+    ///        must specifically have been caused by wallet fault (the
+    ///        Bridge's `lastTimeoutWasWalletFault` marker) -- otherwise
+    ///        this path would let an owner use it as an ordinary
+    ///        fee-free first redemption, or grief wallet operators for
+    ///        free by repeatedly requesting, waiting out the timeout
+    ///        (slashing the wallet), and retrying,
     ///      - The caller must have approved this vault in the Bank for the
     ///        gross minted amount (`Bank.approveBalance`).
     ///
@@ -337,12 +377,12 @@ contract ReservationVault is IVault, Ownable {
         uint256 reservationKey,
         bytes calldata redeemerOutputScript
     ) external {
-        Reservation.ReservationRequest memory reservation = bridge.reservations(
+        Reservation.ReservationRequest memory reservation = _ownedReservation(
             reservationKey
         );
         require(
-            reservation.owner == msg.sender,
-            "Caller is not the reservation owner"
+            reservation.lastTimeoutWasWalletFault,
+            "Previous request did not time out through wallet fault"
         );
 
         uint256 grossTbtc = uint256(reservation.mintedAmount) *
@@ -374,6 +414,7 @@ contract ReservationVault is IVault, Ownable {
             redeemerOutputScript
         );
     }
+
 
     /// @notice Updates the vault fee parameters.
     /// @dev Requirements:

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -86,8 +86,7 @@ const config: HardhatUserConfig = {
       // hot paths is 0-8 gas (noise); runs=100-vs-90 is smaller still.
       // DRAFT NOTE: the durable alternative is a router-style refactor
       // moving entry points out of the Bridge (as done on the P2TR
-      // activation track) -- see the blocking-dependency note on
-      // `Bridge.submitReservationProof`.
+      // activation track).
       "contracts/bridge/Bridge.sol": {
         version: "0.8.17",
         settings: {

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -75,19 +75,25 @@ const config: HardhatUserConfig = {
       "contracts/bridge/BridgeGovernance.sol": bridgeGovernanceCompilerConfig,
       // Reduce the number of optimizer runs to preserve the Bridge's
       // EIP-170 deployment margin after adding the reservation entry
-      // points. The runtime-gas cost of this is effectively nil: the Bridge
-      // is a thin dispatch shell over linked libraries (Deposit,
-      // DepositSweep, Redemption, Reservation) that stay at runs=1000, so a
-      // measured runs=1000-vs-100 diff over the deposit/redemption/
-      // reservation hot paths is 0-8 gas (noise). DRAFT NOTE: the durable
-      // alternative is a router-style refactor moving entry points out of
-      // the Bridge (as done on the P2TR activation track).
+      // points. Further reduced from 100 to 90 after the reserved
+      // redemption timeout/veto correctness fixes (settlement records,
+      // wallet-state-independent refund) grew the `reservations()`
+      // getter's struct-copy bytecode past the 100-runs margin. The
+      // runtime-gas cost of this is effectively nil: the Bridge is a
+      // thin dispatch shell over linked libraries (Deposit, DepositSweep,
+      // Redemption, Reservation) that stay at runs=1000, so a measured
+      // runs=1000-vs-100 diff over the deposit/redemption/reservation
+      // hot paths is 0-8 gas (noise); runs=100-vs-90 is smaller still.
+      // DRAFT NOTE: the durable alternative is a router-style refactor
+      // moving entry points out of the Bridge (as done on the P2TR
+      // activation track) -- see the blocking-dependency note on
+      // `Bridge.submitReservationProof`.
       "contracts/bridge/Bridge.sol": {
         version: "0.8.17",
         settings: {
           optimizer: {
             enabled: true,
-            runs: 100,
+            runs: 90,
           },
         },
       },

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -76,7 +76,6 @@ describe("Bridge - Reservation", () => {
       tbtc,
       tbtcVault,
     } = await waffle.loadFixture(bridgeFixture))
-
     ;({
       redemptionTimeoutSlashingAmount,
       redemptionTimeoutNotifierRewardMultiplier,
@@ -354,19 +353,17 @@ describe("Bridge - Reservation", () => {
 
       it("should revert when the minimum amount is not greater than the tx max fee", async () => {
         await expect(
-          bridge
-            .connect(bridgeGovernanceSigner)
-            .updateReservationParameters(
-              reservationVault.address,
-              RESERVATION_TX_MAX_FEE, // equal, not greater
-              RESERVATION_TX_MAX_FEE,
-              RESERVATION_DISSOLUTION_TX_MAX_FEE,
-              RESERVATION_TERM,
-              RESERVATION_GRACE,
-              RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET,
-              MAX_CUMULATIVE_REANCHOR_FEE
-            )
+          bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+            reservationVault.address,
+            RESERVATION_TX_MAX_FEE, // equal, not greater
+            RESERVATION_TX_MAX_FEE,
+            RESERVATION_DISSOLUTION_TX_MAX_FEE,
+            RESERVATION_TERM,
+            RESERVATION_GRACE,
+            RESERVATION_MAX_TOTAL,
+            MAX_RESERVATIONS_PER_WALLET,
+            MAX_CUMULATIVE_REANCHOR_FEE
+          )
         ).to.be.revertedWith(
           "Reservation minimum amount must be greater than the reservation TX max fee"
         )
@@ -708,9 +705,7 @@ describe("Bridge - Reservation", () => {
           state: 2, // RedemptionRequested
         })
 
-        const vaultSigner = await impersonateContract(
-          reservationVault.address
-        )
+        const vaultSigner = await impersonateContract(reservationVault.address)
         await expect(
           bridge.connect(vaultSigner).extendReservation(pendingKey)
         ).to.be.revertedWith("Reservation is not active")
@@ -866,9 +861,7 @@ describe("Bridge - Reservation", () => {
         .increaseBalance(reservationVault.address, amountSat)
 
       const vaultSigner = await impersonateContract(reservationVault.address)
-      await bank
-        .connect(vaultSigner)
-        .approveBalance(bridge.address, amountSat)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
       await bridge
         .connect(vaultSigner)
         .requestReservedRedemption(
@@ -1038,10 +1031,7 @@ describe("Bridge - Reservation", () => {
             [firstAmount, secondAmount]
           )
 
-        const firstFee = firstAmount
-          .mul(SATOSHI_MULTIPLIER)
-          .mul(40)
-          .div(10000)
+        const firstFee = firstAmount.mul(SATOSHI_MULTIPLIER).mul(40).div(10000)
         const secondFee = secondAmount
           .mul(SATOSHI_MULTIPLIER)
           .mul(40)
@@ -1260,9 +1250,9 @@ describe("Bridge - Reservation", () => {
         expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
           ownerBalanceBefore.sub(fee)
         )
-        expect(
-          (await bridge.reservations(reservationKey)).expiresAt
-        ).to.equal(expiresAtBefore + RESERVATION_TERM)
+        expect((await bridge.reservations(reservationKey)).expiresAt).to.equal(
+          expiresAtBefore + RESERVATION_TERM
+        )
       })
     })
 
@@ -1696,9 +1686,7 @@ describe("Bridge - Reservation", () => {
         .connect(bridgeSigner)
         .increaseBalance(reservationVault.address, amountSat)
       const vaultSigner = await impersonateContract(reservationVault.address)
-      await bank
-        .connect(vaultSigner)
-        .approveBalance(bridge.address, amountSat)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
       await bridge
         .connect(vaultSigner)
         .requestReservedRedemption(
@@ -1730,9 +1718,7 @@ describe("Bridge - Reservation", () => {
         )),
         state: 2, // RedemptionRequested
         redeemer: thirdParty.address,
-        redeemerOutputScriptHash: ethers.utils.keccak256(
-          redeemerOutputScript
-        ),
+        redeemerOutputScriptHash: ethers.utils.keccak256(redeemerOutputScript),
         redemptionRequestedAt: grandfatheredRequestedAt,
         redemptionTxMaxFee: RESERVATION_TX_MAX_FEE,
       })
@@ -2689,9 +2675,9 @@ describe("Bridge - Reservation", () => {
       )
 
       expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
-      expect(
-        (await bridge.reservations(reservationKey)).anchorTxHash
-      ).to.equal(reanchorTx.txHash)
+      expect((await bridge.reservations(reservationKey)).anchorTxHash).to.equal(
+        reanchorTx.txHash
+      )
     })
 
     it("acknowledges a late redemption proof for a reservation that was vetoed", async () => {
@@ -3015,19 +3001,17 @@ describe("Bridge - Reservation", () => {
     it("rejects a re-anchor once the cumulative fee budget is exceeded", async () => {
       // Lower the cumulative budget so two ordinary-fee re-anchor hops
       // exceed it on the second hop.
-      await bridge
-        .connect(bridgeGovernanceSigner)
-        .updateReservationParameters(
-          reservationVault.address,
-          RESERVATION_MIN_AMOUNT,
-          RESERVATION_TX_MAX_FEE,
-          RESERVATION_DISSOLUTION_TX_MAX_FEE,
-          RESERVATION_TERM,
-          RESERVATION_GRACE,
-          RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET,
-          anchorFee // budget == exactly one hop's fee
-        )
+      await bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        RESERVATION_DISSOLUTION_TX_MAX_FEE,
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        anchorFee // budget == exactly one hop's fee
+      )
 
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
       await liveWallet(secondWalletPubKeyHash)

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -3381,6 +3381,234 @@ describe("Bridge - Reservation", () => {
       )
     })
 
+    it("leaves residual backing independent of claim size after maximal grinding", async () => {
+      // Characterization of the accepted underbacking risk (follow-up item 7
+      // in the reservation review notes). It pins the *shape* of the risk so
+      // any later change to the dust floor, the dissolution cap, the
+      // cumulative budget, or the `mintedAmount` accounting has to restate it
+      // rather than move it silently.
+      //
+      // The finding: the dust floor is absolute (`> reservationTxMaxFee`),
+      // so the satoshi left backing a fully-ground reservation is the
+      // constant `reservationTxMaxFee + 1 - reservationDissolutionTxMaxFee`
+      // no matter how large the claim was. Fractional underbacking therefore
+      // grows with position size, and peaks where the cumulative budget and
+      // the dust floor bind at the same time -- NOT on a minimum-sized
+      // reservation, which is the intuitive but wrong guess.
+      //
+      // The parameters below are scaled down from the suite fixture purely to
+      // keep the grind to a handful of hops: reaching the floor under the
+      // fixture's 2000/100000 pair would take 50 re-anchor proofs. The
+      // invariant is parameter-independent, so the scaled regime tests the
+      // same mechanism -- but note this test does NOT measure the fixture's
+      // own worst case, which is arithmetic from the invariant, not a
+      // measured result.
+      const txMaxFee = 100
+      const dissolutionCap = 60
+      const cumulativeCap = 400
+      const minAmount = 150
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          minAmount,
+          txMaxFee,
+          dissolutionCap,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          cumulativeCap
+        )
+      await bridge.setDepositDustThreshold(50)
+
+      const floor = txMaxFee + 1
+      // Residual backing is claim-independent, hence a single constant.
+      const residualBacking = floor - dissolutionCap
+
+      // Reveals and accepts a reservation of exactly `claim` satoshi, paying
+      // a 1-satoshi acceptance fee so the deposit stays within `txMaxFee`.
+      async function acceptClaim(claim: number) {
+        const fundingTx = buildTx(
+          [
+            {
+              txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+              index: 0,
+            },
+          ],
+          [
+            {
+              valueSat: claim + 1,
+              script: p2wshScript(
+                buildDepositScript(
+                  thirdParty.address,
+                  blindingFactor,
+                  walletPubKeyHash,
+                  refundPubKeyHash,
+                  refundLocktime
+                )
+              ),
+            },
+          ]
+        )
+        await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+          fundingOutputIndex: 0,
+          blindingFactor,
+          walletPubKeyHash,
+          refundPubKeyHash,
+          refundLocktime,
+          vault: reservationVault.address,
+        })
+        const anchorTx = buildTx(
+          [{ txHash: fundingTx.txHash, index: 0 }],
+          [{ valueSat: claim, script: p2wpkhScript(walletPubKeyHash) }]
+        )
+        const acceptTx = await bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Acceptance,
+            anchorTx.info,
+            proofFor(anchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            0
+          )
+        const receipt = await acceptTx.wait()
+        const accepted = receipt.events.find(
+          (e) => e.event === "ReservationAccepted"
+        )
+        return { anchorTx, reservationKey: accepted.args.reservationKey }
+      }
+
+      // Grinds the anchor down to the dust floor in maximum-fee hops.
+      async function grindToFloor(
+        startTx: { txHash: string },
+        startValue: number,
+        reservationKey: BigNumber
+      ) {
+        let prevTx = startTx
+        let value = startValue
+        while (value > floor) {
+          const next = Math.max(floor, value - txMaxFee)
+          const hop = buildTx(
+            [{ txHash: prevTx.txHash, index: 0 }],
+            [{ valueSat: next, script: p2wpkhScript(walletPubKeyHash) }]
+          )
+          // Sequential on purpose: each hop spends the previous hop's output,
+          // so the proofs cannot be submitted concurrently.
+          // eslint-disable-next-line no-await-in-loop
+          await bridge
+            .connect(spvMaintainer)
+            .submitReservationProof(
+              ProofType.Reanchor,
+              hop.info,
+              proofFor(hop.txHash),
+              NO_MAIN_UTXO_PARAM,
+              reservationKey
+            )
+          prevTx = hop
+          value = next
+        }
+        return prevTx
+      }
+
+      // Dissolves 1-in-1-out at the maximum permitted fee and returns the
+      // decomposition the event reports.
+      async function dissolveAtMaxFee(
+        anchorTxToSpend: { txHash: string },
+        reservationKey: BigNumber
+      ) {
+        const dissolutionTx = buildTx(
+          [{ txHash: anchorTxToSpend.txHash, index: 0 }],
+          [
+            {
+              valueSat: residualBacking,
+              script: p2wpkhScript(walletPubKeyHash),
+            },
+          ]
+        )
+        const tx = await bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+        const receipt = await tx.wait()
+        const dissolved = receipt.events.find(
+          (e) => e.event === "ReservationDissolved"
+        )
+        return dissolved.args
+      }
+
+      // Case A: a minimum-sized reservation. One hop reaches the floor, so
+      // the cumulative budget never binds.
+      const small = await acceptClaim(minAmount)
+      const smallFinal = await grindToFloor(
+        small.anchorTx,
+        minAmount,
+        small.reservationKey
+      )
+
+      // Case B: the peak-loss position -- sized so grinding to the floor
+      // consumes the cumulative budget EXACTLY. Any larger claim is better
+      // off proportionally, because the budget stops the grind early.
+      const peakClaim = cumulativeCap + floor
+      const peak = await acceptClaim(peakClaim)
+      const peakFinal = await grindToFloor(
+        peak.anchorTx,
+        peakClaim,
+        peak.reservationKey
+      )
+      expect(
+        (await bridge.reservations(peak.reservationKey)).cumulativeReanchorFee
+      ).to.equal(cumulativeCap)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const smallArgs = await dissolveAtMaxFee(smallFinal, small.reservationKey)
+
+      // The first dissolution's output became the wallet's new main UTXO,
+      // which would force the second into the 2-in-1-out shape. Clear it so
+      // both cases dissolve 1-in-1-out and only the claim size differs --
+      // the 2-in-1-out shape is covered by the decomposition test above.
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      const peakArgs = await dissolveAtMaxFee(peakFinal, peak.reservationKey)
+
+      // The claim differs by more than 3x; the backing left behind does not
+      // differ at all. That constant is the finding.
+      expect(smallArgs.mintedAmount).to.equal(minAmount)
+      expect(peakArgs.mintedAmount).to.equal(peakClaim)
+      expect(smallArgs.anchorAmount).to.equal(floor)
+      expect(peakArgs.anchorAmount).to.equal(floor)
+      expect(smallArgs.anchorAmount.sub(smallArgs.dissolutionFee)).to.equal(
+        residualBacking
+      )
+      expect(peakArgs.anchorAmount.sub(peakArgs.dissolutionFee)).to.equal(
+        residualBacking
+      )
+
+      // Fractional underbacking is therefore worse for the larger claim --
+      // the direction a reader would not predict, and the reason a bound
+      // relative to `reservationMinAmount` alone does not close this.
+      const smallLoss = minAmount - residualBacking
+      const peakLoss = peakClaim - residualBacking
+      expect(peakLoss / peakClaim).to.be.greaterThan(smallLoss / minAmount)
+    })
+
     it("enforces the dissolution-specific fee cap on the proven transaction", async () => {
       // Sanity: the two caps must differ or this test cannot discriminate
       // which one the proof path checks against.

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -36,7 +36,7 @@ const RESERVATION_MIN_AMOUNT = 10000
 const RESERVATION_TX_MAX_FEE = 2000
 const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
 const MAX_RESERVATIONS_PER_WALLET = 10
-const RESERVATION_DISSOLUTION_TX_MAX_FEE = 2000
+const RESERVATION_DISSOLUTION_TX_MAX_FEE = 1500
 const MAX_CUMULATIVE_REANCHOR_FEE = 100000
 
 const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
@@ -3273,6 +3273,150 @@ describe("Bridge - Reservation", () => {
           [dissolutionTx.txHash, 0, reanchoredAmount.sub(dissolutionFee)]
         )
       )
+    })
+
+    it("dissolves into an existing main UTXO and reports the fee-loss decomposition", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      // Re-anchor once so `anchorAmount` falls below `mintedAmount`: that
+      // gap is the in-kind loss the event has to report.
+      const reanchorFee = 800
+      const reanchoredAmount = anchorAmount.sub(reanchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: reanchoredAmount,
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      // Give the custodying wallet a main UTXO so the dissolution takes
+      // the dominant 2-in-1-out shape. Every other test in this suite
+      // dissolves 1-in-1-out, where the anchor value and the combined
+      // input total coincide and cannot be told apart.
+      const mainUtxoTxHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+      const mainUtxoValue = BigNumber.from(1000000)
+      await bridge.setWallet(walletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [mainUtxoTxHash, 0, mainUtxoValue]
+        ),
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const dissolutionFee = 600
+      const dissolutionTx = buildTx(
+        [
+          { txHash: reanchorTx.txHash, index: 0 },
+          { txHash: mainUtxoTxHash, index: 0 },
+        ],
+        [
+          {
+            valueSat: reanchoredAmount.add(mainUtxoValue).sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      const tx = await bridge.connect(spvMaintainer).submitReservationProof(
+        ProofType.Dissolution,
+        dissolutionTx.info,
+        proofFor(dissolutionTx.txHash),
+        {
+          txHash: mainUtxoTxHash,
+          txOutputIndex: 0,
+          txOutputValue: mainUtxoValue,
+        },
+        reservationKey
+      )
+
+      // The event must report the anchor's own value, not the combined
+      // input total: the unreconciled shortfall is
+      // `mintedAmount - anchorAmount + dissolutionFee`, here
+      // `reanchorFee + dissolutionFee`.
+      await expect(tx)
+        .to.emit(bridge, "ReservationDissolved")
+        .withArgs(
+          reservationKey,
+          walletPubKeyHash,
+          dissolutionTx.txHash,
+          anchorAmount,
+          reanchoredAmount,
+          dissolutionFee
+        )
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+
+      // The single output became the wallet's new main UTXO.
+      const wallet = await bridge.wallets(walletPubKeyHash)
+      expect(wallet.mainUtxoHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [
+            dissolutionTx.txHash,
+            0,
+            reanchoredAmount.add(mainUtxoValue).sub(dissolutionFee),
+          ]
+        )
+      )
+    })
+
+    it("enforces the dissolution-specific fee cap on the proven transaction", async () => {
+      // Sanity: the two caps must differ or this test cannot discriminate
+      // which one the proof path checks against.
+      expect(RESERVATION_DISSOLUTION_TX_MAX_FEE).to.be.lessThan(
+        RESERVATION_TX_MAX_FEE
+      )
+
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      // Above `reservationDissolutionTxMaxFee` but still within the shared
+      // `reservationTxMaxFee`: this reverts only if the proven fee is
+      // checked against the dissolution-specific cap.
+      const dissolutionFee = RESERVATION_DISSOLUTION_TX_MAX_FEE + 1
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Transaction fee is too high")
     })
   })
 })

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -2003,6 +2003,53 @@ describe("Bridge - Reservation", () => {
         })
       ).to.be.revertedWith("Reservation custodied by different wallet")
     })
+
+    it("enforces the dissolution-specific fee cap, not the reservation tx max fee", async () => {
+      // Regression test: validateReservationDissolutionProposal must check
+      // proposal.dissolutionTxFee against reservationDissolutionTxMaxFee,
+      // not reservationTxMaxFee. Configure the two caps to differ so a fee
+      // that would pass the wrong cap is caught by the right one.
+      const reservationKey = 54321
+      await bridge.setReservation(
+        reservationKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          500, // reservationDissolutionTxMaxFee, deliberately below RESERVATION_TX_MAX_FEE
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      // Within RESERVATION_TX_MAX_FEE (2000) but above the dissolution cap
+      // (500): must revert if the fee is checked against the right cap.
+      await expect(
+        validator.validateReservationDissolutionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          dissolutionTxFee: 1000,
+        })
+      ).to.be.revertedWith("Proposed transaction fee is too high")
+
+      // Exactly at the dissolution cap: must be accepted.
+      expect(
+        await validator.validateReservationDissolutionProposal({
+          walletPubKeyHash,
+          reservationKey,
+          dissolutionTxFee: 500,
+        })
+      ).to.be.true
+    })
   })
 
   describe("reservation SPV proofs", () => {

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -695,6 +695,27 @@ describe("Bridge - Reservation", () => {
           .withArgs(reservationKey, after_.expiresAt)
       })
     })
+
+    context("when the reservation is not active", () => {
+      it("should revert", async () => {
+        const pendingKey = 778
+        await bridge.setReservation(pendingKey, {
+          ...(await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            BigNumber.from(100000000)
+          )),
+          state: 2, // RedemptionRequested
+        })
+
+        const vaultSigner = await impersonateContract(
+          reservationVault.address
+        )
+        await expect(
+          bridge.connect(vaultSigner).extendReservation(pendingKey)
+        ).to.be.revertedWith("Reservation is not active")
+      })
+    })
   })
 
   describe("requestReservedRedemption", () => {
@@ -801,6 +822,13 @@ describe("Bridge - Reservation", () => {
       await expect(timeoutTx)
         .to.emit(bridge, "ReservedRedemptionTimedOut")
         .withArgs(reservationKey, walletPubKeyHash)
+      await expect(timeoutTx)
+        .to.emit(bridge, "ReservedRedemptionTimeoutSlashingSkipped")
+        .withArgs(reservationKey, walletPubKeyHash)
+      expect(
+        (await bridge.reservations(reservationKey)).lastTimeoutWasWalletFault
+      ).to.be.false
+      expect(walletRegistry.seize).to.not.have.been.called
 
       expect(await bank.balanceOf(thirdParty.address)).to.equal(amountSat)
       expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
@@ -1722,6 +1750,72 @@ describe("Bridge - Reservation", () => {
         .to.emit(redemptionWatchtower, "VetoPeriodCheckOmitted")
         .withArgs(vetoKey)
     })
+
+    it("lets a new request generation start clean after an earlier generation is resolved", async () => {
+      const freshKey = 670
+      const owner = governance.address
+
+      await bridge.setReservation(
+        freshKey,
+        await activeReservation(owner, walletPubKeyHash, amountSat)
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(freshKey, owner, redeemerOutputScript)
+
+      // First generation: one guardian objects, below the 3-objection
+      // veto threshold, then the request times out without being
+      // vetoed.
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(freshKey)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(freshKey, [])
+
+      expect((await bridge.reservations(freshKey)).state).to.equal(1) // Active
+
+      // Second generation: re-request. The guardian who objected against
+      // generation 1 must be able to object again, and the new
+      // generation must start with zero objections -- a stale
+      // `objectionsCount` from the resolved generation 1 must not carry
+      // over and bias or block generation 2.
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      await bank.connect(vaultSigner).approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(freshKey, owner, redeemerOutputScript)
+
+      const { redemptionRequestedAt } = await bridge.reservations(freshKey)
+      const secondGenVetoKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint32"],
+        [freshKey, redemptionRequestedAt]
+      )
+      expect(
+        (await redemptionWatchtower.vetoProposals(secondGenVetoKey))
+          .objectionsCount
+      ).to.equal(0)
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      )
+        .to.emit(redemptionWatchtower, "ObjectionRaised")
+        .withArgs(secondGenVetoKey, guardianSigners[0].address)
+    })
   })
 
   describe("WalletProposalValidator", () => {
@@ -2168,6 +2262,95 @@ describe("Bridge - Reservation", () => {
       ).to.be.revertedWith("Deposit was not revealed as reserved")
     })
 
+    it("accepts a pre-swap reserved deposit after the vault changes, crediting the current vault", async () => {
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: depositAmount,
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+
+      // Revealed while `reservationVault` is still the reservation vault:
+      // classified as reserved at reveal time.
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+
+      const reservationKey = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [fundingTx.txHash, 0]
+      )
+      expect(await bridge.isReservedDeposit(reservationKey)).to.be.true
+
+      // Governance repurposes the reservation vault before the anchor is
+      // proven. The reveal-time classification survives unchanged.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          tbtcVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+      expect(await bridge.isReservedDeposit(reservationKey)).to.be.true
+
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: anchorAmount, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+
+      const supplyBefore = await tbtc.totalSupply()
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          0
+        )
+
+      // Accepted despite the vault swap: the reservation record exists,
+      // which only the reservation path (not an ordinary sweep) creates.
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      // The credit routed through the *current* vault (`tbtcVault`, a
+      // 1:1 ordinary mint with no reservation-vault initiation fee
+      // split), not the vault configured at reveal time.
+      expect(await tbtc.totalSupply()).to.equal(
+        supplyBefore.add(anchorAmount.mul(SATOSHI_MULTIPLIER))
+      )
+      expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+        anchorAmount.mul(SATOSHI_MULTIPLIER)
+      )
+    })
+
     it("rejects an anchor paying an excessive miner fee", async () => {
       await expect(
         makeAcceptedReservation(depositAmount.sub(RESERVATION_TX_MAX_FEE + 1))
@@ -2364,11 +2547,11 @@ describe("Bridge - Reservation", () => {
         bankBalanceBeforeProof
       )
       expect(await tbtc.totalSupply()).to.equal(supplyBeforeProof)
-      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
 
-      // The settlement record is consumed: neither a repeat submission of
-      // the same proof nor a fresh acceptance can reuse the anchor
-      // outpoint.
+      // The settlement record is consumed and the reservation is now
+      // Closed: a repeat submission of the same proof cannot reuse the
+      // anchor outpoint.
       await expect(
         bridge
           .connect(spvMaintainer)
@@ -2379,7 +2562,192 @@ describe("Bridge - Reservation", () => {
             NO_MAIN_UTXO_PARAM,
             reservationKey
           )
-      ).to.be.revertedWith("No pending reserved redemption")
+      ).to.be.revertedWith("No settled reserved redemption")
+    })
+
+    it("rejects a late redemption proof pointing at the wrong settled outpoint", async () => {
+      const { reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [1, 2, 3, 4, 5])
+      walletRegistry.seize.reset()
+
+      // A proof whose input spends a different outpoint than the one
+      // recorded in the settlement must not be acknowledged.
+      const wrongOutpointTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            wrongOutpointTx.info,
+            proofFor(wrongOutpointTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Wrong settled anchor outpoint")
+    })
+
+    it("rejects a late redemption proof once the reservation has been re-anchored since settlement", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+      await liveWallet(secondWalletPubKeyHash)
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [1, 2, 3, 4, 5])
+      walletRegistry.seize.reset()
+
+      // The reservation returns to Active on timeout and is legitimately
+      // re-anchored to a fresh outpoint before the settled anchor's late
+      // proof ever arrives.
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(anchorFee),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      // A late proof against the now-superseded settled anchor must not
+      // be able to force-close a reservation that has since moved on to
+      // a live, unsettled anchor.
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith(
+        "Reservation anchor no longer matches the settlement"
+      )
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+      expect(
+        (await bridge.reservations(reservationKey)).anchorTxHash
+      ).to.equal(reanchorTx.txHash)
+    })
+
+    it("acknowledges a late redemption proof for a reservation that was vetoed", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      // Treat `deployer` as the redemption watchtower, mirroring the
+      // dedicated `notifyReservedRedemptionVeto` unit tests.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .setRedemptionWatchtower(deployer.address)
+      await bridge
+        .connect(deployer)
+        .notifyReservedRedemptionVeto(reservationKey)
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const supplyBeforeProof = await tbtc.totalSupply()
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionSettled")
+        .withArgs(reservationKey, redemptionTx.txHash)
+
+      expect(await tbtc.totalSupply()).to.equal(supplyBeforeProof)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
     })
 
     it("keeps redemption provable when txMaxFee exceeds the anchor (underflow guard)", async () => {
@@ -2644,6 +3012,73 @@ describe("Bridge - Reservation", () => {
       ).to.be.revertedWith("Re-anchor amount below the dust floor")
     })
 
+    it("rejects a re-anchor once the cumulative fee budget is exceeded", async () => {
+      // Lower the cumulative budget so two ordinary-fee re-anchor hops
+      // exceed it on the second hop.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          anchorFee // budget == exactly one hop's fee
+        )
+
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      const firstHop = anchorAmount.sub(anchorFee)
+      const reanchorTx1 = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: firstHop,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      const tx1 = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx1.info,
+          proofFor(reanchorTx1.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+      await expect(tx1).to.emit(bridge, "ReservationReanchored")
+      expect(
+        (await bridge.reservations(reservationKey)).cumulativeReanchorFee
+      ).to.equal(anchorFee)
+
+      // Second hop: any positive fee now exceeds the exhausted budget.
+      const reanchorTx2 = buildTx(
+        [{ txHash: reanchorTx1.txHash, index: 0 }],
+        [
+          {
+            valueSat: firstHop.sub(1),
+            script: p2wpkhScript(walletPubKeyHash),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx2.info,
+            proofFor(reanchorTx2.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Cumulative re-anchor fee budget exceeded")
+    })
+
     it("rejects a dissolution output that does not pay the custodying wallet", async () => {
       const { anchorTx, reservationKey } = await makeAcceptedReservation()
 
@@ -2725,6 +3160,88 @@ describe("Bridge - Reservation", () => {
         ethers.utils.solidityKeccak256(
           ["bytes32", "uint32", "uint64"],
           [dissolutionTx.txHash, 0, anchorAmount.sub(dissolutionFee)]
+        )
+      )
+    })
+
+    it("dissolves a re-anchored reservation without burning unrelated Bank balance", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      // Re-anchor once, incurring a miner fee: `anchorAmount` shrinks
+      // below `mintedAmount`.
+      const reanchoredAmount = anchorAmount.sub(anchorFee)
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: reanchoredAmount,
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          reanchorTx.info,
+          proofFor(reanchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      const reservationBefore = await bridge.reservations(reservationKey)
+      expect(reservationBefore.mintedAmount).to.equal(anchorAmount)
+      expect(reservationBefore.anchorAmount).to.equal(reanchoredAmount)
+
+      // A second, unrelated reservation's escrow, held by the Bridge as
+      // an ordinary Bank balance, must survive dissolution untouched --
+      // mirroring the balance shape the Bridge actually holds while a
+      // pooled or reserved redemption is in flight.
+      const unrelatedBalance = BigNumber.from(500000)
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(bridge.address, unrelatedBalance)
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const dissolutionFee = 200
+      const dissolutionTx = buildTx(
+        [{ txHash: reanchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: reanchoredAmount.sub(dissolutionFee),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Dissolution,
+          dissolutionTx.info,
+          proofFor(dissolutionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx).to.emit(bridge, "ReservationDissolved")
+
+      expect((await bridge.reservations(reservationKey)).state).to.equal(3) // Closed
+
+      // No Bank balance was burned: the unrelated escrow survives
+      // untouched.
+      expect(await bank.balanceOf(bridge.address)).to.equal(unrelatedBalance)
+
+      // The dissolution output carries forward exactly the shrunk
+      // `anchorAmount`, not the original gross `mintedAmount`.
+      const wallet = await bridge.wallets(secondWalletPubKeyHash)
+      expect(wallet.mainUtxoHash).to.equal(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32", "uint64"],
+          [dissolutionTx.txHash, 0, reanchoredAmount.sub(dissolutionFee)]
         )
       )
     })

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -2015,19 +2015,17 @@ describe("Bridge - Reservation", () => {
         await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
       )
 
-      await bridge
-        .connect(bridgeGovernanceSigner)
-        .updateReservationParameters(
-          reservationVault.address,
-          RESERVATION_MIN_AMOUNT,
-          RESERVATION_TX_MAX_FEE,
-          500, // reservationDissolutionTxMaxFee, deliberately below RESERVATION_TX_MAX_FEE
-          RESERVATION_TERM,
-          RESERVATION_GRACE,
-          RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET,
-          MAX_CUMULATIVE_REANCHOR_FEE
-        )
+      await bridge.connect(bridgeGovernanceSigner).updateReservationParameters(
+        reservationVault.address,
+        RESERVATION_MIN_AMOUNT,
+        RESERVATION_TX_MAX_FEE,
+        500, // reservationDissolutionTxMaxFee, deliberately below RESERVATION_TX_MAX_FEE
+        RESERVATION_TERM,
+        RESERVATION_GRACE,
+        RESERVATION_MAX_TOTAL,
+        MAX_RESERVATIONS_PER_WALLET,
+        MAX_CUMULATIVE_REANCHOR_FEE
+      )
 
       await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
 

--- a/solidity/test/bridge/Bridge.Reservation.test.ts
+++ b/solidity/test/bridge/Bridge.Reservation.test.ts
@@ -12,6 +12,7 @@ import type {
   BridgeGovernance,
   BridgeStub,
   IRelay,
+  IWalletRegistry,
   ReservationVault,
   TBTCVault,
   TBTC,
@@ -35,6 +36,8 @@ const RESERVATION_MIN_AMOUNT = 10000
 const RESERVATION_TX_MAX_FEE = 2000
 const RESERVATION_MAX_TOTAL = BigNumber.from("2100000000000000")
 const MAX_RESERVATIONS_PER_WALLET = 10
+const RESERVATION_DISSOLUTION_TX_MAX_FEE = 2000
+const MAX_CUMULATIVE_REANCHOR_FEE = 100000
 
 const SATOSHI_MULTIPLIER = BigNumber.from(10).pow(10)
 
@@ -47,12 +50,15 @@ describe("Bridge - Reservation", () => {
 
   let bank: Bank & BankStub
   let relay: FakeContract<IRelay>
+  let walletRegistry: FakeContract<IWalletRegistry>
   let bridge: Bridge & BridgeStub
   let tbtc: TBTC & Contract
   let tbtcVault: TBTCVault & Contract
   let bridgeGovernance: BridgeGovernance
   let reservationVault: ReservationVault
   let bridgeGovernanceSigner: SignerWithAddress
+  let redemptionTimeoutSlashingAmount: BigNumber
+  let redemptionTimeoutNotifierRewardMultiplier: number
 
   before(async () => {
     // eslint-disable-next-line @typescript-eslint/no-extra-semi
@@ -64,11 +70,17 @@ describe("Bridge - Reservation", () => {
       treasury,
       bank,
       relay,
+      walletRegistry,
       bridge,
       bridgeGovernance,
       tbtc,
       tbtcVault,
     } = await waffle.loadFixture(bridgeFixture))
+
+    ;({
+      redemptionTimeoutSlashingAmount,
+      redemptionTimeoutNotifierRewardMultiplier,
+    } = await bridge.redemptionParameters())
 
     reservationVault = await helpers.contracts.getContract("ReservationVault")
 
@@ -106,10 +118,12 @@ describe("Bridge - Reservation", () => {
         reservationVault.address,
         RESERVATION_MIN_AMOUNT,
         RESERVATION_TX_MAX_FEE,
+        RESERVATION_DISSOLUTION_TX_MAX_FEE,
         RESERVATION_TERM,
         RESERVATION_GRACE,
         RESERVATION_MAX_TOTAL,
-        MAX_RESERVATIONS_PER_WALLET
+        MAX_RESERVATIONS_PER_WALLET,
+        MAX_CUMULATIVE_REANCHOR_FEE
       )
   }
 
@@ -134,6 +148,8 @@ describe("Bridge - Reservation", () => {
       redemptionTxMaxFee: 0,
       redeemer: ZERO_ADDRESS,
       redeemerOutputScriptHash: ZERO_BYTES32,
+      cumulativeReanchorFee: 0,
+      lastTimeoutWasWalletFault: false,
     }
   }
 
@@ -272,10 +288,12 @@ describe("Bridge - Reservation", () => {
               reservationVault.address,
               RESERVATION_MIN_AMOUNT,
               RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
             )
         ).to.be.revertedWith("Caller is not the governance")
       })
@@ -289,10 +307,12 @@ describe("Bridge - Reservation", () => {
             reservationVault.address,
             RESERVATION_MIN_AMOUNT,
             RESERVATION_TX_MAX_FEE,
+            RESERVATION_DISSOLUTION_TX_MAX_FEE,
             RESERVATION_TERM,
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET
+            MAX_RESERVATIONS_PER_WALLET,
+            MAX_CUMULATIVE_REANCHOR_FEE
           )
 
         await expect(tx)
@@ -303,10 +323,12 @@ describe("Bridge - Reservation", () => {
           .withArgs(
             RESERVATION_MIN_AMOUNT,
             RESERVATION_TX_MAX_FEE,
+            RESERVATION_DISSOLUTION_TX_MAX_FEE,
             RESERVATION_TERM,
             RESERVATION_GRACE,
             RESERVATION_MAX_TOTAL,
-            MAX_RESERVATIONS_PER_WALLET
+            MAX_RESERVATIONS_PER_WALLET,
+            MAX_CUMULATIVE_REANCHOR_FEE
           )
       })
 
@@ -318,14 +340,54 @@ describe("Bridge - Reservation", () => {
               reservationVault.address,
               RESERVATION_MIN_AMOUNT,
               0,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
             )
         ).to.be.revertedWith(
           "Reservation transaction max fee must be greater than zero"
         )
+      })
+
+      it("should revert when the minimum amount is not greater than the tx max fee", async () => {
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_TX_MAX_FEE, // equal, not greater
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
+              RESERVATION_TERM,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
+            )
+        ).to.be.revertedWith(
+          "Reservation minimum amount must be greater than the reservation TX max fee"
+        )
+      })
+
+      it("should revert for a zero reservation term", async () => {
+        await expect(
+          bridge
+            .connect(bridgeGovernanceSigner)
+            .updateReservationParameters(
+              reservationVault.address,
+              RESERVATION_MIN_AMOUNT,
+              RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
+              0,
+              RESERVATION_GRACE,
+              RESERVATION_MAX_TOTAL,
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
+            )
+        ).to.be.revertedWith("Reservation term must be greater than zero")
       })
 
       it("should revert when changing the vault with active reservations", async () => {
@@ -346,10 +408,12 @@ describe("Bridge - Reservation", () => {
               thirdParty.address,
               RESERVATION_MIN_AMOUNT,
               RESERVATION_TX_MAX_FEE,
+              RESERVATION_DISSOLUTION_TX_MAX_FEE,
               RESERVATION_TERM,
               RESERVATION_GRACE,
               RESERVATION_MAX_TOTAL,
-              MAX_RESERVATIONS_PER_WALLET
+              MAX_RESERVATIONS_PER_WALLET,
+              MAX_CUMULATIVE_REANCHOR_FEE
             )
         ).to.be.revertedWith("Active reservations exist")
       })
@@ -414,10 +478,12 @@ describe("Bridge - Reservation", () => {
           tbtcVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
       expect(await bridge.isReservedDeposit(depositKey)).to.be.true
 
@@ -526,10 +592,12 @@ describe("Bridge - Reservation", () => {
           tbtcVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       // Classification is a reveal-time fact, not a live vault-address
@@ -737,6 +805,135 @@ describe("Bridge - Reservation", () => {
       expect(await bank.balanceOf(thirdParty.address)).to.equal(amountSat)
       expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
     })
+
+    it("slashes the wallet operators on timeout when the wallet is Live", async () => {
+      const liveReservationKey = 889
+      const liveWalletPubKeyHash = "0xafcdf88d15a0e0c2134dbbc9f6da24d0e26c8f21"
+      const walletMembersIDs = [1, 2, 3, 4, 5]
+
+      await bridge.setWallet(liveWalletPubKeyHash, {
+        ecdsaWalletID: ethers.utils.randomBytes(32),
+        mainUtxoHash: ZERO_BYTES32,
+        pendingRedemptionsValue: 0,
+        createdAt: await lastBlockTime(),
+        movingFundsRequestedAt: 0,
+        closingStartedAt: 0,
+        pendingMovedFundsSweepRequestsCount: 0,
+        state: walletState.Live,
+        movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
+      })
+      await bridge.setActiveWallet(liveWalletPubKeyHash)
+      await bridge.setReservation(
+        liveReservationKey,
+        await activeReservation(
+          thirdParty.address,
+          liveWalletPubKeyHash,
+          amountSat
+        )
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank
+        .connect(vaultSigner)
+        .approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          liveReservationKey,
+          thirdParty.address,
+          redeemerOutputScript
+        )
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+
+      const wallet = await bridge.wallets(liveWalletPubKeyHash)
+      const tx = await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(liveReservationKey, walletMembersIDs)
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionTimedOut")
+        .withArgs(liveReservationKey, liveWalletPubKeyHash)
+      expect(walletRegistry.seize).to.have.been.calledOnceWith(
+        redemptionTimeoutSlashingAmount,
+        redemptionTimeoutNotifierRewardMultiplier,
+        await thirdParty.getAddress(),
+        wallet.ecdsaWalletID,
+        walletMembersIDs
+      )
+
+      walletRegistry.seize.reset()
+    })
+
+    it("should revert when the redeemer output script points to the wallet public key hash", async () => {
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      const bridgeSigner = await impersonateContract(bridge.address)
+
+      const guardKey = 890
+      await bridge.setReservation(
+        guardKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+
+      // Wallet public key hash hidden under P2WPKH.
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            guardKey,
+            thirdParty.address,
+            `0x160014${walletPubKeyHash.substring(2)}`
+          )
+      ).to.be.revertedWith(
+        "Redeemer output script must not point to the wallet PKH"
+      )
+
+      // Wallet public key hash hidden under P2PKH.
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            guardKey,
+            thirdParty.address,
+            `0x1976a914${walletPubKeyHash.substring(2)}88ac`
+          )
+      ).to.be.revertedWith(
+        "Redeemer output script must not point to the wallet PKH"
+      )
+    })
+
+    it("should revert when the redeemer output script is not a standard type", async () => {
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      const bridgeSigner = await impersonateContract(bridge.address)
+
+      const guardKey = 891
+      await bridge.setReservation(
+        guardKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+
+      await expect(
+        bridge
+          .connect(vaultSigner)
+          .requestReservedRedemption(
+            guardKey,
+            thirdParty.address,
+            "0x1988a914f4eedc8f40d4b8e30771f792b065ebec0abaddef88ac"
+          )
+      ).to.be.revertedWith("Redeemer output script must be a standard type")
+    })
   })
 
   describe("ReservationVault", () => {
@@ -784,6 +981,57 @@ describe("Bridge - Reservation", () => {
           grossTbtc.sub(expectedFee)
         )
         expect(await tbtc.balanceOf(treasury.address)).to.equal(expectedFee)
+      })
+
+      it("should revert when no depositors are specified", async () => {
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await expect(
+          bank
+            .connect(bridgeSigner)
+            .increaseBalanceAndCall(reservationVault.address, [], [])
+        ).to.be.revertedWith("No depositors specified")
+      })
+
+      it("should mint gross TBTC and split the initiation fee across multiple depositors", async () => {
+        const bridgeSigner = await impersonateContract(bridge.address)
+        const secondDepositor = governance.address
+        const firstAmount = amountSat
+        const secondAmount = amountSat.mul(3)
+
+        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+        const firstBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+        const secondBalanceBefore = await tbtc.balanceOf(secondDepositor)
+
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address, secondDepositor],
+            [firstAmount, secondAmount]
+          )
+
+        const firstFee = firstAmount
+          .mul(SATOSHI_MULTIPLIER)
+          .mul(40)
+          .div(10000)
+        const secondFee = secondAmount
+          .mul(SATOSHI_MULTIPLIER)
+          .mul(40)
+          .div(10000)
+
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          firstBalanceBefore.add(
+            firstAmount.mul(SATOSHI_MULTIPLIER).sub(firstFee)
+          )
+        )
+        expect(await tbtc.balanceOf(secondDepositor)).to.equal(
+          secondBalanceBefore.add(
+            secondAmount.mul(SATOSHI_MULTIPLIER).sub(secondFee)
+          )
+        )
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore.add(firstFee).add(secondFee)
+        )
       })
     })
 
@@ -924,6 +1172,85 @@ describe("Bridge - Reservation", () => {
         await reservationVault.connect(deployer).updateFees(40, 20, 20)
       })
     })
+
+    describe("extendCustody", () => {
+      const reservationKey = 997
+      const walletPubKeyHash = "0x8db50eb52063ea9d98b3eac91489a90f738986f6"
+
+      before(async () => {
+        await bridge.setReservation(
+          reservationKey,
+          await activeReservation(
+            thirdParty.address,
+            walletPubKeyHash,
+            amountSat
+          )
+        )
+
+        // Fund the owner with TBTC for the extension fee via an
+        // acceptance-sized credit.
+        const bridgeSigner = await impersonateContract(bridge.address)
+        await bank
+          .connect(bridgeSigner)
+          .increaseBalanceAndCall(
+            reservationVault.address,
+            [thirdParty.address],
+            [amountSat]
+          )
+        await tbtc
+          .connect(thirdParty)
+          .approve(reservationVault.address, ethers.constants.MaxUint256)
+      })
+
+      it("should revert when the fee exceeds the caller's bound", async () => {
+        const fee = grossTbtc.mul(20).div(10000)
+        await expect(
+          reservationVault
+            .connect(thirdParty)
+            .extendCustody(reservationKey, fee.sub(1))
+        ).to.be.revertedWith("Fee exceeds the caller's bound")
+      })
+
+      it("should transfer the extension fee to the treasury and advance expiresAt through the real vault path", async () => {
+        const fee = grossTbtc.mul(20).div(10000) // 20 bps extensionFeeBps
+        const treasuryBalanceBefore = await tbtc.balanceOf(treasury.address)
+        const ownerBalanceBefore = await tbtc.balanceOf(thirdParty.address)
+        const expiresAtBefore = (await bridge.reservations(reservationKey))
+          .expiresAt
+
+        const tx = await reservationVault
+          .connect(thirdParty)
+          .extendCustody(reservationKey, fee)
+
+        await expect(tx)
+          .to.emit(reservationVault, "CustodyExtended")
+          .withArgs(reservationKey, thirdParty.address, fee)
+
+        expect(await tbtc.balanceOf(treasury.address)).to.equal(
+          treasuryBalanceBefore.add(fee)
+        )
+        expect(await tbtc.balanceOf(thirdParty.address)).to.equal(
+          ownerBalanceBefore.sub(fee)
+        )
+        expect(
+          (await bridge.reservations(reservationKey)).expiresAt
+        ).to.equal(expiresAtBefore + RESERVATION_TERM)
+      })
+    })
+
+    describe("updateFees", () => {
+      it("should revert when a fee parameter exceeds the maximum", async () => {
+        await expect(
+          reservationVault.connect(deployer).updateFees(501, 20, 20)
+        ).to.be.revertedWith("Fee exceeds the maximum")
+        await expect(
+          reservationVault.connect(deployer).updateFees(40, 501, 20)
+        ).to.be.revertedWith("Fee exceeds the maximum")
+        await expect(
+          reservationVault.connect(deployer).updateFees(40, 20, 501)
+        ).to.be.revertedWith("Fee exceeds the maximum")
+      })
+    })
   })
 
   describe("notifyReservedRedemptionVeto", () => {
@@ -1024,10 +1351,14 @@ describe("Bridge - Reservation", () => {
         state: walletState.Terminated,
         movingFundsTargetWalletsCommitmentHash: ZERO_BYTES32,
       })
-      await bridge.setReservation(
-        reservationKey,
-        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
-      )
+      await bridge.setReservation(reservationKey, {
+        ...(await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          amountSat
+        )),
+        lastTimeoutWasWalletFault: true,
+      })
 
       // Simulate the state a redemption timeout leaves the owner in: the
       // gross amount refunded as Bank balance. The fee is paid in TBTC,
@@ -1067,6 +1398,34 @@ describe("Bridge - Reservation", () => {
         treasuryBalanceBefore
       )
     })
+
+    it("reverts when the previous request did not time out through wallet fault", async () => {
+      const otherReservationKey = 445
+      await bridge.setReservation(otherReservationKey, {
+        ...(await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          amountSat
+        )),
+        lastTimeoutWasWalletFault: false,
+      })
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(thirdParty.address, amountSat)
+      await bank
+        .connect(thirdParty)
+        .approveBalance(reservationVault.address, amountSat)
+
+      await expect(
+        reservationVault
+          .connect(thirdParty)
+          .retryRedeemReservation(otherReservationKey, redeemerOutputScript)
+      ).to.be.revertedWith(
+        "Previous request did not time out through wallet fault"
+      )
+    })
   })
 
   describe("governance-delayed reservation parameters update", () => {
@@ -1085,10 +1444,12 @@ describe("Bridge - Reservation", () => {
           reservationVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       const beginReceipt = await beginTx.wait()
@@ -1102,10 +1463,12 @@ describe("Bridge - Reservation", () => {
           reservationVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
           MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE,
           beginBlock.timestamp
         )
 
@@ -1131,10 +1494,12 @@ describe("Bridge - Reservation", () => {
         .withArgs(
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
     })
   })
@@ -1224,6 +1589,14 @@ describe("Bridge - Reservation", () => {
     })
 
     it("vetoes a reserved redemption after three guardian objections", async () => {
+      const { redemptionRequestedAt } = await bridge.reservations(
+        reservationKey
+      )
+      const vetoKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint32"],
+        [reservationKey, redemptionRequestedAt]
+      )
+
       await redemptionWatchtower
         .connect(guardianSigners[0])
         .raiseReservedObjection(reservationKey)
@@ -1237,7 +1610,7 @@ describe("Bridge - Reservation", () => {
 
       await expect(tx)
         .to.emit(redemptionWatchtower, "VetoFinalized")
-        .withArgs(reservationKey)
+        .withArgs(vetoKey)
       await expect(tx)
         .to.emit(bridge, "ReservedRedemptionVetoed")
         .withArgs(reservationKey)
@@ -1249,7 +1622,7 @@ describe("Bridge - Reservation", () => {
       expect((await bridge.reservations(reservationKey)).state).to.equal(1)
 
       // Default penalty is 100%: the whole detained amount is burned.
-      const veto = await redemptionWatchtower.vetoProposals(reservationKey)
+      const veto = await redemptionWatchtower.vetoProposals(vetoKey)
       expect(veto.withdrawableAmount).to.equal(0)
       expect(await bank.balanceOf(redemptionWatchtower.address)).to.equal(0)
 
@@ -1265,6 +1638,89 @@ describe("Bridge - Reservation", () => {
             redeemerOutputScript
           )
       ).to.be.revertedWith("Redemption request rejected by the watchtower")
+    })
+
+    it("should revert when the reserved redemption does not exist", async () => {
+      const freshKey = 667
+      await bridge.setReservation(
+        freshKey,
+        await activeReservation(thirdParty.address, walletPubKeyHash, amountSat)
+      )
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      ).to.be.revertedWith("Reserved redemption does not exist")
+    })
+
+    it("should revert when a guardian already objected", async () => {
+      const freshKey = 668
+      // thirdParty was banned by the earlier veto test above; use a
+      // different, unbanned owner/redeemer for this reservation.
+      await bridge.setReservation(
+        freshKey,
+        await activeReservation(governance.address, walletPubKeyHash, amountSat)
+      )
+
+      const bridgeSigner = await impersonateContract(bridge.address)
+      await bank
+        .connect(bridgeSigner)
+        .increaseBalance(reservationVault.address, amountSat)
+      const vaultSigner = await impersonateContract(reservationVault.address)
+      await bank
+        .connect(vaultSigner)
+        .approveBalance(bridge.address, amountSat)
+      await bridge
+        .connect(vaultSigner)
+        .requestReservedRedemption(
+          freshKey,
+          governance.address,
+          redeemerOutputScript
+        )
+
+      await redemptionWatchtower
+        .connect(guardianSigners[0])
+        .raiseReservedObjection(freshKey)
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      ).to.be.revertedWith("Guardian already objected")
+    })
+
+    it("should emit VetoPeriodCheckOmitted for a redemption requested before the watchtower was enabled", async () => {
+      const freshKey = 669
+      const grandfatheredRequestedAt = 1 // long before watchtowerEnabledAt
+
+      await bridge.setReservation(freshKey, {
+        ...(await activeReservation(
+          thirdParty.address,
+          walletPubKeyHash,
+          amountSat
+        )),
+        state: 2, // RedemptionRequested
+        redeemer: thirdParty.address,
+        redeemerOutputScriptHash: ethers.utils.keccak256(
+          redeemerOutputScript
+        ),
+        redemptionRequestedAt: grandfatheredRequestedAt,
+        redemptionTxMaxFee: RESERVATION_TX_MAX_FEE,
+      })
+
+      const vetoKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint32"],
+        [freshKey, grandfatheredRequestedAt]
+      )
+
+      await expect(
+        redemptionWatchtower
+          .connect(guardianSigners[0])
+          .raiseReservedObjection(freshKey)
+      )
+        .to.emit(redemptionWatchtower, "VetoPeriodCheckOmitted")
+        .withArgs(vetoKey)
     })
   })
 
@@ -1686,10 +2142,12 @@ describe("Bridge - Reservation", () => {
           tbtcVault.address,
           RESERVATION_MIN_AMOUNT,
           RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       const anchorTx = buildTx(
@@ -1714,6 +2172,73 @@ describe("Bridge - Reservation", () => {
       await expect(
         makeAcceptedReservation(depositAmount.sub(RESERVATION_TX_MAX_FEE + 1))
       ).to.be.revertedWith("Transaction fee is too high")
+    })
+
+    it("rejects an acceptance proof when reservations are disabled", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          ZERO_ADDRESS,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await expect(makeAcceptedReservation()).to.be.revertedWith(
+        "Reservations are disabled"
+      )
+    })
+
+    it("rejects an anchor below the reservation minimum amount", async () => {
+      await expect(
+        makeAcceptedReservation(BigNumber.from(RESERVATION_MIN_AMOUNT - 1))
+      ).to.be.revertedWith("Reservation amount too small")
+    })
+
+    it("rejects an acceptance that would exceed the total reserved amount cap", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          anchorAmount.sub(1),
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await expect(makeAcceptedReservation()).to.be.revertedWith(
+        "Total reserved amount cap exceeded"
+      )
+    })
+
+    it("rejects an acceptance that would exceed the per-wallet reservations cap", async () => {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          RESERVATION_MIN_AMOUNT,
+          RESERVATION_TX_MAX_FEE,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          1,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+
+      await makeAcceptedReservation()
+      await expect(makeAcceptedReservation()).to.be.revertedWith(
+        "Wallet reservations cap exceeded"
+      )
     })
 
     it("completes an in-kind reserved redemption", async () => {
@@ -1768,6 +2293,95 @@ describe("Bridge - Reservation", () => {
       expect(await tbtc.totalSupply()).to.equal(supplyBefore.sub(grossTbtc))
     })
 
+    it("acknowledges a late redemption proof for a reservation that already timed out", async () => {
+      // The wallet may have already broadcast the redemption transaction
+      // before the redeemer noticed the timeout. Once
+      // `notifyReservedRedemptionTimeout` records the terminal settlement
+      // and refunds the redeemer, the SPV proof for that exact anchor
+      // spend must still be acknowledgeable -- and must not move any
+      // further balance or allow the outpoint to be reused.
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await makeAcceptedReservation() // funds the owner with extra TBTC
+
+      const redeemerScript = `0x16${p2wpkhScript(
+        ethers.utils.hexlify(ethers.utils.randomBytes(20))
+      )}`
+      const redemptionFee = grossTbtc.mul(20).div(10000)
+      await tbtc
+        .connect(thirdParty)
+        .approve(reservationVault.address, grossTbtc.add(redemptionFee))
+      await reservationVault
+        .connect(thirdParty)
+        .redeemReservation(reservationKey, redeemerScript, redemptionFee)
+
+      const { redemptionTimeout } = await bridge.redemptionParameters()
+      await increaseTime(redemptionTimeout + 1)
+
+      const redeemerBalanceBeforeTimeout = await bank.balanceOf(
+        thirdParty.address
+      )
+      await bridge
+        .connect(thirdParty)
+        .notifyReservedRedemptionTimeout(reservationKey, [1, 2, 3, 4, 5])
+      walletRegistry.seize.reset()
+
+      // The gross amount was refunded as Bank balance on timeout.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        redeemerBalanceBeforeTimeout.add(anchorAmount)
+      )
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      const redemptionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(1000),
+            script: redeemerScript.slice(4),
+          },
+        ]
+      )
+
+      const bankBalanceBeforeProof = await bank.balanceOf(thirdParty.address)
+      const supplyBeforeProof = await tbtc.totalSupply()
+
+      const tx = await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Redemption,
+          redemptionTx.info,
+          proofFor(redemptionTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey
+        )
+
+      await expect(tx)
+        .to.emit(bridge, "ReservedRedemptionSettled")
+        .withArgs(reservationKey, redemptionTx.txHash)
+
+      // No further balance movement: the redeemer was already made whole
+      // by the timeout refund above, and the reservation stays Active.
+      expect(await bank.balanceOf(thirdParty.address)).to.equal(
+        bankBalanceBeforeProof
+      )
+      expect(await tbtc.totalSupply()).to.equal(supplyBeforeProof)
+      expect((await bridge.reservations(reservationKey)).state).to.equal(1) // Active
+
+      // The settlement record is consumed: neither a repeat submission of
+      // the same proof nor a fresh acceptance can reuse the anchor
+      // outpoint.
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Redemption,
+            redemptionTx.info,
+            proofFor(redemptionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("No pending reserved redemption")
+    })
+
     it("keeps redemption provable when txMaxFee exceeds the anchor (underflow guard)", async () => {
       // Regression: redemptionTxMaxFee is a governable parameter, not a
       // tx-derived value, so a governance increase can push it above an
@@ -1785,10 +2399,12 @@ describe("Bridge - Reservation", () => {
           reservationVault.address,
           anchorAmount.add(2),
           anchorAmount.add(1),
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
           RESERVATION_TERM,
           RESERVATION_GRACE,
           RESERVATION_MAX_TOTAL,
-          MAX_RESERVATIONS_PER_WALLET
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
         )
 
       const redeemerScript = `0x16${p2wpkhScript(
@@ -1906,6 +2522,158 @@ describe("Bridge - Reservation", () => {
           reanchorTx.txHash,
           migrated
         )
+    })
+
+    it("rejects a re-anchor paying an excessive fee", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(RESERVATION_TX_MAX_FEE + 1),
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Transaction fee is too high")
+    })
+
+    it("rejects a re-anchor landing at or below the dust floor", async () => {
+      // Lower the governance parameters so a single hop can carry an
+      // above-minimum anchor down to at-or-below the dust floor while
+      // staying within the per-transaction fee bound (minAmount must
+      // stay above txMaxFee by construction, so minAmount <= 2*txMaxFee
+      // is required to reach the floor in one hop). Build a small custom
+      // deposit/anchor pair instead of `makeAcceptedReservation`, whose
+      // fixed deposit size would blow the lowered fee bound.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          150,
+          100,
+          RESERVATION_DISSOLUTION_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          MAX_CUMULATIVE_REANCHOR_FEE
+        )
+      await bridge.setDepositDustThreshold(50)
+
+      const fundingTx = buildTx(
+        [
+          {
+            txHash: ethers.utils.hexlify(ethers.utils.randomBytes(32)),
+            index: 0,
+          },
+        ],
+        [
+          {
+            valueSat: 200, // 150 anchor + 50 acceptance-time fee
+            script: p2wshScript(
+              buildDepositScript(
+                thirdParty.address,
+                blindingFactor,
+                walletPubKeyHash,
+                refundPubKeyHash,
+                refundLocktime
+              )
+            ),
+          },
+        ]
+      )
+      await bridge.connect(thirdParty).revealDeposit(fundingTx.info, {
+        fundingOutputIndex: 0,
+        blindingFactor,
+        walletPubKeyHash,
+        refundPubKeyHash,
+        refundLocktime,
+        vault: reservationVault.address,
+      })
+      const anchorTx = buildTx(
+        [{ txHash: fundingTx.txHash, index: 0 }],
+        [{ valueSat: 150, script: p2wpkhScript(walletPubKeyHash) }]
+      )
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Acceptance,
+          anchorTx.info,
+          proofFor(anchorTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          0
+        )
+      const reservationKey = BigNumber.from(
+        ethers.utils.solidityKeccak256(
+          ["bytes32", "uint32"],
+          [fundingTx.txHash, 0]
+        )
+      )
+
+      await liveWallet(secondWalletPubKeyHash)
+
+      const reanchorTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [{ valueSat: 100, script: p2wpkhScript(secondWalletPubKeyHash) }]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            reanchorTx.info,
+            proofFor(reanchorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith("Re-anchor amount below the dust floor")
+    })
+
+    it("rejects a dissolution output that does not pay the custodying wallet", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+
+      await increaseTime(RESERVATION_TERM + RESERVATION_GRACE + 60)
+
+      const dissolutionFee = 500
+      const dissolutionTx = buildTx(
+        [{ txHash: anchorTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: anchorAmount.sub(dissolutionFee),
+            // Pays a different wallet than the custodying one.
+            script: p2wpkhScript(secondWalletPubKeyHash),
+          },
+        ]
+      )
+
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Dissolution,
+            dissolutionTx.info,
+            proofFor(dissolutionTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey
+          )
+      ).to.be.revertedWith(
+        "Dissolution output must pay to the custodying wallet"
+      )
     })
 
     it("dissolves an expired reservation into the wallet main UTXO", async () => {


### PR DESCRIPTION
Follow-up to #1088 addressing the confirmed findings from its multi-agent review (see `agent-docs/reviews/pr-1088/report.md` for the full report), plus the confirmed findings from this PR's own follow-up multi-agent review. Stacked on `feat/utxo-reservation-core` rather than pushed directly to it.

## Correctness (P0/P1)
- Fix the redemption timeout/veto settlement race (P0-1/P0-2 from #1088): a late-arriving SPV proof for an already-settled anchor spend is now acknowledged via a terminal settlement record instead of reverting or double-crediting the redeemer.
- The late-proof settlement branch now terminalizes the reservation (calls `closeReservation`) instead of leaving it permanently `Active` with an anchor that Bitcoin has already spent -- closes a zombie-reservation / unbounded wallet-slashing loop.
- Removed the dissolution fee-loss burn that decremented the Bridge's own aggregate Bank balance -- composed entirely of unrelated users' escrow, not the dissolving reservation's own funds. Removing it leaves the re-anchor fee gap (`mintedAmount` vs `anchorAmount`) unreconciled rather than burned against the wrong balance; `ReservationDissolved` now emits the decomposition so that cost is observable. See "Known tradeoffs" below.
- The settlement branch now validates a late-arriving proof's output against the redeemer script snapshotted at settlement time (`ReservedRedemptionSettlement.redeemerOutputScriptHash`), closing a fraud-challenge-evasion gap where a wallet could redirect a settled anchor's spend to an address it controls.
- `Bridge.reservationParameters()` now exposes `reservationDissolutionTxMaxFee` and `maxCumulativeReanchorFee`; `WalletProposalValidator`'s dissolution proposal check now bounds against the dedicated dissolution cap instead of the shared `reservationTxMaxFee`.
- `updateReservationParameters` now validates both new governance parameters (`reservationDissolutionTxMaxFee`, `maxCumulativeReanchorFee`) are nonzero, matching the existing convention for `reservationTxMaxFee`.
- Gate `ReservationVault.retryRedeemReservation` on a genuine wallet-fault timeout marker instead of any timeout; narrowed the marker itself to only flag true slashing (Live/MovingFunds), not a Terminated-wallet timeout that skips slashing.
- Key `RedemptionWatchtower`'s reserved veto state per request generation (reservation key + request timestamp) instead of the bare reservation key, so a stale veto/objection count from a resolved request generation can't block or bias a future one.
- The terminal settlement record now clears on reservation close (redemption, dissolution, or a late-arriving proof) so it cannot outlive the request generation that created it, and drops its redundant `pending` bool in favor of a zero-sentinel check on `anchorTxHash`.
- Add a dust floor to re-anchor amounts, cap cumulative re-anchor fee loss per reservation, and bound `extendCustody` fees with a caller-supplied `maxFee` (mirroring `redeemReservation`; `retryRedeemReservation` itself charges no fee, so no bound applies there).
- Fix a redundant, drifted `ReservationParametersUpdated` event redeclaration in `Bridge.sol` that no longer matched the emitted signature.

## Known tradeoffs (accepted, not resolved here)
- **Re-anchor and dissolution miner fees stay unreconciled, bounded per reservation by `maxCumulativeReanchorFee` + `reservationDissolutionTxMaxFee`.** `mintedAmount` (the owner's gross claim) never changes on re-anchor; `anchorAmount` shrinks by the Bitcoin fee each hop, and dissolution pays one more fee. On dissolution the difference is not reconciled against any balance. The prior code tried to burn it from the Bridge's pooled Bank balance -- unrelated depositors' escrow, since a dissolving reservation (state `Active`) has nothing escrowed in the Bridge -- which was the actual bug.

  This is not a new class of loss. `MovingFunds.submitMovingFundsProof` caps wallet-migration fees against `movingFundsTxMaxTotalFee` and reconciles nothing either, and baseline deposit sweeps socialize the sweep fee the same way: operationally-driven Bitcoin fees have always been pool-socialized in tBTC. The owner did not choose the re-anchor, the wallet did -- the same reasoning that makes moving-funds socialization acceptable, and why charging the owner is not an obvious fix. Reconciling it would need a mechanism that first obtains the shortfall from the owner: new policy rather than a bug fix, and out of scope here. `ReservationDissolved` now emits `mintedAmount`, `anchorAmount`, and `dissolutionFee` so the realized shortfall is observable off-chain.

## Test coverage
Add tests for the confirmed test-coverage findings: the timeout/late-proof settlement race (including the wrong-outpoint guard and the vetoed-request variant), `extendCustody` through the real vault path, Live-wallet timeout slashing, the Terminated-wallet slashing-skip path, redeemer output-script guards, re-anchor/dissolution negative paths (including the cumulative re-anchor fee budget and a re-anchor-then-dissolve run proving no Bank balance is burned), reservation caps, `updateFees` bound violation, multi-depositor `receiveBalanceIncrease`, `raiseReservedObjection` negative paths and cross-generation isolation, acceptance entry guards (including acceptance after a vault swap), `extendReservation`'s active-state guard, and the remaining `updateReservationParameters` validation reverts.

Self-review addendum -- three coverage gaps found reviewing this branch's own work. (1) The existing `validateReservationDissolutionProposal` test never advanced past its own "term/grace not elapsed" revert, so it gave zero discriminating coverage of the `reservationDissolutionTxMaxFee` vs `reservationTxMaxFee` fix; both constants were 2000 in the fixture, so a test would have passed either way. (2) The same ambiguity applied to the on-chain check in `submitReservationDissolutionProof` -- confirmed by mutation that swapping it to `reservationTxMaxFee` left the entire suite green. The fixture caps are now distinct (2000 vs 1500) and both paths have discriminating tests, each confirmed to fail against the pre-fix or mutated code. (3) Every dissolution test in the suite was 1-in-1-out, leaving the dominant 2-in-1-out shape (`processDissolutionInputs`' main-UTXO branch) entirely untested; the new decomposition test covers it.

## Refactors and behavior changes not from the review
Scope drifted beyond the "address #1088's review findings" framing; called out explicitly here rather than left implicit:
- New governance parameter `reservationDissolutionTxMaxFee` (dedicated dissolution fee cap, distinct from `reservationTxMaxFee`).
- `extendReservation` narrowed from `Active || RedemptionRequested` to `Active`-only.
- `closeReservation`'s aggregate decrement changed from `anchorAmount` to `mintedAmount` -- itself a genuine, previously-unannounced bug fix (the old formula under-decremented `reservationTotalAmount` after re-anchor hops).
- `reservationsByAnchorUtxo` index deleted outright (no longer needed).
- The redeemer-output-script check extracted into the shared `OutboundTx.validateRedeemerOutputScript` helper and rewired into the pooled redemption path too.
- `ReservationDissolved` gained three fields -- `mintedAmount`, `anchorAmount`, `dissolutionFee` -- so the unreconciled fee loss described under "Known tradeoffs" is observable off-chain instead of invisible. An event ABI change, done now because the reservation feature is unreleased and the ABI is still malleable; after merge the same change costs a migration.

## Other
- Add a shared `_outpointKey` helper for the repeated outpoint-hash formula in `Reservation.sol` (P3 simplicity finding).
- Correct `BridgeState.Storage.__gap` from 42 to 41 slots to match the actual net storage variables this branch inserts -- restores upgrade-safety against the deployed TIP-109 Bridge layout.
- Reduce the `Bridge.sol` optimizer `runs` from 100 to 90 to keep it under the Spurious Dragon size limit after these fixes.
- Various NatSpec/doc corrections for comments that had drifted from behavior.

## Verification
- `yarn hardhat compile` (clean, exit 0, all contracts under the size limit including `Bridge.sol`).
- `USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat test test/bridge/Bridge.Reservation.test.ts` -- 63 passing.
- `USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true hardhat test` (full suite) -- 3075 passing, 33 pending (pre-existing skips), 0 failing.
- `yarn format` (eslint + solhint + prettier) -- clean.

