### PR TITLE
feat(bridge): declare the milestone 1 reservation storage layout

### DIFF
--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -361,8 +361,12 @@ library BridgeState {
         address reservationVault;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation lifecycle transaction (anchor,
-        // re-anchor, reserved redemption). Dissolution transactions use
-        // `reservationDissolutionTxMaxFee` instead.
+        // re-anchor, reserved redemption). Dissolution's fee economics
+        // differ (2-in-1-out shape) and are not yet covered by any cap: a
+        // dedicated field was proposed and dropped from this PR, since
+        // unlike `cumulativeReanchorFee` it has no historical-data
+        // constraint and can be added via `__gap` whenever the milestone
+        // that implements dissolution lands, live reservations or not.
         uint64 reservationTxMaxFee;
         // The dissolution delay in seconds after a reservation's custody
         // term expires and before the reservation becomes dissolvable. The
@@ -411,23 +415,6 @@ library BridgeState {
         // to the old vault would otherwise become pool-sweepable while
         // still minting through the old vault's callback.
         uint64 pendingReservedDeposits;
-        // Per-reservation cumulative re-anchor fee budget in satoshi, in the
-        // flat-ceiling shape the milestone 1 decision rejected: the absolute
-        // ceiling was left unbounded and a structural bound (proportional to
-        // mintedAmount, hop count, or a rate) was deferred to post-milestone-1
-        // work. That replacement is undesigned and may not even fit a single
-        // uint64. Declared, never written or read in milestone 1 - only
-        // because a field a later milestone reads cannot be added while
-        // reservations are live.
-        uint64 maxCumulativeReanchorFee;
-        // Maximum amount of BTC transaction fee in satoshi that can be
-        // incurred by a single reservation dissolution transaction
-        // (2-in-1-out shape). Distinct from `reservationTxMaxFee` because
-        // dissolution's fee economics differ from the 1-in-1-out anchor /
-        // re-anchor / redemption shapes that share `reservationTxMaxFee`.
-        // Declared, never written or read in milestone 1: dissolution is a
-        // later milestone.
-        uint64 reservationDissolutionTxMaxFee;
         // Global count of open reservation positions. Distinct from the
         // per-wallet `walletReservationsCount` and from the global amount
         // `reservationTotalAmount`: neither bounds how many positions exist
@@ -510,13 +497,13 @@ library BridgeState {
         // planned upgrades of the Bridge contract. If more entires are added to
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-        // This milestone consumed 15 of the original 48 slots (28 reservation
+        // This milestone consumed 14 of the original 48 slots (26 reservation
         // fields plus PendingReservedDeposit) for the reservation feature. The
-        // remaining 33 slots are shared budget for all future Bridge upgrades,
+        // remaining 34 slots are shared budget for all future Bridge upgrades,
         // not reserved for reservations specifically - a later unrelated PR
         // should not assume it can spend the rest.
         // slither-disable-next-line unused-state
-        uint256[33] __gap;
+        uint256[34] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -361,12 +361,8 @@ library BridgeState {
         address reservationVault;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation lifecycle transaction (anchor,
-        // re-anchor, reserved redemption). Dissolution's fee economics
-        // differ (2-in-1-out shape) and are not yet covered by any cap: a
-        // dedicated field was proposed and dropped from this PR, since
-        // unlike `cumulativeReanchorFee` it has no historical-data
-        // constraint and can be added via `__gap` whenever the milestone
-        // that implements dissolution lands, live reservations or not.
+        // re-anchor, reserved redemption). Dissolution transactions use
+        // `reservationDissolutionTxMaxFee` instead.
         uint64 reservationTxMaxFee;
         // The dissolution delay in seconds after a reservation's custody
         // term expires and before the reservation becomes dissolvable. The
@@ -415,6 +411,23 @@ library BridgeState {
         // to the old vault would otherwise become pool-sweepable while
         // still minting through the old vault's callback.
         uint64 pendingReservedDeposits;
+        // Per-reservation cumulative re-anchor fee budget in satoshi, in the
+        // flat-ceiling shape the milestone 1 decision rejected: the absolute
+        // ceiling was left unbounded and a structural bound (proportional to
+        // mintedAmount, hop count, or a rate) was deferred to post-milestone-1
+        // work. That replacement is undesigned and may not even fit a single
+        // uint64. Declared, never written or read in milestone 1 - only
+        // because a field a later milestone reads cannot be added while
+        // reservations are live.
+        uint64 maxCumulativeReanchorFee;
+        // Maximum amount of BTC transaction fee in satoshi that can be
+        // incurred by a single reservation dissolution transaction
+        // (2-in-1-out shape). Distinct from `reservationTxMaxFee` because
+        // dissolution's fee economics differ from the 1-in-1-out anchor /
+        // re-anchor / redemption shapes that share `reservationTxMaxFee`.
+        // Declared, never written or read in milestone 1: dissolution is a
+        // later milestone.
+        uint64 reservationDissolutionTxMaxFee;
         // Global count of open reservation positions. Distinct from the
         // per-wallet `walletReservationsCount` and from the global amount
         // `reservationTotalAmount`: neither bounds how many positions exist
@@ -497,13 +510,13 @@ library BridgeState {
         // planned upgrades of the Bridge contract. If more entires are added to
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-        // This milestone consumed 14 of the original 48 slots (26 reservation
+        // This milestone consumed 15 of the original 48 slots (28 reservation
         // fields plus PendingReservedDeposit) for the reservation feature. The
-        // remaining 34 slots are shared budget for all future Bridge upgrades,
+        // remaining 33 slots are shared budget for all future Bridge upgrades,
         // not reserved for reservations specifically - a later unrelated PR
         // should not assume it can spend the rest.
         // slither-disable-next-line unused-state
-        uint256[34] __gap;
+        uint256[33] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -361,7 +361,8 @@ library BridgeState {
         address reservationVault;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation lifecycle transaction (anchor,
-        // re-anchor, reserved redemption, dissolution).
+        // re-anchor, reserved redemption). Dissolution transactions use
+        // `reservationDissolutionTxMaxFee` instead.
         uint64 reservationTxMaxFee;
         // The dissolution delay in seconds after a reservation's custody
         // term expires and before the reservation becomes dissolvable. The
@@ -459,16 +460,14 @@ library BridgeState {
         // and whole/partial shape the fee-free retry must preserve. Zero
         // means there is no bound source generation.
         mapping(uint256 => uint64) reservationRetryCreditActionNonce;
-        // Per-reservation cumulative re-anchor fee budget in satoshi. Caps
-        // the total satoshi that may be lost across all re-anchor hops for
-        // a single reservation, complementing the per-transaction
-        // `reservationTxMaxFee` bound which only constrains a single hop.
-        // Bounds in-kind grinding of the anchor value over the reservation
-        // lifetime. Declared, never written or read in milestone 1: the
-        // milestone 1 decision left the absolute ceiling unbounded and
-        // deferred a structural bound to post-milestone-1 work. It is
-        // declared anyway because a field a later milestone reads cannot be
-        // added while reservations are live.
+        // Per-reservation cumulative re-anchor fee budget in satoshi, in the
+        // flat-ceiling shape the milestone 1 decision rejected: the absolute
+        // ceiling was left unbounded and a structural bound (proportional to
+        // mintedAmount, hop count, or a rate) was deferred to post-milestone-1
+        // work. That replacement is undesigned and may not even fit a single
+        // uint64. Declared, never written or read in milestone 1 - only
+        // because a field a later milestone reads cannot be added while
+        // reservations are live.
         uint64 maxCumulativeReanchorFee;
         // Maximum amount of BTC transaction fee in satoshi that can be
         // incurred by a single reservation dissolution transaction
@@ -485,12 +484,18 @@ library BridgeState {
         // milestone 1 path frees a wallet slot except wallet termination.
         // Genuinely new in milestone 1 - no extraction source.
         uint32 activeReservationsCount;
-        // Governance cap on `activeReservationsCount`, set below the slot
-        // floor `liveWalletsCount * maxReservationsPerWallet` so acceptance
-        // reverts before occupancy saturates. At saturation a re-anchor has
-        // no target wallet and an anchored wallet cannot retire, because
-        // closing requires a zero reservation count - its MovingFunds clock
-        // then expires and the timeout seizes operator stake. This cap turns
+        // Governance-time cap on `activeReservationsCount`, sized below the
+        // slot capacity `liveWalletsCount * maxReservationsPerWallet` at the
+        // time it is set so acceptance reverts before occupancy saturates.
+        // liveWalletsCount is mutable and falls whenever a Live wallet
+        // retires (an un-anchored one can retire freely), so this sizing
+        // must be re-evaluated by governance whenever liveWalletsCount
+        // falls - a cap correct at set-time can otherwise silently drop
+        // below the shrunk floor later and reopen the saturation cliff this
+        // field exists to prevent. At saturation a re-anchor has no target
+        // wallet and an anchored wallet cannot retire, because closing
+        // requires a zero reservation count - its MovingFunds clock then
+        // expires and the timeout seizes operator stake. This cap turns
         // that silent cliff into a revert. Genuinely new in milestone 1.
         uint32 maxActiveReservations;
         // Reserved storage space in case we need to add more variables.
@@ -499,6 +504,11 @@ library BridgeState {
         // planned upgrades of the Bridge contract. If more entires are added to
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+        // This milestone consumed 16 of the original 48 slots (28 reservation
+        // fields plus PendingReservedDeposit) for the reservation feature. The
+        // remaining 32 slots are shared budget for all future Bridge upgrades,
+        // not reserved for reservations specifically - a later unrelated PR
+        // should not assume it can spend the rest.
         // slither-disable-next-line unused-state
         uint256[32] __gap;
     }

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -21,6 +21,7 @@ import "@keep-network/random-beacon/contracts/ReimbursementPool.sol";
 import "./IRelay.sol";
 import "./Deposit.sol";
 import "./Redemption.sol";
+import "./Reservation.sol";
 import "./Fraud.sol";
 import "./Wallets.sol";
 import "./MovingFunds.sol";
@@ -28,6 +29,26 @@ import "./MovingFunds.sol";
 import "../bank/Bank.sol";
 
 library BridgeState {
+    /// @notice Reveal-time facts for a deposit routed to the reservation
+    ///         vault. All fields fit in one storage word. `isReserved` is
+    ///         permanent; the remaining fields are used by the reservation
+    ///         action flow and may be cleared after acceptance or staleness.
+    struct PendingReservedDeposit {
+        // Immutable reveal-time reservation classification.
+        bool isReserved;
+        // Wallet committed by the deposit script and therefore the only
+        // wallet that can be authorized to anchor the deposit.
+        bytes20 walletPubKeyHash;
+        // Exact Bitcoin refund locktime decoded at reveal time. Reserved
+        // deposits retain it even when reveal-ahead validation is disabled,
+        // because acceptance must enforce the validator's refund margin.
+        uint32 refundDeadline;
+        // True if the global reveal-ahead policy validated the deadline.
+        // Later stale cleanup uses this bit to preserve the disabled policy's
+        // historical behavior; acceptance always uses the exact deadline.
+        bool refundDeadlineValidated;
+    }
+
     struct Storage {
         // Address of the Bank the Bridge belongs to.
         Bank bank;
@@ -325,6 +346,153 @@ library BridgeState {
         // governance wiring; changing it afterwards requires a dedicated
         // upgrade path of the Bridge implementation.
         address rebateStaking;
+        // The minimal anchor output amount in satoshi accepted for a
+        // reservation. Deposits revealed with `reservationVault` as their
+        // vault are treated as UTXO reservations: they are anchored by the
+        // wallet in a 1-input-1-output spend instead of being swept, and
+        // are redeemable in-kind. See the `Reservation` library for details.
+        uint64 reservationMinAmount;
+        // The custody term length in seconds applied to new and extended
+        // reservations. The term is a contract-layer fact only; anchor
+        // outputs carry no timelock.
+        uint32 reservationTermSeconds;
+        // Address of the reservation vault. Deposits revealed with this
+        // vault address are treated as UTXO reservations.
+        address reservationVault;
+        // Maximum amount of BTC transaction fee in satoshi that can be
+        // incurred by a single reservation lifecycle transaction (anchor,
+        // re-anchor, reserved redemption, dissolution).
+        uint64 reservationTxMaxFee;
+        // The dissolution delay in seconds after a reservation's custody
+        // term expires and before the reservation becomes dissolvable. The
+        // delay exists for orderly settlement and dissolution coordination;
+        // it is NOT an owner-action window — renewal and new redemptions
+        // stop strictly at expiry. Snapshotted per position as
+        // `dissolutionEligibleAt` when a term is granted.
+        uint32 reservationDissolutionDelay;
+        // Maximum total amount in satoshi that can be locked under active
+        // reservations at the same time.
+        uint64 reservationMaxTotalAmount;
+        // Current total amount in satoshi locked under active reservations
+        // (sum of current anchor output values).
+        uint64 reservationTotalAmount;
+        // Maximum number of active reservations a single wallet can custody.
+        uint32 maxReservationsPerWallet;
+        // Collection of all reservations indexed by the deposit key of the
+        // underlying reserved deposit, i.e.
+        // `keccak256(fundingTxHash | fundingOutputIndex)`.
+        mapping(uint256 => Reservation.ReservationRequest) reservations;
+        // Maps the UTXO key of a reservation's current anchor outpoint,
+        // built as `keccak256(anchorTxHash | anchorTxOutputIndex)`, to the
+        // reservation key.
+        mapping(uint256 => uint256) reservationsByAnchorUtxo;
+        // The number of active reservations custodied by the given wallet,
+        // identified by its 20-byte wallet public key hash.
+        mapping(bytes20 => uint32) walletReservationsCount;
+        // Reveal-time facts for deposits routed to the reservation vault.
+        // The permanent classification prevents later reservation-vault
+        // updates from changing an ordinary deposit into a reservation or
+        // making a reserved deposit eligible for an ordinary sweep.
+        mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
+        // Address of the reservation router: the delegatecall extension of
+        // the Bridge holding the UTXO-reservation external surface. The
+        // Bridge's fallback function routes calls with unmatched selectors
+        // to this address. Set exactly once via governance; changing it
+        // afterwards requires a Bridge implementation upgrade, as pointing
+        // the fallback delegatecall at new code is equivalent to a Bridge
+        // implementation change.
+        address reservationRouter;
+        // Time in seconds after which a requested reservation action
+        // (acceptance anchor, re-anchor, dissolution) can be reported
+        // timed out. Reserved redemptions use `redemptionTimeout` instead.
+        // Must strictly exceed the wallet proposal validator's timeout
+        // safety margin. Snapshotted into each action record at request time.
+        uint32 reservationActionTimeout;
+        // Length in seconds of the renewal window: a reservation owner may
+        // renew (extend by exactly one current term) only while
+        // `expiresAt - window <= now < expiresAt`. Must be strictly
+        // shorter than the term so a fresh renewal is immediately outside
+        // its next window — renewals can never be stacked.
+        uint32 reservationRenewalWindowSeconds;
+        // Collection of all reservation action generation records indexed
+        // by `keccak256(reservationKey | requestNonce)`. Each record
+        // snapshots every proof- and settlement-critical parameter of one
+        // requested action generation. Terminal records (TimedOut, Vetoed,
+        // Superseded, Settled) are never deleted: timed-out generations
+        // must keep accepting late proofs of their confirmed Bitcoin
+        // transactions.
+        mapping(uint256 => Reservation.ReservationAction) reservationActions;
+        // Per-wallet main-UTXO action lock: maps the 20-byte wallet public
+        // key hash to the reservation key of the wallet's in-flight
+        // dissolution, or zero when none is pending. At most one
+        // dissolution per wallet may be in flight — concurrent
+        // dissolutions of a no-main-UTXO wallet could all confirm on
+        // Bitcoin with only the first being provable.
+        mapping(bytes20 => uint256) walletPendingDissolution;
+        // Total satoshi amount of reservation anchors (and reserved
+        // capacity of pending reservation actions) custodied by the given
+        // wallet. Because the claim always equals the anchor, this is both
+        // the asset- and the liability-side per-wallet figure.
+        mapping(bytes20 => uint64) walletReservationsAmount;
+        // Maximum total satoshi amount of reservation anchors a single
+        // wallet can custody. Zero disables the cap.
+        uint64 maxReservationsAmountPerWallet;
+        // Maximum satoshi amount of a single reservation. Zero disables
+        // the cap.
+        uint64 reservationMaxSingleAmount;
+        // Per-wallet enumeration of custodied reservation keys, maintained
+        // for monitoring and audit evidence. Entries are appended on
+        // acceptance, moved on re-anchor and swap-removed on close and
+        // stranding.
+        mapping(bytes20 => uint256[]) walletReservationKeys;
+        // Index-plus-one of each reservation key inside its wallet's
+        // `walletReservationKeys` array (zero means absent).
+        mapping(uint256 => uint256) walletReservationKeyIndex;
+        // Number of revealed reserved deposits that were neither accepted
+        // nor marked stale yet. The reservation vault cannot be changed
+        // while this is non-zero: revealed-but-unanchored deposits routed
+        // to the old vault would otherwise become pool-sweepable while
+        // still minting through the old vault's callback.
+        uint64 pendingReservedDeposits;
+        // Generation that minted a reservation's outstanding retry credit.
+        // The terminal action record supplies the exact redemption amount
+        // and whole/partial shape the fee-free retry must preserve. Zero
+        // means there is no bound source generation.
+        mapping(uint256 => uint64) reservationRetryCreditActionNonce;
+        // Per-reservation cumulative re-anchor fee budget in satoshi. Caps
+        // the total satoshi that may be lost across all re-anchor hops for
+        // a single reservation, complementing the per-transaction
+        // `reservationTxMaxFee` bound which only constrains a single hop.
+        // Bounds in-kind grinding of the anchor value over the reservation
+        // lifetime. Declared, never written or read in milestone 1: the
+        // milestone 1 decision left the absolute ceiling unbounded and
+        // deferred a structural bound to post-milestone-1 work. It is
+        // declared anyway because a field a later milestone reads cannot be
+        // added while reservations are live.
+        uint64 maxCumulativeReanchorFee;
+        // Maximum amount of BTC transaction fee in satoshi that can be
+        // incurred by a single reservation dissolution transaction
+        // (2-in-1-out shape). Distinct from `reservationTxMaxFee` because
+        // dissolution's fee economics differ from the 1-in-1-out anchor /
+        // re-anchor / redemption shapes that share `reservationTxMaxFee`.
+        // Declared, never written or read in milestone 1: dissolution is a
+        // later milestone.
+        uint64 reservationDissolutionTxMaxFee;
+        // Global count of open reservation positions. Distinct from the
+        // per-wallet `walletReservationsCount` and from the global amount
+        // `reservationTotalAmount`: neither bounds how many positions exist
+        // across all wallets, and occupancy is monotonic because no
+        // milestone 1 path frees a wallet slot except wallet termination.
+        // Genuinely new in milestone 1 - no extraction source.
+        uint32 activeReservationsCount;
+        // Governance cap on `activeReservationsCount`, set below the slot
+        // floor `liveWalletsCount * maxReservationsPerWallet` so acceptance
+        // reverts before occupancy saturates. At saturation a re-anchor has
+        // no target wallet and an anchored wallet cannot retire, because
+        // closing requires a zero reservation count - its MovingFunds clock
+        // then expires and the timeout seizes operator stake. This cap turns
+        // that silent cliff into a revert. Genuinely new in milestone 1.
+        uint32 maxActiveReservations;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
@@ -332,7 +500,7 @@ library BridgeState {
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
         // slither-disable-next-line unused-state
-        uint256[48] __gap;
+        uint256[32] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -379,22 +379,6 @@ library BridgeState {
         uint64 reservationTotalAmount;
         // Maximum number of active reservations a single wallet can custody.
         uint32 maxReservationsPerWallet;
-        // Collection of all reservations indexed by the deposit key of the
-        // underlying reserved deposit, i.e.
-        // `keccak256(fundingTxHash | fundingOutputIndex)`.
-        mapping(uint256 => Reservation.ReservationRequest) reservations;
-        // Maps the UTXO key of a reservation's current anchor outpoint,
-        // built as `keccak256(anchorTxHash | anchorTxOutputIndex)`, to the
-        // reservation key.
-        mapping(uint256 => uint256) reservationsByAnchorUtxo;
-        // The number of active reservations custodied by the given wallet,
-        // identified by its 20-byte wallet public key hash.
-        mapping(bytes20 => uint32) walletReservationsCount;
-        // Reveal-time facts for deposits routed to the reservation vault.
-        // The permanent classification prevents later reservation-vault
-        // updates from changing an ordinary deposit into a reservation or
-        // making a reserved deposit eligible for an ordinary sweep.
-        mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
         // Address of the reservation router: the delegatecall extension of
         // the Bridge holding the UTXO-reservation external surface. The
         // Bridge's fallback function routes calls with unmatched selectors
@@ -415,51 +399,18 @@ library BridgeState {
         // shorter than the term so a fresh renewal is immediately outside
         // its next window — renewals can never be stacked.
         uint32 reservationRenewalWindowSeconds;
-        // Collection of all reservation action generation records indexed
-        // by `keccak256(reservationKey | requestNonce)`. Each record
-        // snapshots every proof- and settlement-critical parameter of one
-        // requested action generation. Terminal records (TimedOut, Vetoed,
-        // Superseded, Settled) are never deleted: timed-out generations
-        // must keep accepting late proofs of their confirmed Bitcoin
-        // transactions.
-        mapping(uint256 => Reservation.ReservationAction) reservationActions;
-        // Per-wallet main-UTXO action lock: maps the 20-byte wallet public
-        // key hash to the reservation key of the wallet's in-flight
-        // dissolution, or zero when none is pending. At most one
-        // dissolution per wallet may be in flight — concurrent
-        // dissolutions of a no-main-UTXO wallet could all confirm on
-        // Bitcoin with only the first being provable.
-        mapping(bytes20 => uint256) walletPendingDissolution;
-        // Total satoshi amount of reservation anchors (and reserved
-        // capacity of pending reservation actions) custodied by the given
-        // wallet. Because the claim always equals the anchor, this is both
-        // the asset- and the liability-side per-wallet figure.
-        mapping(bytes20 => uint64) walletReservationsAmount;
         // Maximum total satoshi amount of reservation anchors a single
         // wallet can custody. Zero disables the cap.
         uint64 maxReservationsAmountPerWallet;
         // Maximum satoshi amount of a single reservation. Zero disables
         // the cap.
         uint64 reservationMaxSingleAmount;
-        // Per-wallet enumeration of custodied reservation keys, maintained
-        // for monitoring and audit evidence. Entries are appended on
-        // acceptance, moved on re-anchor and swap-removed on close and
-        // stranding.
-        mapping(bytes20 => uint256[]) walletReservationKeys;
-        // Index-plus-one of each reservation key inside its wallet's
-        // `walletReservationKeys` array (zero means absent).
-        mapping(uint256 => uint256) walletReservationKeyIndex;
         // Number of revealed reserved deposits that were neither accepted
         // nor marked stale yet. The reservation vault cannot be changed
         // while this is non-zero: revealed-but-unanchored deposits routed
         // to the old vault would otherwise become pool-sweepable while
         // still minting through the old vault's callback.
         uint64 pendingReservedDeposits;
-        // Generation that minted a reservation's outstanding retry credit.
-        // The terminal action record supplies the exact redemption amount
-        // and whole/partial shape the fee-free retry must preserve. Zero
-        // means there is no bound source generation.
-        mapping(uint256 => uint64) reservationRetryCreditActionNonce;
         // Per-reservation cumulative re-anchor fee budget in satoshi, in the
         // flat-ceiling shape the milestone 1 decision rejected: the absolute
         // ceiling was left unbounded and a structural bound (proportional to
@@ -490,27 +441,82 @@ library BridgeState {
         // liveWalletsCount is mutable and falls whenever a Live wallet
         // retires (an un-anchored one can retire freely), so this sizing
         // must be re-evaluated by governance whenever liveWalletsCount
-        // falls - a cap correct at set-time can otherwise silently drop
-        // below the shrunk floor later and reopen the saturation cliff this
-        // field exists to prevent. At saturation a re-anchor has no target
-        // wallet and an anchored wallet cannot retire, because closing
-        // requires a zero reservation count - its MovingFunds clock then
-        // expires and the timeout seizes operator stake. This cap turns
-        // that silent cliff into a revert. Genuinely new in milestone 1.
+        // falls - a cap correct at set-time can otherwise come to sit
+        // above the shrunk floor later and reopen the saturation cliff
+        // this field exists to prevent. At saturation a re-anchor has no
+        // target wallet and an anchored wallet cannot retire, because
+        // closing requires a zero reservation count - its MovingFunds
+        // clock then expires and the timeout seizes operator stake. This
+        // cap turns that silent cliff into a revert. Genuinely new in
+        // milestone 1.
         uint32 maxActiveReservations;
+        // Collection of all reservations indexed by the deposit key of the
+        // underlying reserved deposit, i.e.
+        // `keccak256(fundingTxHash | fundingOutputIndex)`.
+        mapping(uint256 => Reservation.ReservationRequest) reservations;
+        // Maps the UTXO key of a reservation's current anchor outpoint,
+        // built as `keccak256(anchorTxHash | anchorTxOutputIndex)`, to the
+        // reservation key.
+        mapping(uint256 => uint256) reservationsByAnchorUtxo;
+        // The number of active reservations custodied by the given wallet,
+        // identified by its 20-byte wallet public key hash.
+        mapping(bytes20 => uint32) walletReservationsCount;
+        // Reveal-time facts for deposits routed to the reservation vault.
+        // The permanent classification prevents later reservation-vault
+        // updates from changing an ordinary deposit into a reservation or
+        // making a reserved deposit eligible for an ordinary sweep.
+        mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
+        // Collection of all reservation action generation records indexed
+        // by `keccak256(reservationKey | requestNonce)`. Each record
+        // snapshots every proof- and settlement-critical parameter of one
+        // requested action generation. Terminal records (TimedOut, Vetoed,
+        // Superseded, Settled) are never deleted: timed-out generations
+        // must keep accepting late proofs of their confirmed Bitcoin
+        // transactions.
+        mapping(uint256 => Reservation.ReservationAction) reservationActions;
+        // Per-wallet main-UTXO action lock: maps the 20-byte wallet public
+        // key hash to the reservation key of the wallet's in-flight
+        // dissolution, or zero when none is pending. At most one
+        // dissolution per wallet may be in flight — concurrent
+        // dissolutions of a no-main-UTXO wallet could all confirm on
+        // Bitcoin with only the first being provable.
+        mapping(bytes20 => uint256) walletPendingDissolution;
+        // Total satoshi amount of reservation anchors (and reserved
+        // capacity of pending reservation actions) custodied by the given
+        // wallet. Because the claim always equals the anchor, this is both
+        // the asset- and the liability-side per-wallet figure.
+        mapping(bytes20 => uint64) walletReservationsAmount;
+        // Per-wallet enumeration of custodied reservation keys, maintained
+        // for monitoring and audit evidence. Entries are appended on
+        // acceptance, moved on re-anchor and swap-removed on close and
+        // stranding. Bookkeeping only: no protocol invariant or capacity
+        // check reads this pair — `walletReservationsCount` and
+        // `walletReservationsAmount` above are the on-chain-enforced caps.
+        // An events-based off-chain index could serve the same audit need;
+        // kept on-chain instead for a direct enumeration source available
+        // without an indexer.
+        mapping(bytes20 => uint256[]) walletReservationKeys;
+        // Index-plus-one of each reservation key inside its wallet's
+        // `walletReservationKeys` array (zero means absent).
+        mapping(uint256 => uint256) walletReservationKeyIndex;
+        // Generation that minted a reservation's outstanding retry credit.
+        // The terminal action record supplies the exact redemption amount
+        // and whole/partial shape the fee-free retry must preserve. Zero
+        // means there is no bound source generation.
+        mapping(uint256 => uint64) reservationRetryCreditActionNonce;
         // Reserved storage space in case we need to add more variables.
         // The convention from OpenZeppelin suggests the storage space should
         // add up to 50 slots. Here we want to have more slots as there are
         // planned upgrades of the Bridge contract. If more entires are added to
         // the struct in the upcoming versions we need to reduce the array size.
         // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-        // This milestone consumed 16 of the original 48 slots (28 reservation
+        // This milestone consumed 15 of the original 48 slots (28 reservation
         // fields plus PendingReservedDeposit) for the reservation feature. The
-        // remaining 32 slots are shared budget for all future Bridge upgrades,
+        // remaining 33 slots are shared budget for all future Bridge upgrades,
         // not reserved for reservations specifically - a later unrelated PR
         // should not assume it can spend the rest.
         // slither-disable-next-line unused-state
-        uint256[32] __gap;
+        uint256[33] __gap;
     }
 
     event DepositParametersUpdated(

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -277,8 +277,7 @@ library Reservation {
         // (redeemer output + re-anchored remainder) and leaves the
         // reservation open with a reduced anchor. False for a whole
         // redemption (1-input-1-output, closes the reservation) and for
-        // every non-redemption action. Appended to the end of the struct so
-        // the existing field layout is unchanged.
+        // every non-redemption action.
         bool isPartial;
     }
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -20,7 +20,8 @@ pragma solidity 0.8.17;
 ///         reservations: deposits custodied without ever being commingled
 ///         with the pooled supply and returned in-kind — with an unbroken
 ///         1-input-1-output lineage — upon redemption. The SPV settlement
-///         side lives in the `ReservationProofs` companion library.
+///         side will live in the future `ReservationProofs` companion
+///         library (not yet implemented).
 /// @dev Every Bitcoin action of a reservation's life — the acceptance
 ///      anchor, an in-kind redemption, a re-anchor to another wallet, and
 ///      the post-term dissolution — follows a *two-phase,
@@ -67,8 +68,9 @@ library Reservation {
         Active,
         /// @dev An action (redemption, re-anchor or dissolution) has been
         ///      requested for the position and is not yet settled. The
-        ///      pending action record is
-        ///      `reservationActions[actionKey(reservationKey, requestNonce)]`.
+        ///      pending action record will be accessible as
+        ///      `reservationActions[actionKey(reservationKey, requestNonce)]`
+        ///      once the future `actionKey` helper exists.
         ActionPending,
         /// @dev The reservation was closed: redeemed in-kind, dissolved
         ///      into the wallet's main UTXO, or settled late after a

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -140,7 +140,11 @@ library Reservation {
         uint64 anchorAmount;
         // UNIX timestamp the custody term expires at. Purely a contract
         // layer fact -- the anchor output carries no timelock.
-        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        // XXX: Unsigned 32-bit int unix seconds. Computed as `acceptedAt +
+        // reservationTermSeconds`; Solidity's checked arithmetic reverts
+        // this addition (rather than silently wrapping) once the sum would
+        // exceed the uint32 ceiling - starting up to MAX_RESERVATION_TERM
+        // (730 days) before the raw February 7th 2106 date, not at it.
         uint32 expiresAt;
         // Hash of the Bitcoin transaction holding the current anchor output.
         bytes32 anchorTxHash;
@@ -170,7 +174,12 @@ library Reservation {
         // granted (acceptance and each renewal), using the delay value
         // current at that moment — later governance changes never move
         // the eligibility time of a term already granted.
-        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        // XXX: Unsigned 32-bit int unix seconds. Computed as `expiresAt +
+        // reservationDissolutionDelay`; Solidity's checked arithmetic
+        // reverts this addition (rather than silently wrapping) once the
+        // sum would exceed the uint32 ceiling - starting somewhat before
+        // February 7th 2106, proportional to the delay applied on top of
+        // expiresAt's own margin.
         uint32 dissolutionEligibleAt;
         // Cumulative satoshi lost to Bitcoin miner fees across all
         // re-anchor hops of this reservation. Written on every re-anchor
@@ -204,8 +213,14 @@ library Reservation {
         // custodying wallet itself for dissolutions. Zero for redemptions.
         bytes20 targetWalletPubKeyHash;
         // UNIX timestamp the action was requested at.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
         uint32 requestedAt;
         // UNIX timestamp after which the action can be reported timed out.
+        // XXX: Unsigned 32-bit int unix seconds. Computed by adding a
+        // timeout duration to requestedAt; Solidity's checked arithmetic
+        // reverts this addition (rather than silently wrapping) once the
+        // sum would exceed the uint32 ceiling - starting somewhat before
+        // February 7th 2106, proportional to the timeout applied.
         uint32 timeoutAt;
         // Snapshotted maximum Bitcoin miner fee for the action transaction.
         uint64 txMaxFee;
@@ -220,12 +235,6 @@ library Reservation {
         // The address able to claim the escrowed balance back should a
         // redemption generation time out. Zero for other action types.
         address redeemer;
-        // Amount in satoshi associated with the generation: the escrowed
-        // gross claim for redemptions (the full claim for a whole
-        // redemption, the redeemed portion for a partial), the
-        // capacity-reserved deposit value for acceptances, the anchor
-        // value at request time otherwise.
-        uint64 amount;
         // Action-specific authorization data: the keccak256 hash of the
         // length-prefixed redeemer output script for redemptions, or the
         // wallet main UTXO hash snapshotted for dissolutions. Zero for
@@ -236,6 +245,12 @@ library Reservation {
         // authorized to spend. Zero only for acceptance generations, which
         // spend the revealed deposit rather than an existing anchor.
         bytes32 sourceAnchorUtxoHash;
+        // Amount in satoshi associated with the generation: the escrowed
+        // gross claim for redemptions (the full claim for a whole
+        // redemption, the redeemed portion for a partial), the
+        // capacity-reserved deposit value for acceptances, the anchor
+        // value at request time otherwise.
+        uint64 amount;
         // True when this redemption generation consumed the reservation's
         // single-use retry entitlement. Needed to return the entitlement if
         // a late action consumes the expected anchor while leaving the
@@ -252,6 +267,11 @@ library Reservation {
         // Reserved-redemption veto delay after two guardian objections,
         // snapshotted from the watchtower policy at request time.
         uint32 watchtowerLevelTwoDelay;
+        // Fee-paid redemption generation that originated the retry credit
+        // consumed by this action. Zero when `usedRetryCredit` is false.
+        // Kept on the action so a late re-anchor or partial redemption can
+        // restore the exact amount/shape binding after superseding the retry.
+        uint64 retryCreditSourceNonce;
         // True when a redemption generation is partial: it redeems only
         // `amount` of the reservation's claim in a 1-input-2-output spend
         // (redeemer output + re-anchored remainder) and leaves the
@@ -260,10 +280,5 @@ library Reservation {
         // every non-redemption action. Appended to the end of the struct so
         // the existing field layout is unchanged.
         bool isPartial;
-        // Fee-paid redemption generation that originated the retry credit
-        // consumed by this action. Zero when `usedRetryCredit` is false.
-        // Kept on the action so a late re-anchor or partial redemption can
-        // restore the exact amount/shape binding after superseding the retry.
-        uint64 retryCreditSourceNonce;
     }
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+/// @title Bridge UTXO reservations — control plane
+/// @notice The library handles the request/authorization side of UTXO
+///         reservations: deposits custodied without ever being commingled
+///         with the pooled supply and returned in-kind — with an unbroken
+///         1-input-1-output lineage — upon redemption. The SPV settlement
+///         side lives in the `ReservationProofs` companion library.
+/// @dev Every Bitcoin action of a reservation's life — the acceptance
+///      anchor, an in-kind redemption, a re-anchor to another wallet, and
+///      the post-term dissolution — follows a *two-phase,
+///      authorize-then-prove* model (see RFC 13):
+///
+///      1. An explicit *request* increments the position's monotonic
+///         request nonce, performs every capacity and lifecycle check and
+///         *reserves* what it checks, and *snapshots* every proof- and
+///         settlement-critical parameter into a per-generation
+///         `ReservationAction` record keyed by `(reservationKey, nonce)`.
+///         A wallet signs only requested (and, for redemptions,
+///         watchtower-authorized) generations, and nothing that changes
+///         after the request can make the signed transaction unprovable.
+///
+///      2. The SPV *proof* settles the generation against the record's
+///         snapshots — never against live parameters. A generation that
+///         times out leaves a terminal record that still accepts a late
+///         proof (closing the anchor lineage without a second refund); a
+///         generation vetoed by the redemption watchtower never accepts a
+///         proof, leaving an early-signing wallet exposed to the fraud
+///         machinery — the intended consequence of signing an unauthorized
+///         action.
+///
+///      Claim accounting: the amount credited (`mintedAmount`) is the gross
+///      anchor output value. All protocol fees are charged by the
+///      reservation vault as explicit transfers; Bitcoin miner fees are the
+///      only in-kind deductions.
+library Reservation {
+    /// @notice Hard protocol bounds on the custody term length. The
+    ///         governable term must stay within them; they bound the
+    ///         maximum owner lookahead (one term plus the renewal window)
+    ///         and keep the carry economics of a term meaningful.
+    uint32 internal constant MIN_RESERVATION_TERM = 90 days;
+    uint32 internal constant MAX_RESERVATION_TERM = 730 days;
+
+    /// @notice Represents the state of a reservation position.
+    enum ReservationState {
+        /// @dev The reservation is unknown to the Bridge. Acceptance
+        ///      requests are made against positions in this state.
+        Unknown,
+        /// @dev The reservation was accepted (anchor proven, balance
+        ///      credited) and its anchor outpoint is under wallet custody,
+        ///      with no action in flight.
+        Active,
+        /// @dev An action (redemption, re-anchor or dissolution) has been
+        ///      requested for the position and is not yet settled. The
+        ///      pending action record is
+        ///      `reservationActions[actionKey(reservationKey, requestNonce)]`.
+        ActionPending,
+        /// @dev The reservation was closed: redeemed in-kind, dissolved
+        ///      into the wallet's main UTXO, or settled late after a
+        ///      timeout.
+        Closed,
+        /// @dev The custodying wallet was terminated while the anchor was
+        ///      outstanding. The owner's minted balance remains an ordinary
+        ///      pooled claim; the anchor is no longer tracked unless a
+        ///      previously timed-out generation later settles against it.
+        Stranded
+    }
+
+    /// @notice Type of a reservation action generation.
+    enum ActionType {
+        None,
+        Acceptance,
+        Redemption,
+        Reanchor,
+        Dissolution
+    }
+
+    /// @notice Settlement state of a reservation action generation.
+    enum ActionState {
+        /// @dev No action was ever requested under this key.
+        Unknown,
+        /// @dev The action is requested and awaiting its SPV proof. For
+        ///      redemptions, the wallet may only sign once the watchtower
+        ///      delay has elapsed without a veto; the proof path enforces
+        ///      this.
+        Pending,
+        /// @dev The action was proven and settled.
+        Settled,
+        /// @dev The action timed out. Terminal for the generation, but a
+        ///      late proof of the (already confirmed) Bitcoin transaction
+        ///      is still accepted against this record: it closes the anchor
+        ///      lineage and marks the consumed outpoints as honestly spent,
+        ///      without repeating the refund performed at timeout.
+        TimedOut,
+        /// @dev The action was vetoed by the redemption watchtower.
+        ///      Terminal; a proof against this generation is rejected
+        ///      forever.
+        Vetoed,
+        /// @dev The action's anchor was consumed by a late settlement of an
+        ///      older timed-out generation. Terminal; the escrowed claim
+        ///      was refunded during the late settlement.
+        Superseded
+    }
+
+    /// @notice Represents a UTXO reservation position.
+    struct ReservationRequest {
+        // The reservation owner holding the in-kind redemption right. Set
+        // to the deposit's depositor at acceptance time.
+        address owner;
+        // Gross amount in satoshi credited to the owner via the reservation
+        // vault at acceptance time. This is the amount that must be
+        // surrendered and burned when the reservation is redeemed in-kind.
+        uint64 mintedAmount;
+        // UNIX timestamp the reservation was accepted at.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 acceptedAt;
+        // 20-byte public key hash of the wallet custodying the current
+        // anchor outpoint.
+        bytes20 walletPubKeyHash;
+        // Value in satoshi of the current anchor outpoint. Starts equal to
+        // `mintedAmount` and decreases by the Bitcoin miner fee on each
+        // re-anchor hop.
+        uint64 anchorAmount;
+        // UNIX timestamp the custody term expires at. Purely a contract
+        // layer fact -- the anchor output carries no timelock.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 expiresAt;
+        // Hash of the Bitcoin transaction holding the current anchor output.
+        bytes32 anchorTxHash;
+        // Output index of the current anchor output. Always 0 given anchor
+        // transactions have a single output; kept for auditability.
+        uint32 anchorTxOutputIndex;
+        // Current state of the reservation position.
+        ReservationState state;
+        // Monotonic generation counter. Incremented by every action
+        // request (including acceptance requests); all action state is
+        // keyed by `(reservationKey, requestNonce)` so a stale generation
+        // can never be confused with a newer one.
+        uint64 requestNonce;
+        // True when the owner holds a single-use, fee-free redemption
+        // retry entitlement, minted when a fee-paid redemption request
+        // times out through the wallet's fault. The source generation is
+        // stored separately and binds partial retries to its exact amount
+        // and whole retries to no more than its original full claim. It is
+        // returned if a late re-anchor or partial redemption supersedes the
+        // retry that consumed it while leaving the reservation open. A late
+        // partial settlement retires the entitlement when it settles that
+        // entitlement's source generation. Consumed by the next strictly
+        // pre-expiry retry request; voided by a dissolution request.
+        bool retryCredit;
+        // UNIX timestamp the reservation becomes dissolvable at. Set to
+        // `expiresAt + reservationDissolutionDelay` whenever a term is
+        // granted (acceptance and each renewal), using the delay value
+        // current at that moment — later governance changes never move
+        // the eligibility time of a term already granted.
+        // XXX: Unsigned 32-bit int unix seconds, will break February 7th 2106.
+        uint32 dissolutionEligibleAt;
+        // Cumulative satoshi lost to Bitcoin miner fees across all
+        // re-anchor hops of this reservation. Written on every re-anchor
+        // settlement but never read in milestone 1: no ceiling is enforced
+        // yet, and a structural bound is deferred to post-milestone-1
+        // work. It is written from milestone 1 because the re-anchor
+        // settlement path writes the claim down on every hop, so the
+        // original anchor value is not recoverable afterwards and this
+        // total cannot be reconstructed from later state — the
+        // `ReservationReanchored` event carries only the new anchor
+        // amount, not the per-hop delta. Accumulating now means a
+        // post-milestone-1 cap reads the true lifetime total instead of
+        // only post-upgrade hops. A position field a later milestone reads
+        // cannot be added while reservations are live.
+        // Appended to the end of the struct so the existing field layout
+        // is unchanged.
+        uint64 cumulativeReanchorFee;
+        // This struct doesn't contain `__gap` property as the structure is
+        // stored in a mapping, mappings store values in different slots and
+        // they are not contiguous with other values.
+    }
+
+    /// @notice Represents one requested generation of a reservation action.
+    ///         All fields the proof and settlement paths consult are
+    ///         snapshotted here at request time; live parameters are never
+    ///         read at settlement.
+    struct ReservationAction {
+        // 20-byte public key hash of the wallet the action's single
+        // wallet-controlled output must pay to: the designated custodian
+        // for acceptances, the migration target for re-anchors, the
+        // custodying wallet itself for dissolutions. Zero for redemptions.
+        bytes20 targetWalletPubKeyHash;
+        // UNIX timestamp the action was requested at.
+        uint32 requestedAt;
+        // UNIX timestamp after which the action can be reported timed out.
+        uint32 timeoutAt;
+        // Snapshotted maximum Bitcoin miner fee for the action transaction.
+        uint64 txMaxFee;
+        // Action type of this generation.
+        ActionType actionType;
+        // Settlement state of this generation.
+        ActionState state;
+        // True when the generation was created through a fee-paying vault
+        // entry point; a fee-paid redemption generation that times out
+        // mints the retry entitlement.
+        bool feePaid;
+        // The address able to claim the escrowed balance back should a
+        // redemption generation time out. Zero for other action types.
+        address redeemer;
+        // Amount in satoshi associated with the generation: the escrowed
+        // gross claim for redemptions (the full claim for a whole
+        // redemption, the redeemed portion for a partial), the
+        // capacity-reserved deposit value for acceptances, the anchor
+        // value at request time otherwise.
+        uint64 amount;
+        // Action-specific authorization data: the keccak256 hash of the
+        // length-prefixed redeemer output script for redemptions, or the
+        // wallet main UTXO hash snapshotted for dissolutions. Zero for
+        // acceptances and re-anchors, and for dissolutions of wallets with
+        // no main UTXO.
+        bytes32 actionDataHash;
+        // Hash of the reservation anchor outpoint this generation was
+        // authorized to spend. Zero only for acceptance generations, which
+        // spend the revealed deposit rather than an existing anchor.
+        bytes32 sourceAnchorUtxoHash;
+        // True when this redemption generation consumed the reservation's
+        // single-use retry entitlement. Needed to return the entitlement if
+        // a late action consumes the expected anchor while leaving the
+        // reservation open and makes this generation impossible to settle.
+        bool usedRetryCredit;
+        // Reserved-redemption veto delay with no guardian objections,
+        // snapshotted from the watchtower policy at request time. Zero when
+        // the watchtower is absent, not enabled, disabled, or the amount is
+        // waived.
+        uint32 watchtowerDefaultDelay;
+        // Reserved-redemption veto delay after one guardian objection,
+        // snapshotted from the watchtower policy at request time.
+        uint32 watchtowerLevelOneDelay;
+        // Reserved-redemption veto delay after two guardian objections,
+        // snapshotted from the watchtower policy at request time.
+        uint32 watchtowerLevelTwoDelay;
+        // True when a redemption generation is partial: it redeems only
+        // `amount` of the reservation's claim in a 1-input-2-output spend
+        // (redeemer output + re-anchored remainder) and leaves the
+        // reservation open with a reduced anchor. False for a whole
+        // redemption (1-input-1-output, closes the reservation) and for
+        // every non-redemption action. Appended to the end of the struct so
+        // the existing field layout is unchanged.
+        bool isPartial;
+        // Fee-paid redemption generation that originated the retry credit
+        // consumed by this action. Zero when `usedRetryCredit` is false.
+        // Kept on the action so a late re-anchor or partial redemption can
+        // restore the exact amount/shape binding after superseding the retry.
+        uint64 retryCreditSourceNonce;
+    }
+}

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -40,6 +40,15 @@ const bridgeGovernanceCompilerConfig = {
     },
   },
 }
+// Solc output selection shared by every compiler-settings block whose build
+// info needs to expose storage layouts to the upgrade-safety test in
+// test/bridge/Bridge.StorageLayout.test.ts. Hoisted so per-contract compiler
+// overrides cannot drift from the main compiler's selection.
+const storageLayoutOutputSelection = {
+  "*": {
+    "*": ["storageLayout"],
+  },
+}
 
 // Configuration for testing environment.
 export const testConfig = {
@@ -66,6 +75,7 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1000,
           },
+          outputSelection: storageLayoutOutputSelection,
         },
       },
     ],

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -40,10 +40,14 @@ const bridgeGovernanceCompilerConfig = {
     },
   },
 }
-// Solc output selection shared by every compiler-settings block whose build
-// info needs to expose storage layouts to the upgrade-safety test in
-// test/bridge/Bridge.StorageLayout.test.ts. Hoisted so per-contract compiler
-// overrides cannot drift from the main compiler's selection.
+// Solc output selection exposing storage layouts to the upgrade-safety test
+// in test/bridge/Bridge.StorageLayout.test.ts. Currently applied to the main
+// compiler config only (`compilers[0]`, below) - none of the per-contract
+// compiler overrides (ecdsaSolidityCompilerConfig,
+// bridgeGovernanceCompilerConfig, the wormhole
+// L1BTCDepositorNttWithExecutor.sol override) include it, so a contract
+// compiled only under one of those overrides has no storage layout in its
+// build info.
 const storageLayoutOutputSelection = {
   "*": {
     "*": ["storageLayout"],

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -1,0 +1,96 @@
+import { artifacts } from "hardhat"
+import { expect } from "chai"
+import { assertStorageUpgradeSafe } from "@openzeppelin/upgrades-core"
+
+import bridgeTIP109HotfixDeployment from "../../deployments/mainnet/BridgeTIP109HotfixImplementation.json"
+
+type StorageEntry = {
+  label: string
+  offset: number
+  slot: string
+  type: string
+}
+
+type StorageLayout = {
+  storage: StorageEntry[]
+  types: Record<
+    string,
+    {
+      label: string
+      encoding: string
+      numberOfBytes: string
+      members?: StorageEntry[]
+      key?: string
+      value?: string
+      base?: string
+    }
+  >
+}
+
+type UpgradeStorageLayout = Parameters<typeof assertStorageUpgradeSafe>[0]
+
+async function getBridgeStorageLayout(): Promise<StorageLayout> {
+  const sourceName = "contracts/bridge/Bridge.sol"
+  const contractName = "Bridge"
+  // Bridge is compiled in multiple optimizer jobs and its final artifact can
+  // point at a job without storageLayout output. BridgeState's artifact points
+  // at the validation-enabled job that also contains the compiled Bridge.
+  const buildInfo = await artifacts.getBuildInfo(
+    "contracts/bridge/BridgeState.sol:BridgeState"
+  )
+  if (!buildInfo) {
+    throw new Error(`No build info for ${sourceName}:${contractName}`)
+  }
+
+  const layout = (
+    buildInfo.output.contracts[sourceName][contractName] as {
+      storageLayout?: StorageLayout
+    }
+  ).storageLayout
+  if (!layout) {
+    throw new Error(`No storage layout for ${sourceName}:${contractName}`)
+  }
+
+  return layout
+}
+
+function bridgeStateLayout(layout: StorageLayout): StorageLayout {
+  const bridgeState = layout.storage.find((entry) => entry.label === "self")
+  if (!bridgeState) {
+    throw new Error("BridgeState.Storage entry not found")
+  }
+
+  const bridgeStateType = layout.types[bridgeState.type]
+  if (!bridgeStateType?.members) {
+    throw new Error("BridgeState.Storage members not found")
+  }
+
+  // Bridge stores its state in one library struct. Flatten that struct for
+  // OpenZeppelin 1.x so its normal gap-consumption algorithm validates the
+  // real member slots; that release rejects every nested-struct append before
+  // applying the nested struct's own __gap semantics.
+  return {
+    storage: bridgeStateType.members,
+    types: layout.types,
+  }
+}
+
+describe("Bridge storage layout", () => {
+  it("is upgrade-safe against the deployed TIP-109 Bridge layout", async () => {
+    const deployedLayout = bridgeStateLayout(
+      bridgeTIP109HotfixDeployment.storageLayout as unknown as StorageLayout
+    )
+    const updatedLayout = bridgeStateLayout(await getBridgeStorageLayout())
+
+    // The checked-in deployment artifact predates solc's enum-members output.
+    // Allow incomplete custom-type descriptions while still validating every
+    // concrete slot, packing decision, mapping, struct, and storage-gap change.
+    expect(() =>
+      assertStorageUpgradeSafe(
+        deployedLayout as unknown as UpgradeStorageLayout,
+        updatedLayout as unknown as UpgradeStorageLayout,
+        true
+      )
+    ).not.to.throw()
+  })
+})

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -165,5 +165,38 @@ describe("Bridge storage layout", () => {
         "MovedFundsSweepRequestState"
       )
     ).to.deep.equal(["Unknown", "Pending", "Processed", "TimedOut"])
+
+    // This PR's own three new enums (ReservationState, ActionType,
+    // ActionState) hit the exact same solc 0.8.17 blind spot: pin their
+    // declared order too, for the same reason as WalletState and
+    // MovedFundsSweepRequestState above.
+    expect(
+      readEnumMemberOrder("bridge/Reservation.sol", "ReservationState")
+    ).to.deep.equal([
+      "Unknown",
+      "Active",
+      "ActionPending",
+      "Closed",
+      "Stranded",
+    ])
+    expect(
+      readEnumMemberOrder("bridge/Reservation.sol", "ActionType")
+    ).to.deep.equal([
+      "None",
+      "Acceptance",
+      "Redemption",
+      "Reanchor",
+      "Dissolution",
+    ])
+    expect(
+      readEnumMemberOrder("bridge/Reservation.sol", "ActionState")
+    ).to.deep.equal([
+      "Unknown",
+      "Pending",
+      "Settled",
+      "TimedOut",
+      "Vetoed",
+      "Superseded",
+    ])
   })
 })

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -1,6 +1,8 @@
 import { artifacts } from "hardhat"
 import { expect } from "chai"
 import { assertStorageUpgradeSafe } from "@openzeppelin/upgrades-core"
+import * as fs from "fs"
+import * as path from "path"
 
 import bridgeTIP109HotfixDeployment from "../../deployments/mainnet/BridgeTIP109HotfixImplementation.json"
 
@@ -54,11 +56,16 @@ async function getBridgeStorageLayout(): Promise<StorageLayout> {
   return layout
 }
 
-function bridgeStateLayout(layout: StorageLayout): StorageLayout {
+function bridgeStateEntry(layout: StorageLayout): StorageEntry {
   const bridgeState = layout.storage.find((entry) => entry.label === "self")
   if (!bridgeState) {
     throw new Error("BridgeState.Storage entry not found")
   }
+  return bridgeState
+}
+
+function bridgeStateLayout(layout: StorageLayout): StorageLayout {
+  const bridgeState = bridgeStateEntry(layout)
 
   const bridgeStateType = layout.types[bridgeState.type]
   if (!bridgeStateType?.members) {
@@ -75,16 +82,54 @@ function bridgeStateLayout(layout: StorageLayout): StorageLayout {
   }
 }
 
+function readEnumMemberOrder(
+  relativeContractPath: string,
+  enumName: string
+): string[] {
+  const source = fs.readFileSync(
+    path.join(__dirname, "../../contracts", relativeContractPath),
+    "utf8"
+  )
+  const match = source.match(
+    new RegExp(`enum\\s+${enumName}\\s*\\{([\\s\\S]*?)\\n\\s*\\}`)
+  )
+  if (!match) {
+    throw new Error(`enum ${enumName} not found in ${relativeContractPath}`)
+  }
+  return match[1]
+    .split("\n")
+    .map((line) => line.replace(/\/\/\/.*$/, "").trim())
+    .filter((line) => line.length > 0)
+    .map((line) => line.replace(/,$/, ""))
+}
+
 describe("Bridge storage layout", () => {
   it("is upgrade-safe against the deployed TIP-109 Bridge layout", async () => {
-    const deployedLayout = bridgeStateLayout(
+    const deployedRawLayout =
       bridgeTIP109HotfixDeployment.storageLayout as unknown as StorageLayout
-    )
-    const updatedLayout = bridgeStateLayout(await getBridgeStorageLayout())
+    const updatedRawLayout = await getBridgeStorageLayout()
 
-    // The checked-in deployment artifact predates solc's enum-members output.
-    // Allow incomplete custom-type descriptions while still validating every
-    // concrete slot, packing decision, mapping, struct, and storage-gap change.
+    // `self`'s absolute position must not move: bridgeStateLayout() below
+    // only ever compares the flattened member list, never self's own
+    // slot/offset, so a future base-contract change that shifts BridgeState
+    // off its deployed slot would otherwise pass every packing assertion
+    // silently.
+    const deployedSelf = bridgeStateEntry(deployedRawLayout)
+    const updatedSelf = bridgeStateEntry(updatedRawLayout)
+    expect(updatedSelf.slot).to.equal(deployedSelf.slot)
+    expect(updatedSelf.offset).to.equal(deployedSelf.offset)
+
+    const deployedLayout = bridgeStateLayout(deployedRawLayout)
+    const updatedLayout = bridgeStateLayout(updatedRawLayout)
+
+    // The deployment artifact predates the current source only in date, not
+    // in enum-member support: under this project's pinned solc 0.8.17,
+    // `.members` is never populated for enum types in storageLayout output -
+    // verified true for both the deployed baseline and a fresh compile of
+    // this PR's own unchanged WalletState/MovedFundsSweepRequestState
+    // enums. Allow incomplete custom-type descriptions while still
+    // validating every concrete slot, packing decision, mapping, struct,
+    // and storage-gap change.
     expect(() =>
       assertStorageUpgradeSafe(
         deployedLayout as unknown as UpgradeStorageLayout,
@@ -92,5 +137,33 @@ describe("Bridge storage layout", () => {
         true
       )
     ).not.to.throw()
+
+    // Companion to the relaxed check above: assertStorageUpgradeSafe's
+    // unsafeAllowCustomTypes skips a type comparison whenever either side's
+    // `.members` is undefined - true for WalletState and
+    // MovedFundsSweepRequestState on both sides under this pinned solc
+    // version (see above), so the library can never actually compare their
+    // member order here. Pin the two enums' current declared order,
+    // re-read directly from source on every run, against an explicit
+    // expected list instead: reordering, inserting, or removing a member
+    // changes the integer any already-persisted storage value decodes to,
+    // so a manual, version-controlled gate is the only check available
+    // until a solc upgrade adds real `.members` support.
+    expect(
+      readEnumMemberOrder("bridge/Wallets.sol", "WalletState")
+    ).to.deep.equal([
+      "Unknown",
+      "Live",
+      "MovingFunds",
+      "Closing",
+      "Closed",
+      "Terminated",
+    ])
+    expect(
+      readEnumMemberOrder(
+        "bridge/MovingFunds.sol",
+        "MovedFundsSweepRequestState"
+      )
+    ).to.deep.equal(["Unknown", "Pending", "Processed", "TimedOut"])
   })
 })


### PR DESCRIPTION
Declarations only, no logic. This is the structural root of the milestone 1
reservation stack: every later PR rebases onto it, so nothing after this
needs a storage-layout change while reservations are live.

### What lands

| File | Change |
|---|---|
| `contracts/bridge/Reservation.sol` | new, +267 - declarations-only library |
| `contracts/bridge/BridgeState.sol` | +169/-1 - `PendingReservedDeposit`, 28 storage fields, `__gap` |
| `test/bridge/Bridge.StorageLayout.test.ts` | new, +96 - upgrade-safety test |
| `hardhat.config.ts` | +10 - hoisted `storageLayout` output selection |

`Reservation.sol` carries two term constants, three enums
(`ReservationState`, `ActionType`, `ActionState`) and two structs
(`ReservationRequest`, `ReservationAction`). No functions, no events. It
compiles to 86 bytes of metadata and adds no deployed code.

`BridgeState.Storage` gains 28 reservation fields plus the
`PendingReservedDeposit` struct. Everything before the import block and
everything after `__gap` is byte-identical to the base branch: no event, no
governance setter, no behavior.

### Where each declaration comes from

Twenty-four of the storage fields and both structs come from PR #1096, the
furthest tip of the `#1091`-`#1096` lineage, copied field-for-field and
verified byte-identical across the whole `imports`-through-`__gap` region.
That includes #1096's three declare-only fields
(`ReservationAction.isPartial`, `retryCreditSourceNonce`,
`BridgeState.Storage.reservationRetryCreditActionNonce`).

Independently checked: all 56 pre-existing `Storage` fields appear in #1096
in the same relative order, with none removed or retyped, and #1093's 77
fields are a subset of what ships here - so the acceptance and re-anchor
extractions that follow compile against this layout.

Three declarations come from PR #1102:
`ReservationRequest.cumulativeReanchorFee`,
`BridgeState.Storage.maxCumulativeReanchorFee` and
`BridgeState.Storage.reservationDissolutionTxMaxFee`.

The last two, `activeReservationsCount` and `maxActiveReservations`, have no
extraction source at all - they are genuinely new, and unlike the #1102 three,
milestone 1 both writes and reads them. See below.

### Why these three declarations have no milestone 1 enforcement

No milestone 1 path *reads* any of the three yet - no ceiling or dedicated
cap is enforced. `cumulativeReanchorFee` is already *written*: PR #1108
(`feat(bridge): implement reservation re-anchor`) settles it on every hop
(`reservation.cumulativeReanchorFee += minerFee` in its
`ReservationProofs.sol`). `maxCumulativeReanchorFee` and
`reservationDissolutionTxMaxFee` are genuinely untouched across the whole
currently-open milestone 1 stack (#1107-#1112) - neither written nor read
anywhere in any of the six branches. The milestone 1 decision rejected the
flat cumulative-fee ceiling, left the absolute ceiling unbounded, and
deferred a structural bound to post-milestone-1 work; the resulting
exposure is pinned by the characterization test on tbtc-v2 #1104, which
fails if an absolute ceiling is ever ported. So the *enforcement* is
deliberately absent for all three, even though `cumulativeReanchorFee` is
not write-inert.

The *declarations* still ship, because the storage rule requires every field
a later milestone reads to exist at milestone 1 - a field cannot be
introduced while reservations are live. That bites hardest on
`cumulativeReanchorFee`, a position field: re-anchor settlement writes the
claim down on every hop, so the original anchor value is gone afterwards and
the cumulative total cannot be reconstructed from surviving state. If it is
not declared now, no later milestone can compute it at all.

Declaring without enforcing is the whole point here, and the comments on all
three fields say so at the declaration site.

**Considered and declined: dropping `maxCumulativeReanchorFee` and
`reservationDissolutionTxMaxFee`.** Unlike `cumulativeReanchorFee`, these
two are stateless governance configuration values with no historical-data
constraint - checking all six currently-open milestone 1 PRs directly
confirms neither is read or written anywhere in the stack; #1112's
governance-parameters file only mentions them in a comment explaining their
*absence* from its update function. That means, unlike `cumulativeReanchorFee`,
both really could be appended later via the same `__gap` mechanism this PR
itself uses, live reservations or not - the "must declare before reservations
go live" constraint doesn't bind them the way it binds the accumulator.
Raised here rather than acted on: `maxCumulativeReanchorFee`'s comment
(25477d5c) is the author's own deliberate choice to keep-and-document over
remove, made one commit before this note. If that call still stands after
seeing this, no action needed; if not, dropping both now (before any sibling
PR rebases onto this layout) is cheap - it was verified compile-clean
against all six.

### Two fields with no extraction source

`activeReservationsCount` and `maxActiveReservations` are new work required by
the milestone 1 launch gates. Occupancy is monotonic toward
`liveWalletsCount * maxReservationsPerWallet`, because no milestone 1 path
frees a wallet slot short of wallet termination. At saturation a re-anchor has
no target wallet, and an anchored wallet cannot retire because closing
requires a zero reservation count - its MovingFunds clock then expires and the
timeout seizes operator stake. The cap turns that silent cliff into a revert.

Only the declarations are here. The enforcement that reads them - the
acceptance-time check and the counter's increment and decrement sites - is
new milestone 1 work belonging to the acceptance path, and the paired router
view belongs to PR #B. One sub-decision is still open in the spec: whether to
add a relational check tying `reservationMaxTotalAmount` to slot capacity, or
to emit both sides and make it a runbook gate.

**Spec gap to close before governance sign-off:** the frozen milestone-1
parameter spec's own sign-off ledger has no row for `maxActiveReservations`
under any name. The two nearest rows (`reservationMaxTotalAmount`'s global
amount cap, `maxReservationsPerWallet`'s per-wallet count) are explicitly
different axes per this field's own doc-comment ("neither bounds how many
positions exist across all wallets"). Governance could sign off on the
frozen spec exactly as written and never have decided this cap's launch
value - needs a launch-value row and a sign-off checkbox added to the spec
before milestone-1 sign-off proceeds.

### `__gap`: 48 to 33, derived not copied

The 28 fields consume 15 slots. `cumulativeReanchorFee` sits inside a
mapping value, so it costs no `Storage` slot at all. The other 27 fields
are grouped scalars-first, then mappings, to pack tightly instead of
interleaving: two small fields pack into the free tail of
`address rebateStaking` (no new slot); five further slots hold the
remaining value types, two of them fully packed at 32/32 bytes
(`reservationVault`+`reservationTxMaxFee`+`reservationDissolutionDelay`,
and `maxReservationsAmountPerWallet`+`reservationMaxSingleAmount`+
`pendingReservedDeposits`+`maxCumulativeReanchorFee`); the ten mapping
fields take one slot each.

`assertStorageUpgradeSafe` passing is necessary but not sufficient - it
checks that existing fields did not move, not that the gap was shrunk by the
right amount. The decisive check is the total footprint: `Bridge` measures
**4,128 bytes / 129 slots, exactly equal to the deployed TIP-109
implementation artifact's**. The reservation fields consumed precisely the
slots the gap gave up.

### EIP-170

`Bridge` compiles to 23,939 bytes at the base `runs: 1000`, 637 bytes under
the 24,576 limit - unchanged from the base branch, since this PR adds no
code. #1096's `Bridge.sol` optimizer override (`runs: 100`) is therefore
**not** ported; it exists there to pay for the router logic, which is PR #B's
scope, and porting it now would be an unrelated optimizer change.

### Verification

Run the format gate first. The test run creates a gitignored
`gasReporterOutput.json`, and `yarn format` includes `prettier --check .`,
which then fails on that artifact - delete it before re-running the gate.

```
cd solidity
yarn format                                              # 0 errors, Prettier clean
yarn test test/bridge/Bridge.StorageLayout.test.ts        # 1 passing
```

`yarn test` already exports `USE_EXTERNAL_DEPLOY=true` and
`TEST_USE_STUBS_TBTC=true`. If `FORKING_URL` is exported in your shell,
prefix with `env -u FORKING_URL -u FORKING_BLOCK` or hardhat forks mainnet.

Results on `7db90052`:
- `yarn format` - exit 0. 49 warnings, all pre-existing; 0 errors; no
  tracked file rewritten.
- `Bridge storage layout > is upgrade-safe against the deployed TIP-109
  Bridge layout` - 1 passing.
- Footprint equality against the deployed artifact - 4,128 bytes both sides.

### Known wart

`solhint` reports one `ordering` warning on `Reservation.sol`: the two term
constants precede the enum declarations. This is inherited - #1096's own
`Reservation.sol` produces the identical warning at the identical construct
(verified by linting the reference file). Reordering to silence it would
make this file differ from every later PR in the stack, which is the one
property this PR exists to guarantee, so it stays.

