### PR TITLE
test(reservation): characterize the accepted cumulative re-anchor fee exposure

### DIFF
--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -2486,4 +2486,215 @@ describe("Bridge - Reservation settlement", () => {
       expect(walletRegistry.closeWallet).not.to.have.been.called
     })
   })
+
+  // Characterization of an ACCEPTED, DOCUMENTED regression, not a bug
+  // report. `#1093` has no equivalent of `#1102`'s
+  // `maxCumulativeReanchorFee`, so cumulative re-anchor fee loss on one
+  // reservation is bounded only by the dust floor, which scales with the
+  // claim instead of being capped at a small governance-set constant.
+  // Milestone 1 accepts that (see `docs/spec/reservations/pr-review-followups.md`
+  // item 7, lever 4, and the accompanying deferral note), and these tests
+  // exist so the accepted exposure is executable rather than asserted, and
+  // so the assumption it rests on cannot be relaxed silently.
+  describe("cumulative re-anchor fee exposure (accepted regression)", () => {
+    // A scaled parameter regime, the same technique `#1102`'s own
+    // characterization test used: at the default 2,000 sat `txMaxFee` a
+    // full grind of this fixture's 2,998,500 sat anchor would take ~1,498
+    // hops. Raising the fee bound compresses it to 7 without changing the
+    // mechanism under test. `reservationMinAmount` has to move with it to
+    // satisfy `reservationMinAmount > reservationTxMaxFee`.
+    const GRIND_TX_MAX_FEE = 400000
+    const GRIND_MIN_AMOUNT = 500000
+
+    // `#1102`'s fixture ceiling, for the comparison assertion below.
+    const PR1102_CAP = 100000
+
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    async function raiseFeeBound() {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .updateReservationParameters(
+          reservationVault.address,
+          GRIND_MIN_AMOUNT,
+          GRIND_TX_MAX_FEE,
+          RESERVATION_TERM,
+          RESERVATION_GRACE,
+          RESERVATION_MAX_TOTAL,
+          MAX_RESERVATIONS_PER_WALLET,
+          RESERVATION_ACTION_TIMEOUT,
+          RESERVATION_RENEWAL_WINDOW
+        )
+    }
+
+    // One governance-authorized hop, ping-ponging between two Live
+    // wallets. Returns the settled transaction so the next hop can spend
+    // its output.
+    async function grindOneHop(
+      reservationKey: BigNumber,
+      sourceTx: { txHash: string },
+      target: string,
+      newAnchorValue: BigNumber,
+      nonce: number
+    ) {
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, target)
+
+      const hopTx = buildTx(
+        [{ txHash: sourceTx.txHash, index: 0 }],
+        [{ valueSat: newAnchorValue, script: p2wpkhScript(target) }]
+      )
+
+      await bridge
+        .connect(spvMaintainer)
+        .submitReservationProof(
+          ProofType.Reanchor,
+          hopTx.info,
+          proofFor(hopTx.txHash),
+          NO_MAIN_UTXO_PARAM,
+          reservationKey,
+          nonce
+        )
+
+      return hopTx
+    }
+
+    it("lets most of a claim evaporate into miner fees, with no absolute ceiling", async () => {
+      const { anchorTx, reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+      await raiseFeeBound()
+
+      const reserveBefore = await tbtc.balanceOf(reservationVault.address)
+      const debtBefore = await reservationVault.inKindFeeDebtSat()
+
+      // Grind at the maximum permitted fee per hop until the next full-fee
+      // hop would breach the dust floor. The hop count is derived, never
+      // hardcoded: that is the point, since it scales with the claim.
+      let currentTx = anchorTx
+      let currentAnchor = anchorAmount
+      let target = secondWalletPubKeyHash
+      let nonce = 2
+      let hops = 0
+
+      while (currentAnchor.sub(GRIND_TX_MAX_FEE).gt(GRIND_TX_MAX_FEE)) {
+        const nextAnchor = currentAnchor.sub(GRIND_TX_MAX_FEE)
+        currentTx = await grindOneHop(
+          reservationKey,
+          currentTx,
+          target,
+          nextAnchor,
+          nonce
+        )
+        currentAnchor = nextAnchor
+        target =
+          target === secondWalletPubKeyHash
+            ? walletPubKeyHash
+            : secondWalletPubKeyHash
+        nonce += 1
+        hops += 1
+      }
+
+      // One final partial-fee hop lands the anchor exactly on the dust
+      // floor's boundary, `txMaxFee + 1`, which is the true worst case.
+      const floorBoundary = BigNumber.from(GRIND_TX_MAX_FEE + 1)
+      if (currentAnchor.gt(floorBoundary)) {
+        currentTx = await grindOneHop(
+          reservationKey,
+          currentTx,
+          target,
+          floorBoundary,
+          nonce
+        )
+        currentAnchor = floorBoundary
+        nonce += 1
+        hops += 1
+        // The reservation now sits on `target`, so the terminal attempt
+        // below has to name the other wallet. Inside the loop this flip
+        // happens on every iteration; here it has to happen explicitly.
+        target =
+          target === secondWalletPubKeyHash
+            ? walletPubKeyHash
+            : secondWalletPubKeyHash
+      }
+
+      const reservation = await bridge.reservations(reservationKey)
+      const cumulativeFee = anchorAmount.sub(currentAnchor)
+
+      // The claim is written down to the surviving anchor: the owner's
+      // redemption right shrinks by the full grind.
+      expect(reservation.anchorAmount).to.equal(currentAnchor)
+      expect(reservation.mintedAmount).to.equal(currentAnchor)
+
+      // Every satoshi of the grind is financed in kind: burned from the
+      // vault's reserve where it could cover, recorded as global debt
+      // where it could not. Nothing is left unaccounted.
+      const reserveAfter = await tbtc.balanceOf(reservationVault.address)
+      const debtAfter = await reservationVault.inKindFeeDebtSat()
+      const burnedSat = reserveBefore.sub(reserveAfter).div(SATOSHI_MULTIPLIER)
+      expect(burnedSat.add(debtAfter.sub(debtBefore))).to.equal(cumulativeFee)
+
+      // The characterization itself. Both assertions would FAIL if an
+      // absolute per-reservation ceiling were ported, which is exactly
+      // what makes the accepted regression executable rather than a claim
+      // in a document.
+      expect(cumulativeFee).to.be.gt(PR1102_CAP)
+      expect(cumulativeFee.mul(100).div(anchorAmount)).to.be.gte(86)
+
+      // And the grind is genuinely terminal: one more full-fee hop cannot
+      // settle, because the dust floor is the only thing that ever stopped
+      // it.
+      await bridge
+        .connect(bridgeGovernanceSigner)
+        .requestReservationReanchor(reservationKey, target)
+      const belowFloorTx = buildTx(
+        [{ txHash: currentTx.txHash, index: 0 }],
+        [
+          {
+            valueSat: BigNumber.from(GRIND_TX_MAX_FEE),
+            script: p2wpkhScript(target),
+          },
+        ]
+      )
+      await expect(
+        bridge
+          .connect(spvMaintainer)
+          .submitReservationProof(
+            ProofType.Reanchor,
+            belowFloorTx.info,
+            proofFor(belowFloorTx.txHash),
+            NO_MAIN_UTXO_PARAM,
+            reservationKey,
+            nonce
+          )
+      ).to.be.revertedWith("Re-anchor amount below the dust floor")
+
+      // Recorded for the deferral note: the hop count scales with the
+      // claim, so this figure is regime-specific, not a constant bound.
+      expect(hops).to.be.gte(7)
+    })
+
+    it("depends on the governance gate: a Live wallet's anchor cannot be rotated permissionlessly", async () => {
+      // The accepted regression above is only tolerable because reaching
+      // it requires governance to authorize every hop. If this gate is
+      // ever relaxed, the unbounded exposure becomes reachable by the
+      // custodying wallet operator alone, which is the threat model
+      // `pr-review-followups.md` item 7 scored as the severity-driving
+      // case. This test is the tripwire for that change.
+      const { reservationKey } = await makeAcceptedReservation()
+      await liveWallet(secondWalletPubKeyHash)
+
+      await expect(
+        bridge
+          .connect(thirdParty)
+          .requestReservationReanchor(reservationKey, secondWalletPubKeyHash)
+      ).to.be.revertedWith("Only governance can rotate a Live wallet's anchor")
+    })
+  })
 })

--- a/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationSettlement.test.ts
@@ -2494,8 +2494,24 @@ describe("Bridge - Reservation settlement", () => {
   // claim instead of being capped at a small governance-set constant.
   // Milestone 1 accepts that (see `docs/spec/reservations/pr-review-followups.md`
   // item 7, lever 4, and the accompanying deferral note), and these tests
-  // exist so the accepted exposure is executable rather than asserted, and
-  // so the assumption it rests on cannot be relaxed silently.
+  // exist so the accepted exposure is executable rather than asserted.
+  //
+  // Two limits, for whoever edits this next:
+  //
+  // 1. The assertions below are deliberately BOUNDS (`gt`, `gte`), not exact
+  //    figures, so a fixture change cannot fail them spuriously. The exact
+  //    measured numbers (2,598,499 sat, 86.7%, 7 hops) live in the spec prose
+  //    instead, which means the prose can drift away from reality without
+  //    anything here going red. If these bounds are edited, re-check that
+  //    prose too.
+  // 2. The second test pins the governance gate this acceptance rests on, but
+  //    it can only catch the gate being REMOVED. It cannot catch `privileged`
+  //    being BROADENED, e.g. a second authorized role added alongside
+  //    `governance` in `ReservationRouter.sol`, which would reopen the grind
+  //    to a non-governance caller with every test here still green. Anyone
+  //    touching how `privileged` is derived is changing the assumption this
+  //    whole block documents, and voids the acceptance regardless of whether
+  //    CI complains.
   describe("cumulative re-anchor fee exposure (accepted regression)", () => {
     // A scaled parameter regime, the same technique `#1102`'s own
     // characterization test used: at the default 2,000 sat `txMaxFee` a
@@ -2585,6 +2601,9 @@ describe("Bridge - Reservation settlement", () => {
 
       while (currentAnchor.sub(GRIND_TX_MAX_FEE).gt(GRIND_TX_MAX_FEE)) {
         const nextAnchor = currentAnchor.sub(GRIND_TX_MAX_FEE)
+        // Sequential on purpose: each hop spends the previous hop's output,
+        // so these cannot be batched or parallelised.
+        // eslint-disable-next-line no-await-in-loop
         currentTx = await grindOneHop(
           reservationKey,
           currentTx,
@@ -2687,6 +2706,11 @@ describe("Bridge - Reservation settlement", () => {
       // custodying wallet operator alone, which is the threat model
       // `pr-review-followups.md` item 7 scored as the severity-driving
       // case. This test is the tripwire for that change.
+      //
+      // Scope, per limit 2 in this block's header: this catches the gate
+      // being removed, not `privileged` being widened to admit a second
+      // caller. A green run here is not evidence the assumption still
+      // holds; it is only evidence this particular gate still exists.
       const { reservationKey } = await makeAcceptedReservation()
       await liveWallet(secondWalletPubKeyHash)
 


### PR DESCRIPTION
## What

Adds one `describe` block to `Bridge.ReservationSettlement.test.ts`: two
tests, 211 lines, no production code touched.

## Why

This branch has no equivalent of `#1102`'s `maxCumulativeReanchorFee`.
Cumulative re-anchor fee loss is therefore bounded only by the dust floor,
which scales with claim size, rather than by a claim-size-independent
ceiling.

That was reviewed and **accepted for milestone 1**, with a structural bound
deferred to post-m1 work. The accepted option is the one that requires the
choice be written down rather than left as an omission, so leaving it
implicit is not available. Prose alone is weak: nothing stops a later change
from silently reintroducing or contradicting it. These tests make the
accepted exposure executable.

## What the tests assert

**1. `lets most of a claim evaporate into miner fees, with no absolute
ceiling`**

Grinds one reservation at the maximum permitted fee per hop until the dust
floor blocks settlement, deriving the hop count instead of hardcoding it.
Measures 2,598,499 sat lost over 7 hops, 86.7% of a 2,998,500 sat anchor.

- `cumulativeFee > 100000`, `#1102`'s fixture ceiling, so this test **fails
  if an absolute ceiling is later ported**. That inversion is the point.
- `cumulativeFee * 100 / anchorAmount >= 86`
- `hops >= 7`
- Financing invariant, exact: reserve burn plus `inKindFeeDebtSat` delta
  equals the cumulative fee. Nothing is left unaccounted.
- One more full-fee hop reverts with `Re-anchor amount below the dust floor`,
  confirming the floor is the only thing that ever stopped the grind.

**2. `depends on the governance gate: a Live wallet's anchor cannot be
rotated permissionlessly`**

A third party calling `requestReservationReanchor` on a `Live`-sourced
reservation reverts with `Only governance can rotate a Live wallet's anchor`.

## The assumption this rests on

`Reservation.sol:775-779` requires `privileged` when the source wallet is
`Live`; `ReservationRouter.sol:284` derives that as `msg.sender ==
governance`. `Reservation.sol:792-796` requires the hop target to be `Live`
too, so the next hop for the same reservation is forced back through the same
gate. The grind cannot run unilaterally.

The acceptance is void if that gate is relaxed, delegated, or extended to
other source states.

## Known limitations, stated rather than buried

The first two are also written into the test file itself, not only here, since
a PR description is not what someone editing this block in a year will read.

- **The tripwire is partial.** Test 2 catches *removal* of the gate. It does
  not catch a delegated authorizer added alongside `governance`, which would
  satisfy `privileged` for a non-governance caller and reopen the grind with
  every test still green. Pinning the authorizer set instead of one negative
  case would close this.
- **The regime is chosen.** `reservationTxMaxFee` is raised to 400,000 sat and
  `reservationMinAmount` to 500,000 sat, compressing a roughly 1,498-hop grind
  to 7 without changing the mechanism under test. This is the same technique
  `#1102`'s own characterization test used. The 86.7% figure is therefore
  regime-specific and should not be read as a production loss estimate; what
  transfers is the mechanism and the absence of a ceiling.
- **Bounds, not exact figures.** The assertions are `>` and `>=` so a fixture
  change cannot fail them spuriously. The tradeoff is that the precise
  numbers quoted in prose can drift from reality without any test failing.

## Base

Targets `feat/utxo-reservation-backing` because the code under test exists
only on this branch. Against `main` or the milestone epic branch the diff
would be 79 commits and 47 files instead of one file.

## Verification

Use `yarn test`, not `yarn hardhat test`. The env vars come from the `test`
script in `solidity/package.json`, so invoking hardhat directly runs without
them.

```
cd solidity
yarn test \
  test/bridge/Bridge.Reservation.test.ts \
  test/bridge/Bridge.ReservationBacking.test.ts \
  test/bridge/Bridge.ReservationSettlement.test.ts \
  test/bridge/ReservationRouter.test.ts \
  test/deploy/95_deploy_reservation_vault.test.ts \
  test/bridge/Bridge.StorageLayout.test.ts
```

121 passing, 0 failing, measured at `1a636939`. Baseline on this branch before
the change was 119; the two new tests account for the difference.
Snapshot-isolated via `createSnapshot`/`restoreSnapshot`, so the raised fee
regime does not leak into other tests.

If `FORKING_URL` is exported in your shell, prefix
`env -u FORKING_URL -u FORKING_BLOCK`. `hardhat.config.ts` turns forking on
whenever that variable is present, and every `before all` hook then times out
against mainnet. CI is unaffected because it does not set it.

**Lint is a separate gate and the test command does not cover it.** The first
push here passed the suite and still failed `contracts-format` on a single
`no-await-in-loop` error. To reproduce that gate:

```
cd solidity
yarn format
```

That is verbatim what the `contracts-format` job runs. It is read-only:
`format` is `npm run lint && prettier --check .`, while the writing variant is
the separate `format:fix`.

One local-only trap: a test run drops `gasReporterOutput.json`, which is
gitignored and so absent in CI, but present locally it fails the
`prettier --check .` half of this gate. Delete it before running.
