### PR TITLE
feat(bridge): reservation acceptance and re-anchor core

### DIFF
--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -440,10 +440,8 @@ library BridgeState {
         uint64 reservationDissolutionTxMaxFee;
         // Global count of open reservation positions. Distinct from the
         // per-wallet `walletReservationsCount` and from the global amount
-        // `reservationTotalAmount`: neither bounds how many positions exist
-        // across all wallets, and occupancy is monotonic because no
-        // milestone 1 path frees a wallet slot except wallet termination.
-        // Genuinely new in milestone 1 - no extraction source.
+        // `reservationTotalAmount`. Genuinely new in milestone 1 - no
+        // extraction source.
         uint32 activeReservationsCount;
         // Governance-time cap on `activeReservationsCount`, sized below the
         // slot capacity `liveWalletsCount * maxReservationsPerWallet` at the

--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -440,8 +440,7 @@ library BridgeState {
         uint64 reservationDissolutionTxMaxFee;
         // Global count of open reservation positions. Distinct from the
         // per-wallet `walletReservationsCount` and from the global amount
-        // `reservationTotalAmount`. Genuinely new in milestone 1 - no
-        // extraction source.
+        // `reservationTotalAmount`.
         uint32 activeReservationsCount;
         // Governance-time cap on `activeReservationsCount`, sized below the
         // slot capacity `liveWalletsCount * maxReservationsPerWallet` at the

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -343,6 +343,11 @@ event ReservationAcceptanceTimedOut(
         uint64 anchorAmount
     );
 
+    event ReservationReanchorTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
     /// @notice Computes the storage key of the action record of the given
     ///         reservation generation.
     function actionKey(uint256 reservationKey, uint64 requestNonce)
@@ -541,6 +546,12 @@ event ReservationAcceptanceTimedOut(
             "Reservation exceeds the single-reservation cap"
         );
 
+        require(
+            self.maxActiveReservations == 0 ||
+                self.activeReservationsCount < self.maxActiveReservations,
+            "Active reservations cap exceeded"
+        );
+
         // Reserve capacity using the deposit value as the upper bound of
         // the anchor value; the settlement releases the miner-fee delta.
         uint64 newTotal = self.reservationTotalAmount + deposit.amount;
@@ -674,10 +685,14 @@ event ReservationAcceptanceTimedOut(
     /// @dev Requirements:
     ///      - The reservation must be Active,
     ///      - The reservation must not yet be dissolution-eligible,
-    ///      - The source wallet must be in the MovingFunds state (anyone
-    ///        may then request — migration is the system's duty), or Live
+    ///      - The source wallet must be in the MovingFunds or Closing state
+    ///        (anyone may then request — migration is the system's duty,
+    ///        and a retiring wallet must never pin a reservation), or Live
     ///        with the governance as the caller (approved rotation),
     ///      - The target wallet must be Live and different from the source,
+    ///      - At least one integer timestamp must remain between now and the
+    ///        action-timeout safety margin, so every created action has a
+    ///        proposal the wallet validator can sign,
     ///      - The target wallet's reservation-count capacity must allow the
     ///        move; the capacity is reserved by this call and released if
     ///        the authorization times out.
@@ -712,8 +727,9 @@ event ReservationAcceptanceTimedOut(
                 );
             } else {
                 require(
-                    sourceState == Wallets.WalletState.MovingFunds,
-                    "Source wallet must be in Live or MovingFunds state"
+                    sourceState == Wallets.WalletState.MovingFunds ||
+                        sourceState == Wallets.WalletState.Closing,
+                    "Source wallet must be in Live, MovingFunds or Closing state"
                 );
             }
         }
@@ -726,6 +742,27 @@ event ReservationAcceptanceTimedOut(
             self.registeredWallets[targetWalletPubKeyHash].state ==
                 Wallets.WalletState.Live,
             "Target wallet must be in Live state"
+        );
+
+        /* solhint-disable-next-line not-rely-on-time */
+        uint32 timeoutAt = uint32(block.timestamp) +
+            self.reservationActionTimeout;
+
+        // A re-anchor authorization carries no deposit-reveal age floor
+        // (unlike acceptance): the earliest admissible signing timestamp is
+        // simply the next integer second after this request. Require a
+        // non-empty window before the safety-margined deadline so every
+        // created action has a proposal the wallet validator can sign.
+        require(
+            uint256(timeoutAt) >
+                WalletProposalValidatorConstants
+                    .REQUEST_TIMEOUT_SAFETY_MARGIN &&
+                /* solhint-disable-next-line not-rely-on-time */
+                uint256(block.timestamp) + 1 <
+                uint256(timeoutAt) -
+                    WalletProposalValidatorConstants
+                        .REQUEST_TIMEOUT_SAFETY_MARGIN,
+            "Reanchor authorization has no signing window"
         );
 
         // Reserve the target wallet's count and amount capacity; the
@@ -759,12 +796,9 @@ event ReservationAcceptanceTimedOut(
         );
         action.actionType = ActionType.Reanchor;
         action.state = ActionState.Pending;
-        /* solhint-disable not-rely-on-time */
+        /* solhint-disable-next-line not-rely-on-time */
         action.requestedAt = uint32(block.timestamp);
-        action.timeoutAt =
-            uint32(block.timestamp) +
-            self.reservationActionTimeout;
-        /* solhint-enable not-rely-on-time */
+        action.timeoutAt = timeoutAt;
         action.txMaxFee = self.reservationTxMaxFee;
         action.targetWalletPubKeyHash = targetWalletPubKeyHash;
         action.amount = reservation.anchorAmount;
@@ -776,6 +810,66 @@ event ReservationAcceptanceTimedOut(
             reservation.walletPubKeyHash,
             targetWalletPubKeyHash,
             action.txMaxFee
+        );
+    }
+
+    /// @notice Reports a reservation's pending re-anchor generation as
+    ///         timed out: its authorization window elapsed without a
+    ///         settling SPV proof. Permissionless. Releases the target
+    ///         wallet's reserved capacity and restores the reservation to
+    ///         `Active` so a fresh action may be requested; the generation
+    ///         itself remains eligible for a late proof (see
+    ///         `ReservationProofs.submitReservationReanchorProof`), which
+    ///         re-takes the released capacity.
+    /// @param reservationKey The key of the reservation whose current
+    ///        pending generation timed out.
+    /// @dev Requirements:
+    ///      - The reservation's current generation must be a `Reanchor`
+    ///        action in the `Pending` state,
+    ///      - Its snapshotted `timeoutAt` must have elapsed.
+    ///      - Milestone 1 only supports timing out `Reanchor` generations;
+    ///        `Acceptance` settlement predates this PR and is untouched.
+    function notifyReservationActionTimeout(
+        BridgeState.Storage storage self,
+        uint256 reservationKey
+    ) external {
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            reservation.requestNonce
+        );
+
+        require(
+            action.actionType == ActionType.Reanchor,
+            "Unsupported action type for timeout"
+        );
+        require(action.state == ActionState.Pending, "Action is not pending");
+        /* solhint-disable not-rely-on-time */
+        require(
+            block.timestamp >= action.timeoutAt,
+            "Action has not timed out"
+        );
+        /* solhint-enable not-rely-on-time */
+
+        action.state = ActionState.TimedOut;
+
+        // Release the target wallet's capacity reserved at request time;
+        // the source wallet's capacity is untouched because the
+        // reservation stays custodied there. A late proof of this
+        // generation re-takes the released target capacity (see
+        // `ReservationProofs.submitReservationReanchorProof`).
+        self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
+        self.walletReservationsAmount[action.targetWalletPubKeyHash] -= action
+            .amount;
+
+        reservation.state = ReservationState.Active;
+
+        emit ReservationReanchorTimedOut(
+            reservationKey,
+            reservation.requestNonce
         );
     }
 

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -877,13 +877,12 @@ library Reservation {
         // generation re-takes the released target capacity (see
         // `ReservationProofs.submitReservationReanchorProof`).
         self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
-        self.walletReservationsAmount[
-            action.targetWalletPubKeyHash
-        ] -= action.amount;
+        self.walletReservationsAmount[action.targetWalletPubKeyHash] -= action
+            .amount;
 
         reservation.state = ReservationState.Active;
 
-/* solhint-disable not-rely-on-time */
+        /* solhint-disable not-rely-on-time */
         reservation.reanchorCooldownUntil =
             uint32(block.timestamp) +
             self.reservationActionTimeout;

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -68,7 +68,6 @@ library Reservation {
     uint32 internal constant MIN_RESERVATION_TERM = 90 days;
     // slither-disable-next-line unused-state
     uint32 internal constant MAX_RESERVATION_TERM = 730 days;
-
     /// @notice Represents the state of a reservation position.
     enum ReservationState {
         /// @dev The reservation is unknown to the Bridge. Acceptance
@@ -709,13 +708,13 @@ library Reservation {
             reservation.state == ReservationState.Active,
             "Reservation is not active"
         );
+        /* solhint-disable not-rely-on-time */
         if (!privileged) {
             require(
                 block.timestamp >= reservation.reanchorCooldownUntil,
                 "Reanchor cooldown in effect"
             );
         }
-        /* solhint-disable not-rely-on-time */
         require(
             block.timestamp < reservation.dissolutionEligibleAt,
             "Reservation is dissolution-eligible"
@@ -783,7 +782,8 @@ library Reservation {
             targetWalletPubKeyHash
         ] + 1;
         require(
-            self.maxReservationsPerWallet == 0 || targetCount <= self.maxReservationsPerWallet,
+            self.maxReservationsPerWallet == 0 ||
+                targetCount <= self.maxReservationsPerWallet,
             "Wallet reservations cap exceeded"
         );
         self.walletReservationsCount[targetWalletPubKeyHash] = targetCount;
@@ -883,8 +883,11 @@ library Reservation {
 
         reservation.state = ReservationState.Active;
 
+/* solhint-disable not-rely-on-time */
         reservation.reanchorCooldownUntil =
-            uint32(block.timestamp) + self.reservationActionTimeout;
+            uint32(block.timestamp) +
+            self.reservationActionTimeout;
+        /* solhint-enable not-rely-on-time */
 
         emit ReservationReanchorTimedOut(
             reservationKey,
@@ -986,7 +989,9 @@ library Reservation {
         BridgeState.Storage storage self,
         uint256 reservationKey
     ) external {
-        ReservationRequest storage reservation = self.reservations[reservationKey];
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
         require(
             reservation.state == ReservationState.Active,
             "Reservation is not active"
@@ -1002,5 +1007,4 @@ library Reservation {
 
         strandReservation(self, reservation, reservationKey);
     }
-
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -323,9 +323,17 @@ library Reservation {
         uint32 timeoutAt
     );
 
-    event ReservationAcceptanceTimedOut(
+event ReservationAcceptanceTimedOut(
         uint256 indexed reservationKey,
         uint64 requestNonce
+    );
+
+    event ReservationReanchorRequested(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed sourceWalletPubKeyHash,
+        bytes20 indexed targetWalletPubKeyHash,
+        uint64 txMaxFee
     );
 
     event ReservationStranded(
@@ -354,6 +362,23 @@ library Reservation {
         uint64 requestNonce
     ) internal view returns (ReservationAction storage) {
         return self.reservationActions[actionKey(reservationKey, requestNonce)];
+    }
+
+    /// @notice Returns the canonical hash of a reservation anchor outpoint.
+    ///         Action generations snapshot this value so a late proof can
+    ///         only consume the exact anchor that generation authorized.
+    function anchorUtxoHash(ReservationRequest storage reservation)
+        internal
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encodePacked(
+                    reservation.anchorTxHash,
+                    reservation.anchorTxOutputIndex
+                )
+            );
     }
 
     /// @notice Requests the acceptance of a revealed reserved deposit: the
@@ -633,6 +658,125 @@ library Reservation {
         self.activeReservationsCount -= 1;
 
         emit ReservationAcceptanceTimedOut(reservationKey, requestNonce);
+    }
+
+    /// @notice Requests the re-anchoring of a reservation to another
+    ///         wallet: the authorization for the source wallet to spend the
+    ///         anchor in a 1-input-1-output transaction paying the target
+    ///         wallet. Used during wallet migration so reservations never
+    ///         pin retiring wallets, and for governance-approved rotations.
+    /// @param reservationKey The key of the reservation to re-anchor.
+    /// @param targetWalletPubKeyHash 20-byte public key hash of the target
+    ///        wallet.
+    /// @param privileged True when the call is made by the governance
+    ///        (checked by the calling contract), which may rotate anchors
+    ///        away from Live wallets.
+    /// @dev Requirements:
+    ///      - The reservation must be Active,
+    ///      - The reservation must not yet be dissolution-eligible,
+    ///      - The source wallet must be in the MovingFunds state (anyone
+    ///        may then request — migration is the system's duty), or Live
+    ///        with the governance as the caller (approved rotation),
+    ///      - The target wallet must be Live and different from the source,
+    ///      - The target wallet's reservation-count capacity must allow the
+    ///        move; the capacity is reserved by this call and released if
+    ///        the authorization times out.
+    function requestReservationReanchor(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash,
+        bool privileged
+    ) external {
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        require(
+            reservation.state == ReservationState.Active,
+            "Reservation is not active"
+        );
+        /* solhint-disable not-rely-on-time */
+        require(
+            block.timestamp < reservation.dissolutionEligibleAt,
+            "Reservation is dissolution-eligible"
+        );
+        /* solhint-enable not-rely-on-time */
+
+        {
+            Wallets.WalletState sourceState = self
+                .registeredWallets[reservation.walletPubKeyHash]
+                .state;
+            if (sourceState == Wallets.WalletState.Live) {
+                require(
+                    privileged,
+                    "Only governance can rotate a Live wallet's anchor"
+                );
+            } else {
+                require(
+                    sourceState == Wallets.WalletState.MovingFunds,
+                    "Source wallet must be in Live or MovingFunds state"
+                );
+            }
+        }
+
+        require(
+            targetWalletPubKeyHash != reservation.walletPubKeyHash,
+            "Target wallet must differ from the source wallet"
+        );
+        require(
+            self.registeredWallets[targetWalletPubKeyHash].state ==
+                Wallets.WalletState.Live,
+            "Target wallet must be in Live state"
+        );
+
+        // Reserve the target wallet's count and amount capacity; the
+        // source wallet's are released at settlement (or kept on timeout).
+        uint32 targetCount = self.walletReservationsCount[
+            targetWalletPubKeyHash
+        ] + 1;
+        require(
+            targetCount <= self.maxReservationsPerWallet,
+            "Wallet reservations cap exceeded"
+        );
+        self.walletReservationsCount[targetWalletPubKeyHash] = targetCount;
+
+        uint64 targetAmount = self.walletReservationsAmount[
+            targetWalletPubKeyHash
+        ] + reservation.anchorAmount;
+        require(
+            self.maxReservationsAmountPerWallet == 0 ||
+                targetAmount <= self.maxReservationsAmountPerWallet,
+            "Wallet reserved amount cap exceeded"
+        );
+        self.walletReservationsAmount[targetWalletPubKeyHash] = targetAmount;
+
+        reservation.state = ReservationState.ActionPending;
+        uint64 requestNonce = ++reservation.requestNonce;
+
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            requestNonce
+        );
+        action.actionType = ActionType.Reanchor;
+        action.state = ActionState.Pending;
+        /* solhint-disable not-rely-on-time */
+        action.requestedAt = uint32(block.timestamp);
+        action.timeoutAt =
+            uint32(block.timestamp) +
+            self.reservationActionTimeout;
+        /* solhint-enable not-rely-on-time */
+        action.txMaxFee = self.reservationTxMaxFee;
+        action.targetWalletPubKeyHash = targetWalletPubKeyHash;
+        action.amount = reservation.anchorAmount;
+        action.sourceAnchorUtxoHash = anchorUtxoHash(reservation);
+
+        emit ReservationReanchorRequested(
+            reservationKey,
+            requestNonce,
+            reservation.walletPubKeyHash,
+            targetWalletPubKeyHash,
+            action.txMaxFee
+        );
     }
 
     /// @notice Appends a reservation key to a wallet's enumeration list.

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -31,7 +31,7 @@ import "./WalletProposalValidatorConstants.sol";
 /// @dev Every Bitcoin action of a reservation's life — the acceptance
 ///      anchor, an in-kind redemption, a re-anchor to another wallet, and
 ///      the post-term dissolution — follows a *two-phase,
-///      authorize-then-prove* model (see RFC 13, which ships with a later milestone PR and is not yet in this branch's docs/rfc/):
+///      authorize-then-prove* model, as described in tbtc-v2 PR #1108:
 ///
 ///      1. An explicit *request* increments the position's monotonic
 ///         request nonce, performs every capacity and lifecycle check and
@@ -216,11 +216,14 @@ library Reservation {
         // `ReservationReanchored` event carries only the new anchor
         // amount, not the per-hop delta. Accumulating now means a
         // post-milestone-1 cap reads the true lifetime total instead of
-        // only post-upgrade hops. A position field a later milestone reads
-        // cannot be added while reservations are live.
+        // only post-upgrade hops. Appended to the end of the struct: since
+        // the struct is stored in a mapping, fields can be appended safely
+        // without gap-scarcity (see the note below on why this struct has
+        // no `__gap`).
+        uint64 cumulativeReanchorFee;
         // Appended to the end of the struct so the existing field layout
         // is unchanged.
-        uint64 cumulativeReanchorFee;
+        uint32 reanchorCooldownUntil;
         // This struct doesn't contain `__gap` property as the structure is
         // stored in a mapping, mappings store values in different slots and
         // they are not contiguous with other values.
@@ -229,7 +232,8 @@ library Reservation {
     /// @notice Represents one requested generation of a reservation action.
     ///         All fields the proof and settlement paths consult are
     ///         snapshotted here at request time; live parameters are never
-    ///         read at settlement.
+    ///         read at settlement, with the exception of term and dissolution
+    ///         delay grants.
     struct ReservationAction {
         // 20-byte public key hash of the wallet the action's single
         // wallet-controlled output must pay to: the designated custodian
@@ -323,11 +327,6 @@ library Reservation {
         uint64 depositAmount,
         uint64 txMaxFee,
         uint32 timeoutAt
-    );
-
-event ReservationAcceptanceTimedOut(
-        uint256 indexed reservationKey,
-        uint64 requestNonce
     );
 
     event ReservationReanchorRequested(
@@ -427,9 +426,9 @@ event ReservationAcceptanceTimedOut(
     ///      - At least one integer timestamp must remain after the deposit
     ///        minimum age and before both the action-timeout and exact
     ///        reveal-time refund safety margins, so every created action has
-    ///        a proposal the wallet validator can sign,
-    ///      - The authorization window (now + action timeout) must end before
-    ///        the exact refund deadline, so an authorized anchor can never
+    ///        a proposal the wallet validator (see PR #B) can sign,
+    ///      - The authorization window (now + action timeout) must end at or
+    ///        before the exact refund deadline, so an authorized anchor can never
     ///        race the depositor's refund,
     ///      - The single-reservation amount must not exceed the cap,
     ///      - The active-position cap must not be exceeded,
@@ -692,7 +691,7 @@ event ReservationAcceptanceTimedOut(
     ///      - The target wallet must be Live and different from the source,
     ///      - At least one integer timestamp must remain between now and the
     ///        action-timeout safety margin, so every created action has a
-    ///        proposal the wallet validator can sign,
+    ///        proposal the wallet validator (see PR #B) can sign,
     ///      - The target wallet's reservation-count capacity must allow the
     ///        move; the capacity is reserved by this call and released if
     ///        the authorization times out,
@@ -710,6 +709,12 @@ event ReservationAcceptanceTimedOut(
             reservation.state == ReservationState.Active,
             "Reservation is not active"
         );
+        if (!privileged) {
+            require(
+                block.timestamp >= reservation.reanchorCooldownUntil,
+                "Reanchor cooldown in effect"
+            );
+        }
         /* solhint-disable not-rely-on-time */
         require(
             block.timestamp < reservation.dissolutionEligibleAt,
@@ -730,7 +735,7 @@ event ReservationAcceptanceTimedOut(
                 require(
                     sourceState == Wallets.WalletState.MovingFunds ||
                         sourceState == Wallets.WalletState.Closing,
-                    "Source wallet must be in Live, MovingFunds or Closing state"
+                    "Source wallet must be in MovingFunds or Closing state"
                 );
             }
         }
@@ -753,7 +758,8 @@ event ReservationAcceptanceTimedOut(
         // (unlike acceptance): the earliest admissible signing timestamp is
         // simply the next integer second after this request. Require a
         // non-empty window before the safety-margined deadline so every
-        // created action has a proposal the wallet validator can sign.
+        // created action has a proposal the wallet validator (see PR #B)
+        // can sign.
         require(
             uint256(timeoutAt) >
                 WalletProposalValidatorConstants
@@ -765,6 +771,11 @@ event ReservationAcceptanceTimedOut(
                         .REQUEST_TIMEOUT_SAFETY_MARGIN,
             "Reanchor authorization has no signing window"
         );
+        require(
+            reservation.anchorAmount >
+                self.reservationTxMaxFee + self.reservationMinAmount,
+            "Reanchor would fall below the minimum reservation amount"
+        );
 
         // Reserve the target wallet's count and amount capacity; the
         // source wallet's are released at settlement (or kept on timeout).
@@ -772,7 +783,7 @@ event ReservationAcceptanceTimedOut(
             targetWalletPubKeyHash
         ] + 1;
         require(
-            targetCount <= self.maxReservationsPerWallet,
+            self.maxReservationsPerWallet == 0 || targetCount <= self.maxReservationsPerWallet,
             "Wallet reservations cap exceeded"
         );
         self.walletReservationsCount[targetWalletPubKeyHash] = targetCount;
@@ -872,6 +883,9 @@ event ReservationAcceptanceTimedOut(
 
         reservation.state = ReservationState.Active;
 
+        reservation.reanchorCooldownUntil =
+            uint32(block.timestamp) + self.reservationActionTimeout;
+
         emit ReservationReanchorTimedOut(
             reservationKey,
             reservation.requestNonce
@@ -932,19 +946,18 @@ event ReservationAcceptanceTimedOut(
             self.reservationTotalAmount -= anchorAmount;
             self.activeReservationsCount -= 1; // The stranded reservation was counted at request time.
             removeWalletReservationKey(self, walletPubKeyHash, reservationKey);
-        }
-        reservation.state = ReservationState.Stranded;
-
-        delete self.reservationsByAnchorUtxo[
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        reservation.anchorTxHash,
-                        reservation.anchorTxOutputIndex
+            delete self.reservationsByAnchorUtxo[
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            reservation.anchorTxHash,
+                            reservation.anchorTxOutputIndex
+                        )
                     )
                 )
-            )
-        ];
+            ];
+        }
+        reservation.state = ReservationState.Stranded;
 
         // A late dissolution proof can reconstruct and then release the
         // accounting of an already-stranded position. Preserve the original
@@ -959,4 +972,35 @@ event ReservationAcceptanceTimedOut(
             );
         }
     }
+
+    /// @notice Permissionless cleanup entry point for a reservation whose
+    ///         wallet has reached the Terminated state with no settlement
+    ///         currently in flight. Releases the reservation's tracked
+    ///         capacity via `strandReservation`, which also emits the
+    ///         canonical `ReservationStranded` recovery evidence.
+    /// @param reservationKey The key of the reservation to strand.
+    /// @dev Requirements:
+    ///      - The reservation must be Active,
+    ///      - The reservation's wallet must be in the Terminated state.
+    function notifyReservationStranded(
+        BridgeState.Storage storage self,
+        uint256 reservationKey
+    ) external {
+        ReservationRequest storage reservation = self.reservations[reservationKey];
+        require(
+            reservation.state == ReservationState.Active,
+            "Reservation is not active"
+        );
+
+        Wallets.WalletState walletState = self
+            .registeredWallets[reservation.walletPubKeyHash]
+            .state;
+        require(
+            walletState == Wallets.WalletState.Terminated,
+            "Source wallet is not terminated"
+        );
+
+        strandReservation(self, reservation, reservationKey);
+    }
+
 }

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -43,7 +43,9 @@ import "./WalletProposalValidatorConstants.sol";
 ///         after the request can make the signed transaction unprovable.
 ///
 ///      2. The SPV *proof* settles the generation against the record's
-///         snapshots — never against live parameters. A generation that
+///         snapshotted authorization parameters; term and
+///         dissolution-delay grants at settlement additionally read live
+///         governance parameters current at that moment. A generation that
 ///         times out leaves a terminal record that still accepts a late
 ///         proof (closing the anchor lineage without a second refund); a
 ///         generation vetoed by the redemption watchtower never accepts a
@@ -348,6 +350,11 @@ event ReservationAcceptanceTimedOut(
         uint64 requestNonce
     );
 
+    event ReservationAcceptanceTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
     /// @notice Computes the storage key of the action record of the given
     ///         reservation generation.
     function actionKey(uint256 reservationKey, uint64 requestNonce)
@@ -419,18 +426,16 @@ event ReservationAcceptanceTimedOut(
     ///        cap),
     ///      - At least one integer timestamp must remain after the deposit
     ///        minimum age and before both the action-timeout and exact
-    ///        reveal-time refund safety margins; off-chain wallet signing
-    ///        of the resulting acceptance anchor is expected but has no
-    ///        on-chain validator entry point in milestone 1,
-    ///      - The authorization window (now + action timeout) must end at least
-    ///        DEPOSIT_REFUND_SAFETY_MARGIN (24h) before the refund deadline, so
-    ///        an authorized anchor can never race the depositor's refund,
-    ///      - Reservation capacity (total amount `reservationMaxTotalAmount`,
-    ///        per-wallet count `maxReservationsPerWallet`; both 0 blocks
-    ///        all requests, the opposite convention from the caps above)
-    ///        must allow the deposit; both are reserved by this call and
-    ///        released on settlement, unwind, or permissionless timeout
-    ///        notification (see `notifyReservationAcceptanceTimedOut`).
+    ///        reveal-time refund safety margins, so every created action has
+    ///        a proposal the wallet validator can sign,
+    ///      - The authorization window (now + action timeout) must end before
+    ///        the exact refund deadline, so an authorized anchor can never
+    ///        race the depositor's refund,
+    ///      - The single-reservation amount must not exceed the cap,
+    ///      - The active-position cap must not be exceeded,
+    ///      - The global reserved-amount cap must not be exceeded,
+    ///      - The per-wallet reservation-count cap must not be exceeded,
+    ///      - The per-wallet amount cap must not be exceeded.
     function requestReservationAcceptance(
         BridgeState.Storage storage self,
         uint256 reservationKey,
@@ -546,24 +551,29 @@ event ReservationAcceptanceTimedOut(
             "Reservation exceeds the single-reservation cap"
         );
 
+        // Occupancy: number of open reservation positions across all
+        // wallets. Zero disables the cap until governance sets it.
         require(
             self.maxActiveReservations == 0 ||
                 self.activeReservationsCount < self.maxActiveReservations,
             "Active reservations cap exceeded"
         );
+        self.activeReservationsCount += 1;
 
         // Reserve capacity using the deposit value as the upper bound of
         // the anchor value; the settlement releases the miner-fee delta.
         uint64 newTotal = self.reservationTotalAmount + deposit.amount;
         require(
-            newTotal <= self.reservationMaxTotalAmount,
+            self.reservationMaxTotalAmount == 0 ||
+                newTotal <= self.reservationMaxTotalAmount,
             "Total reserved amount cap exceeded"
         );
         self.reservationTotalAmount = newTotal;
 
         uint32 walletCount = self.walletReservationsCount[walletPubKeyHash] + 1;
         require(
-            walletCount <= self.maxReservationsPerWallet,
+            self.maxReservationsPerWallet == 0 ||
+                walletCount <= self.maxReservationsPerWallet,
             "Wallet reservations cap exceeded"
         );
         self.walletReservationsCount[walletPubKeyHash] = walletCount;
@@ -576,16 +586,6 @@ event ReservationAcceptanceTimedOut(
             "Wallet reserved amount cap exceeded"
         );
         self.walletReservationsAmount[walletPubKeyHash] = walletAmount;
-
-        // Occupancy: number of open reservation positions across all
-        // wallets. Zero disables the cap until governance sets it.
-        if (self.maxActiveReservations > 0) {
-            require(
-                self.activeReservationsCount < self.maxActiveReservations,
-                "Max active reservations reached"
-            );
-        }
-        self.activeReservationsCount += 1;
 
         uint64 requestNonce = ++reservation.requestNonce;
 
@@ -686,16 +686,17 @@ event ReservationAcceptanceTimedOut(
     ///      - The reservation must be Active,
     ///      - The reservation must not yet be dissolution-eligible,
     ///      - The source wallet must be in the MovingFunds or Closing state
-    ///        (anyone may then request — migration is the system's duty,
-    ///        and a retiring wallet must never pin a reservation), or Live
-    ///        with the governance as the caller (approved rotation),
+    ///        (the primary re-anchor path for MovingFunds/Closing is
+    ///        permissionless by design, not gated), or Live with the
+    ///        governance as the caller (approved rotation),
     ///      - The target wallet must be Live and different from the source,
     ///      - At least one integer timestamp must remain between now and the
     ///        action-timeout safety margin, so every created action has a
     ///        proposal the wallet validator can sign,
     ///      - The target wallet's reservation-count capacity must allow the
     ///        move; the capacity is reserved by this call and released if
-    ///        the authorization times out.
+    ///        the authorization times out,
+    ///      - The target wallet's amount capacity must allow the move.
     function requestReservationReanchor(
         BridgeState.Storage storage self,
         uint256 reservationKey,
@@ -826,9 +827,8 @@ event ReservationAcceptanceTimedOut(
     /// @dev Requirements:
     ///      - The reservation's current generation must be a `Reanchor`
     ///        action in the `Pending` state,
+    ///      - The reservation itself must be in the `ActionPending` state,
     ///      - Its snapshotted `timeoutAt` must have elapsed.
-    ///      - Milestone 1 only supports timing out `Reanchor` generations;
-    ///        `Acceptance` settlement predates this PR and is untouched.
     function notifyReservationActionTimeout(
         BridgeState.Storage storage self,
         uint256 reservationKey
@@ -846,6 +846,10 @@ event ReservationAcceptanceTimedOut(
             action.actionType == ActionType.Reanchor,
             "Unsupported action type for timeout"
         );
+        require(
+            reservation.state == ReservationState.ActionPending,
+            "Reservation is not in ActionPending state"
+        );
         require(action.state == ActionState.Pending, "Action is not pending");
         /* solhint-disable not-rely-on-time */
         require(
@@ -862,8 +866,9 @@ event ReservationAcceptanceTimedOut(
         // generation re-takes the released target capacity (see
         // `ReservationProofs.submitReservationReanchorProof`).
         self.walletReservationsCount[action.targetWalletPubKeyHash] -= 1;
-        self.walletReservationsAmount[action.targetWalletPubKeyHash] -= action
-            .amount;
+        self.walletReservationsAmount[
+            action.targetWalletPubKeyHash
+        ] -= action.amount;
 
         reservation.state = ReservationState.Active;
 
@@ -907,10 +912,10 @@ event ReservationAcceptanceTimedOut(
         delete self.walletReservationKeyIndex[reservationKey];
     }
 
-    /// @notice Strands a reservation: releases its tracked capacity, removes
-    ///         it from wallet enumeration and emits the canonical recovery
-    ///         evidence. The caller decides whether the anchor was honestly
-    ///         spent before invoking this accounting transition.
+    /// @notice Strands a reservation: releases its tracked capacity and
+    ///         emits the canonical recovery evidence. The caller decides
+    ///         whether the anchor was honestly spent before invoking this
+    ///         accounting transition.
     function strandReservation(
         BridgeState.Storage storage self,
         ReservationRequest storage reservation,
@@ -921,12 +926,14 @@ event ReservationAcceptanceTimedOut(
         bytes20 walletPubKeyHash = reservation.walletPubKeyHash;
         uint64 anchorAmount = reservation.anchorAmount;
 
-        self.walletReservationsCount[walletPubKeyHash] -= 1;
-        self.walletReservationsAmount[walletPubKeyHash] -= anchorAmount;
-        self.reservationTotalAmount -= anchorAmount;
-        removeWalletReservationKey(self, walletPubKeyHash, reservationKey);
+        if (!evidenceAlreadyEmitted) {
+            self.walletReservationsCount[walletPubKeyHash] -= 1;
+            self.walletReservationsAmount[walletPubKeyHash] -= anchorAmount;
+            self.reservationTotalAmount -= anchorAmount;
+            self.activeReservationsCount -= 1; // The stranded reservation was counted at request time.
+            removeWalletReservationKey(self, walletPubKeyHash, reservationKey);
+        }
         reservation.state = ReservationState.Stranded;
-        self.activeReservationsCount -= 1; // The stranded reservation was counted at request time.
 
         delete self.reservationsByAnchorUtxo[
             uint256(

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -222,6 +222,29 @@ library ReservationProofs {
         }
     }
 
+    /// @notice Strands a reservation if its (already updated) target
+    ///         wallet can no longer manage the anchor it was just moved
+    ///         to. Used only for an on-time re-anchor settlement, whose
+    ///         target wallet may have started retiring between request and
+    ///         proof; extracted into its own function to keep the caller's
+    ///         stack shallow.
+    function strandIfTargetWalletClosed(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash
+    ) internal {
+        Wallets.WalletState targetWalletState = self
+            .registeredWallets[targetWalletPubKeyHash]
+            .state;
+        if (
+            targetWalletState == Wallets.WalletState.Closing ||
+            targetWalletState == Wallets.WalletState.Closed
+        ) {
+            self.strandReservation(reservation, reservationKey);
+        }
+    }
+
     /// @notice Validates the position can settle the loaded action and, for a
     ///         timed-out generation whose position was already stranded,
     ///         reconstructs the source anchor's tracking before settlement.
@@ -741,11 +764,6 @@ library ReservationProofs {
         reservation.anchorTxOutputIndex = 0;
         reservation.state = Reservation.ReservationState.Active;
 
-        if (minerFee > 0) {
-            IReservationFeeFinancer(self.deposits[reservationKey].vault)
-                .financeInKindFee(minerFee);
-        }
-
         action.state = Reservation.ActionState.Settled;
 
         self.reservationsByAnchorUtxo[
@@ -768,6 +786,31 @@ library ReservationProofs {
             late,
             evidenceAlreadyEmitted
         );
+
+        // The shared helper above only strands the late branch, matching
+        // the acceptance settlement semantics it is reused from. An
+        // on-time re-anchor proof needs the same safety net: the target
+        // wallet may have started retiring between request and proof, and
+        // without this check the position would stay `Active` under a
+        // wallet that can no longer manage the anchor.
+        if (!late) {
+            strandIfTargetWalletClosed(
+                self,
+                reservation,
+                reservationKey,
+                newWalletPubKeyHash
+            );
+        }
+
+        // Financing the in-kind miner fee is the only external call in
+        // this function; it runs last, after every internal effect and
+        // stranding check has committed, so a malicious or buggy vault
+        // reentering through `financeInKindFee` can only ever observe a
+        // fully settled generation (checks-effects-interactions).
+        if (minerFee > 0) {
+            IReservationFeeFinancer(self.deposits[reservationKey].vault)
+                .financeInKindFee(minerFee);
+        }
     }
 
     /// @notice Unwinds the position's current pending generation during a

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -35,7 +35,12 @@ import "../vault/IReservationFeeFinancer.sol";
 ///         requestNonce)`, and is validated exclusively against that
 ///         generation's snapshotted action record — never against live
 ///         parameters.
-/// @dev Settlement rules shared by all action types (Milestone 1 wires only the acceptance branch; the redemption, re-anchor and dissolution rules described below land with later milestones.):
+/// @dev Settlement rules shared by all action types:
+///
+///      - NOTE: The configured reservationVault is assumed to conform to
+///        IReservationFeeFinancer. This conformance gap must be validated
+///        (via ERC-165 or a probe call) once a governance setter for
+///        reservationVault is implemented.
 ///
 ///      - A `Pending` generation settles normally. For redemptions the
 ///        proof additionally requires the watchtower delay of the
@@ -45,17 +50,11 @@ import "../vault/IReservationFeeFinancer.sol";
 ///        (the fraud machinery handles the unauthorized signature).
 ///
 ///      - A `TimedOut` generation still settles ("late settlement"): the
-///        Bitcoin transaction confirmed and the anchor is irrevocably
-///        spent, so the registry records reality — consumed outpoints are
-///        marked honestly spent (defeating fraud challenges against the
-///        honest-but-late signature), the anchor lineage closes, and any
-///        newer pending generation whose anchor no longer exists is
-///        unwound (its escrow refunded). What late settlement never does
-///        is repeat a Bank movement: the timeout already refunded the
-///        escrow, so nothing is burned or paid again. If the position's
-///        *current pending* redemption generation matches the transaction
-///        as well, the proof must settle against it instead — the
-///        deterministic, economically correct target.
+///        Bitcoin transaction confirmed and the registry records reality.
+///        For Acceptance and Reanchor actions, late settlement performs
+///        the action's terminal state transition; for other types, it
+///        unwinds any newer pending generation whose anchor no longer
+///        exists (its escrow refunded).
 ///
 ///      - A `Vetoed` generation never settles.
 library ReservationProofs {
@@ -130,7 +129,7 @@ library ReservationProofs {
         uint64 requestNonce
     ) external {
         require(
-            proofType < uint8(type(ProofType).max) + 1,
+            proofType <= uint8(type(ProofType).max),
             "Unsupported reservation proof type"
         );
         ProofType parsedProofType = ProofType(proofType);
@@ -178,6 +177,10 @@ library ReservationProofs {
             Reservation.actionKey(reservationKey, requestNonce)
         ];
         require(action.actionType == expectedType, "Action type mismatch");
+        require(
+            self.reservations[reservationKey].requestNonce == requestNonce,
+            "Not the current generation"
+        );
         require(
             action.state == Reservation.ActionState.Pending ||
                 action.state == Reservation.ActionState.TimedOut,
@@ -239,7 +242,8 @@ library ReservationProofs {
             .state;
         if (
             targetWalletState == Wallets.WalletState.Closing ||
-            targetWalletState == Wallets.WalletState.Closed
+            targetWalletState == Wallets.WalletState.Closed ||
+            targetWalletState == Wallets.WalletState.Terminated
         ) {
             self.strandReservation(reservation, reservationKey);
         }
@@ -295,11 +299,6 @@ library ReservationProofs {
         self.walletReservationsAmount[
             reservation.walletPubKeyHash
         ] += reservation.anchorAmount;
-        Reservation.addWalletReservationKey(
-            self,
-            reservation.walletPubKeyHash,
-            reservationKey
-        );
         self.reservationsByAnchorUtxo[anchorUtxoKey] = reservationKey;
     }
 
@@ -518,6 +517,10 @@ library ReservationProofs {
             self.walletReservationsAmount[
                 targetWalletPubKeyHash
             ] += anchorAmount;
+            // The timeout also released activeReservationsCount (see
+            // `Reservation.notifyReservationAcceptanceTimedOut`); re-take it
+            // so a late-settled acceptance is still counted against the cap
+            // and `strandReservation`'s later release stays balanced.
             self.activeReservationsCount += 1;
             emit ReservationLateSettled(
                 reservationKey,
@@ -551,6 +554,7 @@ library ReservationProofs {
         reservation.anchorTxHash = anchorTxHash;
         reservation.anchorTxOutputIndex = 0;
         reservation.state = Reservation.ReservationState.Active;
+// activeReservationsCount is incremented at reservation request time.
         reservation.dissolutionEligibleAt = expiresAt + action.dissolutionDelay;
 
         self.reservationsByAnchorUtxo[
@@ -561,7 +565,6 @@ library ReservationProofs {
             targetWalletPubKeyHash,
             reservationKey
         );
-
         // slither-disable-next-line reentrancy-events
         emit ReservationAccepted(
             reservationKey,
@@ -679,7 +682,7 @@ library ReservationProofs {
         // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
         // consensus (the re-anchor output cannot exceed its input).
         require(
-            reservation.anchorAmount - newAnchorAmount <= action.txMaxFee,
+            action.amount - newAnchorAmount <= action.txMaxFee,
             "Transaction fee is too high"
         );
 
@@ -735,20 +738,10 @@ library ReservationProofs {
         // Afterwards the original anchor value is unrecoverable and
         // `ReservationReanchored` carries only the new anchor amount, so
         // this total could not be reconstructed from later state. No
-        // ceiling is enforced in milestone 1: `maxCumulativeReanchorFee`
-        // stays declare-only until a post-milestone-1 bound lands.
+        // ceiling is enforced in milestone 1: the per-reservation lifetime
+        // fee budget is unbounded until a post-milestone-1 governance cap
+        // lands.
         reservation.cumulativeReanchorFee += minerFee;
-
-        Reservation.removeWalletReservationKey(
-            self,
-            reservation.walletPubKeyHash,
-            reservationKey
-        );
-        Reservation.addWalletReservationKey(
-            self,
-            newWalletPubKeyHash,
-            reservationKey
-        );
 
         reservation.walletPubKeyHash = newWalletPubKeyHash;
         reservation.anchorAmount = newAnchorAmount;
@@ -802,8 +795,8 @@ library ReservationProofs {
             );
         }
 
-        // Financing the in-kind miner fee is the only external call in
-        // this function; it runs last, after every internal effect and
+        // Financing the in-kind miner fee is the only call to untrusted code
+        // in this function; it runs last, after every internal effect and
         // stranding check has committed, so a malicious or buggy vault
         // reentering through `financeInKindFee` can only ever observe a
         // fully settled generation (checks-effects-interactions).

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -37,10 +37,14 @@ import "../vault/IReservationFeeFinancer.sol";
 ///         parameters.
 /// @dev Settlement rules shared by all action types:
 ///
-///      - NOTE: The configured reservationVault is assumed to conform to
-///        IReservationFeeFinancer. This conformance gap must be validated
-///        (via ERC-165 or a probe call) once a governance setter for
-///        reservationVault is implemented.
+///      - NOTE: The untrusted call target is `deposits[reservationKey].vault`
+///        (the deposit's immutable vault, pinned at request time), assumed
+///        to conform to IReservationFeeFinancer. This conformance gap must
+///        be validated (via ERC-165 or a probe call) at that address once a
+///        governance setter for reservationVault is implemented -- every
+///        such address was `reservationVault` at some point, since
+///        `requestReservationAcceptance` already requires
+///        `deposit.vault == reservationVault`.
 ///
 ///      - A `Pending` generation settles normally. For redemptions the
 ///        proof additionally requires the watchtower delay of the

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -29,8 +29,8 @@ import "../vault/IReservationFeeFinancer.sol";
 
 /// @title Bridge UTXO reservations — settlement
 /// @notice SPV settlement side of the two-phase reservation model (see
-///         `Reservation` for the request/authorization side and RFC 13 for
-///         the architecture, whose document ships with a later milestone PR (not yet in this branch's docs/rfc/)). Every proof settles one requested
+///         `Reservation` for the request/authorization side, as described
+///         in tbtc-v2 PR #1108). Every proof settles one requested
 ///         *generation*, named explicitly by `(reservationKey,
 ///         requestNonce)`, and is validated exclusively against that
 ///         generation's snapshotted action record — never against live
@@ -79,7 +79,8 @@ library ReservationProofs {
         uint64 requestNonce,
         bytes20 indexed newWalletPubKeyHash,
         bytes32 newAnchorTxHash,
-        uint64 newAnchorAmount
+        uint64 newAnchorAmount,
+        uint64 minerFee
     );
 
     event ReservationActionSuperseded(
@@ -106,8 +107,9 @@ library ReservationProofs {
         Dissolution
     }
 
-    /// @notice Single entry point for all reservation lifecycle SPV proofs.
-    ///         Dispatches to the appropriate handler based on `proofType`.
+    /// @notice Entry point for supported reservation lifecycle SPV proofs
+    ///         (Acceptance, Reanchor); Redemption and Dissolution proofs
+    ///         revert as unsupported.
     /// @param proofType The type of the submitted proof, see `ProofType`.
     /// @param txInfo Bitcoin transaction data.
     /// @param proof Bitcoin proof data.
@@ -115,10 +117,12 @@ library ReservationProofs {
     /// @param requestNonce The generation being settled. Late settlements
     ///        name an older, timed-out generation.
     /// @dev The `BitcoinTx.UTXO` parameter is retained in the signature
-    ///      without a name to keep the external selector stable for any
-    ///      milestone-1 callers that already deployed against it; only the
-    ///      acceptance and re-anchor branches are wired up, so the value
-    ///      is unused.
+    ///      without a name as it is reserved for the future router's use
+    ///      (see PR #B); it is unused by the current bridge-facing entry
+    ///      point. Unlike every other existing SPV proof entry point in
+    ///      this repo, this function has no caller-identity gate here --
+    ///      the future router (PR #B) must apply the equivalent
+    ///      maintainer-only gate when it wires this entry point up.
     function submitReservationProof(
         BridgeState.Storage storage self,
         uint8 proofType,
@@ -151,8 +155,6 @@ library ReservationProofs {
                 requestNonce
             );
             // Milestone 1 accepts acceptance and re-anchor proofs.
-            // Redemption and dissolution stay rejected for the entirety
-            // of m1.
         } else {
             revert("Unsupported reservation proof type");
         }
@@ -177,10 +179,6 @@ library ReservationProofs {
             Reservation.actionKey(reservationKey, requestNonce)
         ];
         require(action.actionType == expectedType, "Action type mismatch");
-        require(
-            self.reservations[reservationKey].requestNonce == requestNonce,
-            "Not the current generation"
-        );
         require(
             action.state == Reservation.ActionState.Pending ||
                 action.state == Reservation.ActionState.TimedOut,
@@ -299,7 +297,7 @@ library ReservationProofs {
         self.walletReservationsAmount[
             reservation.walletPubKeyHash
         ] += reservation.anchorAmount;
-        self.reservationsByAnchorUtxo[anchorUtxoKey] = reservationKey;
+        self.activeReservationsCount += 1;
     }
 
     /// @notice Reverts unless the reservation still points at the exact
@@ -477,6 +475,13 @@ library ReservationProofs {
         bytes32 anchorTxHash,
         uint64 anchorAmount
     ) internal {
+        if (!late) {
+            require(
+                self.reservations[reservationKey].requestNonce == requestNonce,
+                "Not the current generation"
+            );
+        }
+
         action.state = Reservation.ActionState.Settled;
 
         bytes20 targetWalletPubKeyHash = action.targetWalletPubKeyHash;
@@ -554,7 +559,7 @@ library ReservationProofs {
         reservation.anchorTxHash = anchorTxHash;
         reservation.anchorTxOutputIndex = 0;
         reservation.state = Reservation.ReservationState.Active;
-// activeReservationsCount is incremented at reservation request time.
+        // activeReservationsCount is incremented at reservation request time.
         reservation.dissolutionEligibleAt = expiresAt + action.dissolutionDelay;
 
         self.reservationsByAnchorUtxo[
@@ -590,6 +595,15 @@ library ReservationProofs {
             reservationKey,
             false
         );
+        // If the target wallet retired on the on-time path, strand.
+        if (!late) {
+            strandIfTargetWalletClosed(
+                self,
+                reservation,
+                reservationKey,
+                action.targetWalletPubKeyHash
+            );
+        }
 
         // Credit the gross anchored amount through the vault the deposit was
         // revealed to, but only if that vault is still trusted: governance
@@ -759,17 +773,14 @@ library ReservationProofs {
 
         action.state = Reservation.ActionState.Settled;
 
-        self.reservationsByAnchorUtxo[
-            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
-        ] = reservationKey;
-
         // slither-disable-next-line reentrancy-events
         emit ReservationReanchored(
             reservationKey,
             requestNonce,
             newWalletPubKeyHash,
             reanchorTxHash,
-            newAnchorAmount
+            newAnchorAmount,
+            minerFee
         );
 
         strandLateSettlementIfTargetWalletClosed(

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -25,6 +25,7 @@ import "./Reservation.sol";
 import "./Wallets.sol";
 
 import "../bank/Bank.sol";
+import "../vault/IReservationFeeFinancer.sol";
 
 /// @title Bridge UTXO reservations — settlement
 /// @notice SPV settlement side of the two-phase reservation model (see
@@ -74,6 +75,14 @@ library ReservationProofs {
         uint32 expiresAt
     );
 
+    event ReservationReanchored(
+        uint256 indexed reservationKey,
+        uint64 requestNonce,
+        bytes20 indexed newWalletPubKeyHash,
+        bytes32 newAnchorTxHash,
+        uint64 newAnchorAmount
+    );
+
     event ReservationActionSuperseded(
         uint256 indexed reservationKey,
         uint64 requestNonce
@@ -106,9 +115,11 @@ library ReservationProofs {
     /// @param reservationKey The key of the target reservation.
     /// @param requestNonce The generation being settled. Late settlements
     ///        name an older, timed-out generation.
-    /// @dev Only `ProofType.Acceptance` is wired in milestone 1; the
-    ///      trailing `UTXO` argument is reserved for later proof types and
-    ///      is currently ignored.
+    /// @dev The `BitcoinTx.UTXO` parameter is retained in the signature
+    ///      without a name to keep the external selector stable for any
+    ///      milestone-1 callers that already deployed against it; only the
+    ///      acceptance and re-anchor branches are wired up, so the value
+    ///      is unused.
     function submitReservationProof(
         BridgeState.Storage storage self,
         uint8 proofType,
@@ -132,11 +143,17 @@ library ReservationProofs {
                 reservationKey,
                 requestNonce
             );
-            // Milestone 1 accepts only acceptance proofs. Redemption and
-            // dissolution stay rejected for the entirety of m1. The
-            // re-anchor branch lands with the re-anchor milestone PR as a
-            // new `else if` placed ahead of this `else`; it does not exist
-            // in this branch.
+        } else if (parsedProofType == ProofType.Reanchor) {
+            submitReservationReanchorProof(
+                self,
+                txInfo,
+                proof,
+                reservationKey,
+                requestNonce
+            );
+            // Milestone 1 accepts acceptance and re-anchor proofs.
+            // Redemption and dissolution stay rejected for the entirety
+            // of m1.
         } else {
             revert("Unsupported reservation proof type");
         }
@@ -203,6 +220,80 @@ library ReservationProofs {
             }
             self.strandReservation(reservation, reservationKey);
         }
+    }
+
+    /// @notice Validates the position can settle the loaded action and, for a
+    ///         timed-out generation whose position was already stranded,
+    ///         reconstructs the source anchor's tracking before settlement.
+    /// @dev Stranding releases the global and wallet accounting, enumeration,
+    ///      and reverse anchor index. A transaction confirmed before stranding
+    ///      must still settle, so the proof transaction atomically restores
+    ///      those surfaces before the ordinary settlement path consumes or
+    ///      moves them. Caps are request-time throttles and are deliberately
+    ///      not re-checked for an already-confirmed Bitcoin transaction.
+    function prepareReservationForSettlement(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        uint256 reservationKey,
+        bool late
+    ) internal {
+        bool stranded = reservation.state ==
+            Reservation.ReservationState.Stranded;
+        require(
+            reservation.state == Reservation.ReservationState.Active ||
+                reservation.state ==
+                Reservation.ReservationState.ActionPending ||
+                (stranded && late),
+            "Reservation is not settleable"
+        );
+
+        if (!stranded) {
+            return;
+        }
+
+        uint256 anchorUtxoKey = uint256(
+            keccak256(
+                abi.encodePacked(
+                    reservation.anchorTxHash,
+                    reservation.anchorTxOutputIndex
+                )
+            )
+        );
+        // Multiple timed-out generations can describe the same Bitcoin
+        // transaction. Once one proof consumes the anchor, do not let another
+        // generation reconstruct the position or finance the miner fee again.
+        require(
+            !self.spentMainUTXOs[anchorUtxoKey],
+            "Reservation anchor already spent"
+        );
+
+        self.reservationTotalAmount += reservation.anchorAmount;
+        self.walletReservationsCount[reservation.walletPubKeyHash] += 1;
+        self.walletReservationsAmount[
+            reservation.walletPubKeyHash
+        ] += reservation.anchorAmount;
+        Reservation.addWalletReservationKey(
+            self,
+            reservation.walletPubKeyHash,
+            reservationKey
+        );
+        self.reservationsByAnchorUtxo[anchorUtxoKey] = reservationKey;
+    }
+
+    /// @notice Reverts unless the reservation still points at the exact
+    ///         anchor outpoint this generation was authorized to spend.
+    ///         This prevents a timed-out generation from being replayed
+    ///         against a later anchor whose transaction merely has the old
+    ///         generation's output shape.
+    function requireCurrentSourceAnchor(
+        Reservation.ReservationRequest storage reservation,
+        Reservation.ReservationAction storage action
+    ) internal view {
+        require(
+            Reservation.anchorUtxoHash(reservation) ==
+                action.sourceAnchorUtxoHash,
+            "Action source anchor is no longer current"
+        );
     }
 
     /// @notice Used by the wallet to prove the BTC anchor transaction of an
@@ -500,6 +591,185 @@ library ReservationProofs {
         }
     }
 
+    /// @notice Used by the wallet to prove a re-anchor transaction moving a
+    ///         reservation's anchor outpoint to the authorized target
+    ///         wallet in a 1-input-1-output spend.
+    /// @dev Requirements:
+    ///      - The named generation must be a settleable re-anchor,
+    ///      - `reanchorTx` must spend the current anchor outpoint as its
+    ///        sole input and create a single P2(W)PKH output paying the
+    ///        generation's authorized target wallet,
+    ///      - The miner fee must respect the snapshotted bound and the
+    ///        re-anchored value must stay above the dust floor (the
+    ///        snapshotted fee bound), preserving positive redemption
+    ///        value.
+    function submitReservationReanchorProof(
+        BridgeState.Storage storage self,
+        BitcoinTx.Info calldata reanchorTx,
+        BitcoinTx.Proof calldata reanchorProof,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) internal {
+        (
+            Reservation.ReservationAction storage action,
+            bool late
+        ) = loadSettleableAction(
+                self,
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Reanchor
+            );
+
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        bool evidenceAlreadyEmitted = reservation.state ==
+            Reservation.ReservationState.Stranded;
+        prepareReservationForSettlement(
+            self,
+            reservation,
+            reservationKey,
+            late
+        );
+        if (!late) {
+            require(
+                reservation.requestNonce == requestNonce,
+                "Not the current generation"
+            );
+        }
+
+        requireCurrentSourceAnchor(reservation, action);
+
+        bytes32 reanchorTxHash = self.validateProof(reanchorTx, reanchorProof);
+
+        consumeAnchor(self, reservation, reanchorTx.inputVector);
+
+        bytes memory output = parseSingleOutput(reanchorTx.outputVector);
+        bytes20 newWalletPubKeyHash = self.extractPubKeyHash(output);
+        uint64 newAnchorAmount = output.extractValue();
+
+        require(
+            newWalletPubKeyHash == action.targetWalletPubKeyHash,
+            "Output must pay the authorized target wallet"
+        );
+
+        // `newAnchorAmount <= anchorAmount` is guaranteed by Bitcoin
+        // consensus (the re-anchor output cannot exceed its input).
+        require(
+            reservation.anchorAmount - newAnchorAmount <= action.txMaxFee,
+            "Transaction fee is too high"
+        );
+
+        // Dust floor: the re-anchored amount must stay strictly above the
+        // snapshotted per-transaction fee bound, keeping the anchor clear
+        // of dust and preserving positive redemption value.
+        require(
+            newAnchorAmount > action.txMaxFee,
+            "Re-anchor amount below the dust floor"
+        );
+
+        if (late) {
+            // The timeout released the target wallet's reserved count and
+            // amount; re-take them. Deliberately no cap check (see
+            // acceptance).
+            self.walletReservationsCount[newWalletPubKeyHash] += 1;
+            self.walletReservationsAmount[newWalletPubKeyHash] += reservation
+                .anchorAmount;
+
+            // A newer pending generation references an anchor this
+            // transaction just consumed; unwind it.
+            if (
+                reservation.state == Reservation.ReservationState.ActionPending
+            ) {
+                unwindPendingAction(self, reservation, reservationKey, true);
+            }
+
+            // slither-disable-next-line reentrancy-events
+            emit ReservationLateSettled(
+                reservationKey,
+                requestNonce,
+                Reservation.ActionType.Reanchor
+            );
+        }
+
+        // The source wallet's count and amount are released now; the
+        // target wallet's were reserved at request time (or re-taken
+        // above). The target reserved the pre-hop anchor value; release
+        // the miner-fee delta.
+        self.walletReservationsCount[reservation.walletPubKeyHash] -= 1;
+        self.walletReservationsAmount[
+            reservation.walletPubKeyHash
+        ] -= reservation.anchorAmount;
+        self.walletReservationsAmount[newWalletPubKeyHash] -= (reservation
+            .anchorAmount - newAnchorAmount);
+
+        uint64 minerFee = reservation.anchorAmount - newAnchorAmount;
+
+        // The miner fee reduces the on-chain earmarked amount.
+        self.reservationTotalAmount -= minerFee;
+
+        // Record the per-hop fee before the claim is written down below.
+        // Afterwards the original anchor value is unrecoverable and
+        // `ReservationReanchored` carries only the new anchor amount, so
+        // this total could not be reconstructed from later state. No
+        // ceiling is enforced in milestone 1: `maxCumulativeReanchorFee`
+        // stays declare-only until a post-milestone-1 bound lands.
+        reservation.cumulativeReanchorFee += minerFee;
+
+        Reservation.removeWalletReservationKey(
+            self,
+            reservation.walletPubKeyHash,
+            reservationKey
+        );
+        Reservation.addWalletReservationKey(
+            self,
+            newWalletPubKeyHash,
+            reservationKey
+        );
+
+        reservation.walletPubKeyHash = newWalletPubKeyHash;
+        reservation.anchorAmount = newAnchorAmount;
+        // The claim always equals the anchor: the miner fee is financed
+        // from the vault's custody-fee reserve (which burns supply in
+        // lockstep with the backing loss), and the claim is written down
+        // to the new anchor value. The owner's redemption surrender
+        // shrinks accordingly — rotation costs are borne by the custody
+        // fee that was priced for them, not by the owner and not by the
+        // peg.
+        reservation.mintedAmount = newAnchorAmount;
+        reservation.anchorTxHash = reanchorTxHash;
+        reservation.anchorTxOutputIndex = 0;
+        reservation.state = Reservation.ReservationState.Active;
+
+        if (minerFee > 0) {
+            IReservationFeeFinancer(self.deposits[reservationKey].vault)
+                .financeInKindFee(minerFee);
+        }
+
+        action.state = Reservation.ActionState.Settled;
+
+        self.reservationsByAnchorUtxo[
+            uint256(keccak256(abi.encodePacked(reanchorTxHash, uint32(0))))
+        ] = reservationKey;
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservationReanchored(
+            reservationKey,
+            requestNonce,
+            newWalletPubKeyHash,
+            reanchorTxHash,
+            newAnchorAmount
+        );
+
+        strandLateSettlementIfTargetWalletClosed(
+            self,
+            reservation,
+            reservationKey,
+            late,
+            evidenceAlreadyEmitted
+        );
+    }
+
     /// @notice Unwinds the position's current pending generation during a
     ///         late settlement of an older generation: the anchor the
     ///         pending generation was authorized to spend has provably been
@@ -593,5 +863,36 @@ library ReservationProofs {
         );
 
         output = outputVector.extractOutputAtIndex(0);
+    }
+
+    /// @notice Asserts the given input vector contains exactly one input
+    ///         pointing to the reservation's current anchor outpoint, marks
+    ///         that outpoint as correctly spent (making it recognized by the
+    ///         fraud challenge defeat path) and clears its anchor index
+    ///         entry.
+    function consumeAnchor(
+        BridgeState.Storage storage self,
+        Reservation.ReservationRequest storage reservation,
+        bytes memory inputVector
+    ) internal {
+        (bytes32 outpointTxHash, uint32 outpointIndex) = OutboundTx
+            .parseWalletOutboundTxInput(inputVector);
+
+        require(
+            reservation.anchorTxHash == outpointTxHash &&
+                reservation.anchorTxOutputIndex == outpointIndex,
+            "Transaction input must point to the reservation anchor"
+        );
+
+        uint256 anchorUtxoKey = uint256(
+            keccak256(abi.encodePacked(outpointTxHash, outpointIndex))
+        );
+
+        // Anchor outpoints are wallet-controlled UTXOs. Marking a consumed
+        // anchor in `spentMainUTXOs` -- the existing registry of honestly
+        // spent wallet UTXOs -- makes the spend recognized by
+        // `Fraud.defeatFraudChallenge` without modifying the fraud library.
+        self.spentMainUTXOs[anchorUtxoKey] = true;
+        delete self.reservationsByAnchorUtxo[anchorUtxoKey];
     }
 }

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -511,7 +511,7 @@ library ReservationProofs {
                         )
                     ];
                 if (newer.state == Reservation.ActionState.Pending) {
-                    unwindPendingAction(self, pending, reservationKey);
+                    unwindPendingAction(self, pending, reservationKey, false);
                 }
             }
 
@@ -719,7 +719,7 @@ library ReservationProofs {
             if (
                 reservation.state == Reservation.ReservationState.ActionPending
             ) {
-                unwindPendingAction(self, reservation, reservationKey);
+                unwindPendingAction(self, reservation, reservationKey, true);
             }
 
             // slither-disable-next-line reentrancy-events
@@ -785,7 +785,6 @@ library ReservationProofs {
             self,
             reservation,
             reservationKey,
-            late,
             evidenceAlreadyEmitted
         );
 
@@ -821,10 +820,16 @@ library ReservationProofs {
     ///         consumed, so the generation can never settle. Its reserved
     ///         capacity and locks are released and it is terminally marked
     ///         `Superseded`.
+    /// @param restoreRetryCredit True when the settlement superseding this
+    ///        generation is itself a late re-anchor (the only path that
+    ///        returns a consumed retry entitlement per the field's
+    ///        contract); false from the late-acceptance unwind path, which
+    ///        never restores the entitlement.
     function unwindPendingAction(
         BridgeState.Storage storage self,
         Reservation.ReservationRequest storage reservation,
-        uint256 reservationKey
+        uint256 reservationKey,
+        bool restoreRetryCredit
     ) internal {
         uint64 pendingNonce = reservation.requestNonce;
         Reservation.ReservationAction storage pendingAction = self

--- a/solidity/contracts/bridge/ReservationProofs.sol
+++ b/solidity/contracts/bridge/ReservationProofs.sol
@@ -259,7 +259,6 @@ library ReservationProofs {
     function prepareReservationForSettlement(
         BridgeState.Storage storage self,
         Reservation.ReservationRequest storage reservation,
-        uint256 reservationKey,
         bool late
     ) internal {
         bool stranded = reservation.state ==
@@ -508,7 +507,7 @@ library ReservationProofs {
                         )
                     ];
                 if (newer.state == Reservation.ActionState.Pending) {
-                    unwindPendingAction(self, pending, reservationKey, false);
+                    unwindPendingAction(self, pending, reservationKey);
                 }
             }
 
@@ -665,12 +664,7 @@ library ReservationProofs {
         ];
         bool evidenceAlreadyEmitted = reservation.state ==
             Reservation.ReservationState.Stranded;
-        prepareReservationForSettlement(
-            self,
-            reservation,
-            reservationKey,
-            late
-        );
+        prepareReservationForSettlement(self, reservation, late);
         if (!late) {
             require(
                 reservation.requestNonce == requestNonce,
@@ -721,7 +715,7 @@ library ReservationProofs {
             if (
                 reservation.state == Reservation.ReservationState.ActionPending
             ) {
-                unwindPendingAction(self, reservation, reservationKey, true);
+                unwindPendingAction(self, reservation, reservationKey);
             }
 
             // slither-disable-next-line reentrancy-events
@@ -820,17 +814,13 @@ library ReservationProofs {
     /// @notice Unwinds the position's current pending generation during a
     ///         late settlement of an older generation: the anchor the
     ///         pending generation was authorized to spend has provably been
-    ///         consumed, so the generation can never settle. Its escrow is
-    ///         refunded (redemptions), its reserved capacity and locks are
-    ///         released, and it is terminally marked `Superseded`. Retry
-    ///         credit restoration is enabled only by the late-reanchor call
-    ///         site, whose successful settlement leaves the reservation
-    ///         Active on a replacement anchor.
+    ///         consumed, so the generation can never settle. Its reserved
+    ///         capacity and locks are released and it is terminally marked
+    ///         `Superseded`.
     function unwindPendingAction(
         BridgeState.Storage storage self,
         Reservation.ReservationRequest storage reservation,
-        uint256 reservationKey,
-        bool restoreRetryCredit
+        uint256 reservationKey
     ) internal {
         uint64 pendingNonce = reservation.requestNonce;
         Reservation.ReservationAction storage pendingAction = self

--- a/solidity/contracts/test/TestReservation.sol
+++ b/solidity/contracts/test/TestReservation.sol
@@ -176,13 +176,6 @@ contract TestReservation {
         });
     }
 
-    function setDeposit(
-        uint256 reservationKey,
-        Deposit.DepositRequest calldata deposit
-    ) external {
-        state.deposits[reservationKey] = deposit;
-    }
-
     function setSweptAt(uint256 reservationKey, uint32 sweptAt) external {
         state.deposits[reservationKey].sweptAt = sweptAt;
     }
@@ -494,7 +487,6 @@ contract TestReservation {
 
     function strandLateSettlementIfTargetWalletClosed(
         uint256 reservationKey,
-        bool late,
         bool evidenceAlreadyEmitted
     ) external {
         Reservation.ReservationRequest storage reservation = state
@@ -503,7 +495,6 @@ contract TestReservation {
             state,
             reservation,
             reservationKey,
-            late,
             evidenceAlreadyEmitted
         );
     }
@@ -563,7 +554,7 @@ contract TestReservation {
         state.maxReservationsPerWallet = maxReservationsPerWallet;
     }
 
-    function setPendingReservedDeposit(
+    function seedPendingReservedDeposit(
         uint256 depositKey,
         bool isReserved,
         bytes20 walletPubKeyHash,
@@ -580,10 +571,12 @@ contract TestReservation {
 
     function setDeposit(
         uint256 depositKey,
+        address depositor,
         uint64 amount,
         uint32 revealedAt,
         address vault
     ) external {
+        state.deposits[depositKey].depositor = depositor;
         state.deposits[depositKey].amount = amount;
         state.deposits[depositKey].revealedAt = revealedAt;
         state.deposits[depositKey].vault = vault;

--- a/solidity/contracts/test/TestReservation.sol
+++ b/solidity/contracts/test/TestReservation.sol
@@ -442,4 +442,214 @@ contract TestReservation {
                 action
             );
     }
+
+    function setActionSourceAnchorUtxoHash(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        bytes32 sourceAnchorUtxoHash
+    ) external {
+        Reservation.ReservationAction storage action = state
+            .reservationActions[
+                Reservation.actionKey(reservationKey, requestNonce)
+            ];
+        action.sourceAnchorUtxoHash = sourceAnchorUtxoHash;
+    }
+
+    function requireCurrentSourceAnchor(
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external view {
+        Reservation.ReservationRequest storage reservation = state
+            .reservations[reservationKey];
+        Reservation.ReservationAction storage action = state
+            .reservationActions[
+                Reservation.actionKey(reservationKey, requestNonce)
+            ];
+        ReservationProofs.requireCurrentSourceAnchor(reservation, action);
+    }
+
+    function setReservationFullState(
+        uint256 reservationKey,
+        address owner,
+        bytes20 walletPubKeyHash,
+        uint64 anchorAmount,
+        Reservation.ReservationState newState,
+        uint64 requestNonce
+    ) external {
+        Reservation.ReservationRequest storage reservation = state
+            .reservations[reservationKey];
+        reservation.owner = owner;
+        reservation.walletPubKeyHash = walletPubKeyHash;
+        reservation.anchorAmount = anchorAmount;
+        reservation.state = newState;
+        reservation.requestNonce = requestNonce;
+    }
+
+    function setWalletState(
+        bytes20 walletPubKeyHash,
+        Wallets.WalletState newState
+    ) external {
+        state.registeredWallets[walletPubKeyHash].state = newState;
+    }
+
+    function strandLateSettlementIfTargetWalletClosed(
+        uint256 reservationKey,
+        bool late,
+        bool evidenceAlreadyEmitted
+    ) external {
+        Reservation.ReservationRequest storage reservation = state
+            .reservations[reservationKey];
+        ReservationProofs.strandLateSettlementIfTargetWalletClosed(
+            state,
+            reservation,
+            reservationKey,
+            late,
+            evidenceAlreadyEmitted
+        );
+    }
+
+    function strandIfTargetWalletClosed(
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash
+    ) external {
+        Reservation.ReservationRequest storage reservation = state
+            .reservations[reservationKey];
+        ReservationProofs.strandIfTargetWalletClosed(
+            state,
+            reservation,
+            reservationKey,
+            targetWalletPubKeyHash
+        );
+    }
+
+    function prepareReservationForSettlement(uint256 reservationKey, bool late)
+        external
+    {
+        Reservation.ReservationRequest storage reservation = state
+            .reservations[reservationKey];
+        ReservationProofs.prepareReservationForSettlement(
+            state,
+            reservation,
+            late
+        );
+    }
+
+    function setWalletReservationsCounters(
+        bytes20 walletPubKeyHash,
+        uint32 count,
+        uint64 amount
+    ) external {
+        state.walletReservationsCount[walletPubKeyHash] = count;
+        state.walletReservationsAmount[walletPubKeyHash] = amount;
+    }
+
+    function setGlobalReservationCounters(
+        uint64 totalAmount,
+        uint32 activeCount
+    ) external {
+        state.reservationTotalAmount = totalAmount;
+        state.activeReservationsCount = activeCount;
+    }
+
+    function setGovernanceParameters(
+        uint64 minAmount,
+        uint64 txMaxFee,
+        uint32 actionTimeout,
+        uint32 maxReservationsPerWallet
+    ) external {
+        state.reservationMinAmount = minAmount;
+        state.reservationTxMaxFee = txMaxFee;
+        state.reservationActionTimeout = actionTimeout;
+        state.maxReservationsPerWallet = maxReservationsPerWallet;
+    }
+
+    function setPendingReservedDeposit(
+        uint256 depositKey,
+        bool isReserved,
+        bytes20 walletPubKeyHash,
+        uint32 refundDeadline
+    ) external {
+        state.pendingReservedDeposit[depositKey] = BridgeState
+            .PendingReservedDeposit(
+                isReserved,
+                walletPubKeyHash,
+                refundDeadline,
+                true
+            );
+    }
+
+    function setDeposit(
+        uint256 depositKey,
+        uint64 amount,
+        uint32 revealedAt,
+        address vault
+    ) external {
+        state.deposits[depositKey].amount = amount;
+        state.deposits[depositKey].revealedAt = revealedAt;
+        state.deposits[depositKey].vault = vault;
+    }
+
+    function reservationState(uint256 reservationKey)
+        external
+        view
+        returns (Reservation.ReservationState)
+    {
+        return state.reservations[reservationKey].state;
+    }
+
+    function setFullAction(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType,
+        Reservation.ActionState newActionState,
+        uint32 timeoutAt,
+        bytes20 targetWalletPubKeyHash,
+        uint64 amount
+    ) external {
+        Reservation.ReservationAction storage action = state
+            .reservationActions[
+                Reservation.actionKey(reservationKey, requestNonce)
+            ];
+        action.actionType = actionType;
+        action.state = newActionState;
+        action.timeoutAt = timeoutAt;
+        action.targetWalletPubKeyHash = targetWalletPubKeyHash;
+        action.amount = amount;
+    }
+
+    function actionState(uint256 reservationKey, uint64 requestNonce)
+        external
+        view
+        returns (Reservation.ActionState)
+    {
+        return
+            state
+                .reservationActions[
+                    Reservation.actionKey(reservationKey, requestNonce)
+                ]
+                .state;
+    }
+
+    function loadSettleableAction(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType expectedType
+    ) external view returns (bool late) {
+        (, late) = ReservationProofs.loadSettleableAction(
+            state,
+            reservationKey,
+            requestNonce,
+            expectedType
+        );
+    }
+
+    function notifyReservationActionTimeout(uint256 reservationKey) external {
+        Reservation.notifyReservationActionTimeout(state, reservationKey);
+    }
+
+    function notifyReservationAcceptanceTimedOut(uint256 reservationKey)
+        external
+    {
+        Reservation.notifyReservationAcceptanceTimedOut(state, reservationKey);
+    }
 }

--- a/solidity/contracts/test/TestReservation.sol
+++ b/solidity/contracts/test/TestReservation.sol
@@ -4,12 +4,16 @@ pragma solidity 0.8.17;
 import "../bridge/BridgeState.sol";
 import "../bridge/Deposit.sol";
 import "../bridge/Reservation.sol";
+import "../bridge/ReservationProofs.sol";
 import "../bridge/Wallets.sol";
 import "../bridge/WalletProposalValidatorConstants.sol";
 import "../bridge/BitcoinTx.sol";
 
 /// @title TestReservation
-/// @notice Test harness for the Reservation library control-plane logic.
+/// @notice Test harness for the Reservation and ReservationProofs library
+///         functions, exercised directly without pulling in the full
+///         Bridge contract (and the external library linking that
+///         requires).
 /// @dev Stubs the reveal-side producer contract that milestone-2 reveal flow must implement:
 ///      1. When a deposit is revealed with `vault == reservationVault`, the producer records:
 ///         - `pendingReservedDeposit[key] = PendingReservedDeposit({ isReserved: true, walletPubKeyHash, refundDeadline, refundDeadlineValidated })`
@@ -233,6 +237,17 @@ contract TestReservation {
         state.reservationsByAnchorUtxo[utxoKey] = reservationKey;
     }
 
+    function setReservationAnchor(
+        uint256 reservationKey,
+        bytes32 anchorTxHash,
+        uint32 anchorTxOutputIndex
+    ) external {
+        state.reservations[reservationKey].anchorTxHash = anchorTxHash;
+        state.reservations[reservationKey].anchorTxOutputIndex = (
+            anchorTxOutputIndex
+        );
+    }
+
     function setAction(
         uint256 reservationKey,
         uint64 requestNonce,
@@ -379,5 +394,52 @@ contract TestReservation {
         returns (Wallets.Wallet memory)
     {
         return state.registeredWallets[walletPubKeyHash];
+    }
+
+    function actionKey(uint256 reservationKey, uint64 requestNonce)
+        external
+        pure
+        returns (uint256)
+    {
+        return Reservation.actionKey(reservationKey, requestNonce);
+    }
+
+    function anchorUtxoHash(uint256 reservationKey)
+        external
+        view
+        returns (bytes32)
+    {
+        return Reservation.anchorUtxoHash(state.reservations[reservationKey]);
+    }
+
+    function parseSingleOutput(bytes memory outputVector)
+        external
+        pure
+        returns (bytes memory)
+    {
+        return ReservationProofs.parseSingleOutput(outputVector);
+    }
+
+    function validateAnchorOutput(
+        bytes memory outputVector,
+        bytes20 targetWalletPubKeyHash,
+        uint64 amount,
+        uint64 txMaxFee
+    ) external returns (uint64 anchorAmount) {
+        // A throwaway action record keyed by a fixed slot: each call sets
+        // it fresh, so tests never see stale state from a prior call.
+        Reservation.ReservationAction storage action = state.reservationActions[
+            0
+        ];
+        action.targetWalletPubKeyHash = targetWalletPubKeyHash;
+        action.amount = amount;
+        action.txMaxFee = txMaxFee;
+
+        return
+            ReservationProofs.validateAnchorOutput(
+                state,
+                outputVector,
+                action
+            );
     }
 }

--- a/solidity/contracts/test/TestReservation.sol
+++ b/solidity/contracts/test/TestReservation.sol
@@ -652,4 +652,18 @@ contract TestReservation {
     {
         Reservation.notifyReservationAcceptanceTimedOut(state, reservationKey);
     }
+
+    function setSpentMainUtxo(uint256 reservationKey, bool spent) external {
+        Reservation.ReservationRequest storage reservation = state
+            .reservations[reservationKey];
+        uint256 anchorUtxoKey = uint256(
+            keccak256(
+                abi.encodePacked(
+                    reservation.anchorTxHash,
+                    reservation.anchorTxOutputIndex
+                )
+            )
+        );
+        state.spentMainUTXOs[anchorUtxoKey] = spent;
+    }
 }

--- a/solidity/contracts/test/TestReservation.sol
+++ b/solidity/contracts/test/TestReservation.sol
@@ -429,11 +429,7 @@ contract TestReservation {
         action.txMaxFee = txMaxFee;
 
         return
-            ReservationProofs.validateAnchorOutput(
-                state,
-                outputVector,
-                action
-            );
+            ReservationProofs.validateAnchorOutput(state, outputVector, action);
     }
 
     function setActionSourceAnchorUtxoHash(
@@ -441,10 +437,9 @@ contract TestReservation {
         uint64 requestNonce,
         bytes32 sourceAnchorUtxoHash
     ) external {
-        Reservation.ReservationAction storage action = state
-            .reservationActions[
-                Reservation.actionKey(reservationKey, requestNonce)
-            ];
+        Reservation.ReservationAction storage action = state.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
         action.sourceAnchorUtxoHash = sourceAnchorUtxoHash;
     }
 
@@ -452,12 +447,12 @@ contract TestReservation {
         uint256 reservationKey,
         uint64 requestNonce
     ) external view {
-        Reservation.ReservationRequest storage reservation = state
-            .reservations[reservationKey];
-        Reservation.ReservationAction storage action = state
-            .reservationActions[
-                Reservation.actionKey(reservationKey, requestNonce)
-            ];
+        Reservation.ReservationRequest storage reservation = state.reservations[
+            reservationKey
+        ];
+        Reservation.ReservationAction storage action = state.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
         ReservationProofs.requireCurrentSourceAnchor(reservation, action);
     }
 
@@ -469,8 +464,9 @@ contract TestReservation {
         Reservation.ReservationState newState,
         uint64 requestNonce
     ) external {
-        Reservation.ReservationRequest storage reservation = state
-            .reservations[reservationKey];
+        Reservation.ReservationRequest storage reservation = state.reservations[
+            reservationKey
+        ];
         reservation.owner = owner;
         reservation.walletPubKeyHash = walletPubKeyHash;
         reservation.anchorAmount = anchorAmount;
@@ -489,8 +485,9 @@ contract TestReservation {
         uint256 reservationKey,
         bool evidenceAlreadyEmitted
     ) external {
-        Reservation.ReservationRequest storage reservation = state
-            .reservations[reservationKey];
+        Reservation.ReservationRequest storage reservation = state.reservations[
+            reservationKey
+        ];
         ReservationProofs.strandLateSettlementIfTargetWalletClosed(
             state,
             reservation,
@@ -503,8 +500,9 @@ contract TestReservation {
         uint256 reservationKey,
         bytes20 targetWalletPubKeyHash
     ) external {
-        Reservation.ReservationRequest storage reservation = state
-            .reservations[reservationKey];
+        Reservation.ReservationRequest storage reservation = state.reservations[
+            reservationKey
+        ];
         ReservationProofs.strandIfTargetWalletClosed(
             state,
             reservation,
@@ -516,8 +514,9 @@ contract TestReservation {
     function prepareReservationForSettlement(uint256 reservationKey, bool late)
         external
     {
-        Reservation.ReservationRequest storage reservation = state
-            .reservations[reservationKey];
+        Reservation.ReservationRequest storage reservation = state.reservations[
+            reservationKey
+        ];
         ReservationProofs.prepareReservationForSettlement(
             state,
             reservation,
@@ -599,10 +598,9 @@ contract TestReservation {
         bytes20 targetWalletPubKeyHash,
         uint64 amount
     ) external {
-        Reservation.ReservationAction storage action = state
-            .reservationActions[
-                Reservation.actionKey(reservationKey, requestNonce)
-            ];
+        Reservation.ReservationAction storage action = state.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
         action.actionType = actionType;
         action.state = newActionState;
         action.timeoutAt = timeoutAt;
@@ -647,8 +645,9 @@ contract TestReservation {
     }
 
     function setSpentMainUtxo(uint256 reservationKey, bool spent) external {
-        Reservation.ReservationRequest storage reservation = state
-            .reservations[reservationKey];
+        Reservation.ReservationRequest storage reservation = state.reservations[
+            reservationKey
+        ];
         uint256 anchorUtxoKey = uint256(
             keccak256(
                 abi.encodePacked(

--- a/solidity/contracts/vault/IReservationFeeFinancer.sol
+++ b/solidity/contracts/vault/IReservationFeeFinancer.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.17;
+
+/// @notice Interface of the reservation vault's in-kind fee financing hook.
+///         The Bridge calls it when a reservation settlement pays a Bitcoin
+///         miner fee that no party surrenders TBTC for (re-anchor and
+///         dissolution transactions): the vault burns supply equal to the
+///         fee from its custody-fee reserve so total TBTC supply shrinks in
+///         lockstep with the Bitcoin backing.
+interface IReservationFeeFinancer {
+    /// @notice Finances an in-kind Bitcoin miner fee: burns TBTC equal to
+    ///         `feeSat` from the vault's fee reserve and the corresponding
+    ///         Bank balance. If the reserve cannot cover the full amount,
+    ///         the shortfall is recorded as public debt and the call still
+    ///         succeeds — a confirmed Bitcoin spend must never fail to
+    ///         settle because of the reserve level.
+    /// @param feeSat The in-kind fee in satoshi.
+    function financeInKindFee(uint64 feeSat) external;
+}

--- a/solidity/contracts/vault/IReservationFeeFinancer.sol
+++ b/solidity/contracts/vault/IReservationFeeFinancer.sol
@@ -22,16 +22,17 @@ pragma solidity 0.8.17;
 ///         fee from its custody-fee reserve so total TBTC supply shrinks in
 ///         lockstep with the Bitcoin backing.
 interface IReservationFeeFinancer {
-    /// @dev NOTE: This interface has no in-repo implementation. The implementing
-    ///      PR must not merge with a signature or semantic divergence from what
-    ///      is documented here, and should add a conformance test asserting the
-    ///      implementation satisfies each documented clause.
     /// @notice Finances an in-kind Bitcoin miner fee: burns TBTC equal to
     ///         `feeSat` from the vault's fee reserve and the corresponding
     ///         Bank balance. If the reserve cannot cover the full amount,
     ///         the shortfall is recorded as public debt and the call still
     ///         succeeds — a confirmed Bitcoin spend must never fail to
-    ///         settle because of the reserve level.
+    ///         settle because of the reserve level. This function has no
+    ///         return value and the legitimate partial-burn case makes a
+    ///         balance-delta check unreliable, so callers cannot fully
+    ///         verify the burn from this call alone; a non-conforming vault
+    ///         must be caught before it is wired up (governance-gated
+    ///         `reservationVault`/`isVaultTrusted`), not at call time.
     /// @param feeSat The in-kind fee in satoshi.
     function financeInKindFee(uint64 feeSat) external;
 }

--- a/solidity/contracts/vault/IReservationFeeFinancer.sol
+++ b/solidity/contracts/vault/IReservationFeeFinancer.sol
@@ -22,6 +22,10 @@ pragma solidity 0.8.17;
 ///         fee from its custody-fee reserve so total TBTC supply shrinks in
 ///         lockstep with the Bitcoin backing.
 interface IReservationFeeFinancer {
+    /// @dev NOTE: This interface has no in-repo implementation. The implementing
+    ///      PR must not merge with a signature or semantic divergence from what
+    ///      is documented here, and should add a conformance test asserting the
+    ///      implementation satisfies each documented clause.
     /// @notice Finances an in-kind Bitcoin miner fee: burns TBTC equal to
     ///         `feeSat` from the vault's fee reserve and the corresponding
     ///         Bank balance. If the reserve cannot cover the full amount,

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -36,6 +36,7 @@ const ecdsaSolidityCompilerConfig = {
       enabled: true,
       runs: 200,
     },
+    outputSelection: storageLayoutOutputSelection,
   },
 }
 
@@ -92,6 +93,7 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 1, // Minimal runs to minimize bytecode size
           },
+          outputSelection: storageLayoutOutputSelection,
         },
       },
     },

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -56,6 +56,17 @@ async function getBridgeStorageLayout(): Promise<StorageLayout> {
   return layout
 }
 
+function getMissingMemberTypes(layout: StorageLayout): string[] {
+  return Object.values(layout.types)
+    .filter(
+      (type) =>
+        type.members === undefined &&
+        (type.label.startsWith("enum ") || type.label.startsWith("struct "))
+    )
+    .map((type) => type.label)
+    .sort()
+}
+
 function bridgeStateEntry(layout: StorageLayout): StorageEntry {
   const bridgeState = layout.storage.find((entry) => entry.label === "self")
   if (!bridgeState) {
@@ -109,7 +120,7 @@ describe("Bridge storage layout", () => {
       bridgeTIP109HotfixDeployment.storageLayout as unknown as StorageLayout
     const updatedRawLayout = await getBridgeStorageLayout()
 
-    // `self`'s absolute position must not move: bridgeStateLayout() below
+// `self`'s absolute position must not move: bridgeStateLayout() below
     // only ever compares the flattened member list, never self's own
     // slot/offset, so a future base-contract change that shifts BridgeState
     // off its deployed slot would otherwise pass every packing assertion
@@ -121,6 +132,26 @@ describe("Bridge storage layout", () => {
 
     const deployedLayout = bridgeStateLayout(deployedRawLayout)
     const updatedLayout = bridgeStateLayout(updatedRawLayout)
+
+    const expectedDeployedMissingMembers = [
+      "enum MovingFunds.MovedFundsSweepRequestState",
+      "enum Wallets.WalletState",
+    ].sort()
+
+    const expectedUpdatedMissingMembers = [
+      "enum MovingFunds.MovedFundsSweepRequestState",
+      "enum Reservation.ActionState",
+      "enum Reservation.ActionType",
+      "enum Reservation.ReservationState",
+      "enum Wallets.WalletState",
+    ].sort()
+
+    expect(getMissingMemberTypes(deployedLayout)).to.deep.equal(
+      expectedDeployedMissingMembers
+    )
+    expect(getMissingMemberTypes(updatedLayout)).to.deep.equal(
+      expectedUpdatedMissingMembers
+    )
 
     // The deployment artifact predates the current source only in date, not
     // in enum-member support: under this project's pinned solc 0.8.17,

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -120,7 +120,7 @@ describe("Bridge storage layout", () => {
       bridgeTIP109HotfixDeployment.storageLayout as unknown as StorageLayout
     const updatedRawLayout = await getBridgeStorageLayout()
 
-// `self`'s absolute position must not move: bridgeStateLayout() below
+    // `self`'s absolute position must not move: bridgeStateLayout() below
     // only ever compares the flattened member list, never self's own
     // slot/offset, so a future base-contract change that shifts BridgeState
     // off its deployed slot would otherwise pass every packing assertion

--- a/solidity/test/bridge/Reservation.test.ts
+++ b/solidity/test/bridge/Reservation.test.ts
@@ -1111,4 +1111,141 @@ describe("Reservation", () => {
       ).to.equal(0)
     })
   })
+
+  describe("actionKey", () => {
+    it("should produce correct action keys", async () => {
+      const reservationKey = 1
+      const requestNonce = 2
+      const expectedKey = ethers.utils.solidityKeccak256(
+        ["uint256", "uint64"],
+        [reservationKey, requestNonce]
+      )
+      expect(
+        await testReservation.actionKey(reservationKey, requestNonce)
+      ).to.equal(expectedKey)
+    })
+
+    it("should be sensitive to argument order", async () => {
+      const key1 = await testReservation.actionKey(1, 2)
+      const key2 = await testReservation.actionKey(2, 1)
+      expect(key1).to.not.equal(key2)
+    })
+  })
+
+  describe("anchorUtxoHash", () => {
+    it("should produce correct hash and react to input changes", async () => {
+      const reservationKey = 123
+      const anchorTxHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+      const anchorTxOutputIndex = 0
+      await testReservation.setReservationAnchor(
+        reservationKey,
+        anchorTxHash,
+        anchorTxOutputIndex
+      )
+
+      const expectedHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTxHash, anchorTxOutputIndex]
+      )
+      expect(await testReservation.anchorUtxoHash(reservationKey)).to.equal(
+        expectedHash
+      )
+
+      // Changing the anchor tx hash must change the resulting hash.
+      const newAnchorTxHash = ethers.utils.hexlify(ethers.utils.randomBytes(32))
+      await testReservation.setReservationAnchor(
+        reservationKey,
+        newAnchorTxHash,
+        anchorTxOutputIndex
+      )
+      expect(await testReservation.anchorUtxoHash(reservationKey)).to.not.equal(
+        expectedHash
+      )
+
+      // Changing only the output index (same tx hash) must also change it.
+      const newOutputIndex = 1
+      await testReservation.setReservationAnchor(
+        reservationKey,
+        newAnchorTxHash,
+        newOutputIndex
+      )
+      const expectedHashNewIndex = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [newAnchorTxHash, newOutputIndex]
+      )
+      expect(await testReservation.anchorUtxoHash(reservationKey)).to.equal(
+        expectedHashNewIndex
+      )
+    })
+  })
+
+  // A single well-formed P2WPKH (witness v0, 20-byte program) output:
+  // varint(count=1) | value (8-byte LE, 99500 sat) | scriptLen (0x16=22) |
+  // 0x0014 (OP_0 PUSH20) | 20-byte pubkey hash.
+  const anchorPubKeyHash = "0xaf802a76c10b6a646fff8d358241c121c9be1c53"
+  const singleOutputBody =
+    "ac84010000000000160014af802a76c10b6a646fff8d358241c121c9be1c53"
+  const singleOutput = `0x01${singleOutputBody}`
+  // The same output repeated twice, with a matching count=2 prefix.
+  const multiOutput = `0x02${singleOutputBody}${singleOutputBody}`
+
+  describe("parseSingleOutput", () => {
+    it("should parse a single-output vector successfully", async () => {
+      const output = await testReservation.parseSingleOutput(singleOutput)
+      // The parsed output is the value+script slice with the leading
+      // varint count byte stripped off.
+      expect(output).to.equal(`0x${singleOutputBody}`)
+    })
+
+    it("should revert for a multi-output vector", async () => {
+      await expect(
+        testReservation.parseSingleOutput(multiOutput)
+      ).to.be.revertedWith("Reservation transaction must have a single output")
+    })
+  })
+
+  describe("validateAnchorOutput", () => {
+    // The single output above carries 99500 satoshi.
+    const anchorAmount = 99500
+    const amount = 100000
+    const txMaxFee = 1000
+
+    it("should validate a correct anchor output and return its amount", async () => {
+      expect(
+        await testReservation.callStatic.validateAnchorOutput(
+          singleOutput,
+          anchorPubKeyHash,
+          amount,
+          txMaxFee
+        )
+      ).to.equal(anchorAmount)
+    })
+
+    it("should revert when the output pays the wrong wallet", async () => {
+      const wrongPubKeyHash = `0x${"11".repeat(20)}`
+      await expect(
+        testReservation.validateAnchorOutput(
+          singleOutput,
+          wrongPubKeyHash,
+          amount,
+          txMaxFee
+        )
+      ).to.be.revertedWith("Anchor output must pay the authorized wallet")
+    })
+
+    it("should revert when the fee exceeds the snapshotted bound", async () => {
+      // amount(100000) - anchorAmount(99500) = 500 <= 1000 normally passes;
+      // raise the requested amount so the implied fee (200000 -> 99500,
+      // difference 100500) blows past the 1000 satoshi bound.
+      const tooHighAmount = 200000
+      await expect(
+        testReservation.validateAnchorOutput(
+          singleOutput,
+          anchorPubKeyHash,
+          tooHighAmount,
+          txMaxFee
+        )
+      ).to.be.revertedWith("Transaction fee is too high")
+    })
+  })
 })

--- a/solidity/test/bridge/Reservation.test.ts
+++ b/solidity/test/bridge/Reservation.test.ts
@@ -732,7 +732,7 @@ describe("Reservation", () => {
         expect(await testReservation.activeReservationsCount()).to.equal(2)
       })
 
-      it("should revert when activeReservationsCount reaches maxActiveReservations (Max active reservations reached)", async () => {
+      it("should revert when activeReservationsCount reaches maxActiveReservations (Active reservations cap exceeded)", async () => {
         await setupValidDeposit(reservationKey1, walletPubKeyHash)
         await testReservation.setMaxActiveReservations(1)
 
@@ -763,7 +763,7 @@ describe("Reservation", () => {
           testReservation
             .connect(depositor)
             .requestReservationAcceptance(reservationKey2, walletPubKeyHash)
-        ).to.be.revertedWith("Max active reservations reached")
+        ).to.be.revertedWith("Active reservations cap exceeded")
       })
 
       it("should allow a new request after strandReservation decrements activeReservationsCount", async () => {
@@ -1391,34 +1391,7 @@ describe("Reservation", () => {
       expect(await testReservation.reservationState(strandKey)).to.equal(4)
     })
 
-    it("should be a no-op when the settlement is not late", async () => {
-      const key = 102
-      await testReservation.setWalletState(walletPubKeyHash, 3) // 3 = Closing
-      await testReservation.setReservationFullState(
-        key,
-        owner,
-        walletPubKeyHash,
-        anchorAmount,
-        1, // Active
-        requestNonce
-      )
-      await testReservation.setWalletReservationsCounters(
-        walletPubKeyHash,
-        1,
-        anchorAmount
-      )
-      await testReservation.strandLateSettlementIfTargetWalletClosed(
-        key,
-        false, // late
-        false // evidenceAlreadyEmitted
-      )
-      expect(await testReservation.reservationState(key)).to.equal(1) // still Active
-      expect(
-        await testReservation.walletReservationsCount(walletPubKeyHash)
-      ).to.equal(1)
-    })
-
-    it("should not strand a late settlement whose target wallet is still Live", async () => {
+    it("should not strand when the target wallet is still Live", async () => {
       const key = 103
       await testReservation.setWalletState(walletPubKeyHash, 1) // 1 = Live
       await testReservation.setReservationFullState(
@@ -1431,13 +1404,12 @@ describe("Reservation", () => {
       )
       await testReservation.strandLateSettlementIfTargetWalletClosed(
         key,
-        true, // late
         false // evidenceAlreadyEmitted
       )
       expect(await testReservation.reservationState(key)).to.equal(1) // still Active
     })
 
-    it("should strand a late settlement whose target wallet is Closing", async () => {
+    it("should strand a settlement whose target wallet is Closing", async () => {
       const key = 104
       await testReservation.setWalletState(walletPubKeyHash, 3) // 3 = Closing
       await testReservation.setReservationFullState(
@@ -1456,7 +1428,6 @@ describe("Reservation", () => {
       await testReservation.setGlobalReservationCounters(anchorAmount, 1)
       await testReservation.strandLateSettlementIfTargetWalletClosed(
         key,
-        true, // late
         false // evidenceAlreadyEmitted
       )
       expect(await testReservation.reservationState(key)).to.equal(4) // Stranded
@@ -1465,7 +1436,7 @@ describe("Reservation", () => {
       ).to.equal(0)
     })
 
-    it("should defer a late Terminated settlement to the permissionless cleanup path when not already stranded", async () => {
+    it("should strand a settlement whose target wallet is Terminated", async () => {
       const key = 105
       await testReservation.setWalletState(walletPubKeyHash, 5) // 5 = Terminated
       await testReservation.setReservationFullState(
@@ -1476,16 +1447,23 @@ describe("Reservation", () => {
         1, // Active
         requestNonce
       )
+      await testReservation.setWalletReservationsCounters(
+        walletPubKeyHash,
+        1,
+        anchorAmount
+      )
+      await testReservation.setGlobalReservationCounters(anchorAmount, 1)
       await testReservation.strandLateSettlementIfTargetWalletClosed(
         key,
-        true, // late
         false // evidenceAlreadyEmitted
       )
-      // Left Active: notifyReservationStranded is the intended cleanup path.
-      expect(await testReservation.reservationState(key)).to.equal(1)
+      expect(await testReservation.reservationState(key)).to.equal(4) // Stranded
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(0)
     })
 
-    it("should strand a late Terminated settlement without double-releasing when evidence was already emitted", async () => {
+    it("should strand a Terminated settlement without double-releasing when evidence was already emitted", async () => {
       const key = 106
       await testReservation.setWalletState(walletPubKeyHash, 5) // 5 = Terminated
       await testReservation.setReservationFullState(
@@ -1499,7 +1477,6 @@ describe("Reservation", () => {
       )
       await testReservation.strandLateSettlementIfTargetWalletClosed(
         key,
-        true, // late
         true // evidenceAlreadyEmitted
       )
       expect(await testReservation.reservationState(key)).to.equal(4) // Stranded
@@ -1660,7 +1637,7 @@ describe("Reservation", () => {
     })
   })
 
-  describe("notifyReservationActionTimeout", () => {
+  describe("notifyReservationAcceptanceTimedOut", () => {
     it("should time out a pending acceptance and release its capacity", async () => {
       const reservationKey = 400
       const targetWalletPubKeyHash = `0x${"11".repeat(20)}`
@@ -1684,7 +1661,7 @@ describe("Reservation", () => {
       )
       await testReservation.setGlobalReservationCounters(amount, 1)
 
-      await testReservation.notifyReservationActionTimeout(reservationKey)
+      await testReservation.notifyReservationAcceptanceTimedOut(reservationKey)
 
       expect(await testReservation.actionState(reservationKey, 0)).to.equal(3) // TimedOut
       expect(
@@ -1716,11 +1693,12 @@ describe("Reservation", () => {
       await testReservation.setWalletState(walletPubKeyHash, 1) // 1 = Live
       await testReservation.setDeposit(
         reservationKey,
+        depositor.address,
         1000,
         now - 3 * 60 * 60,
         vault
       )
-      await testReservation.setPendingReservedDeposit(
+      await testReservation.seedPendingReservedDeposit(
         reservationKey,
         true,
         walletPubKeyHash,
@@ -1728,10 +1706,9 @@ describe("Reservation", () => {
       )
 
       // Call
-      await testReservation.requestReservationAcceptance(
-        reservationKey,
-        walletPubKeyHash
-      )
+      await testReservation
+        .connect(depositor)
+        .requestReservationAcceptance(reservationKey, walletPubKeyHash)
 
       // Assert
       expect(

--- a/solidity/test/bridge/Reservation.test.ts
+++ b/solidity/test/bridge/Reservation.test.ts
@@ -1247,5 +1247,500 @@ describe("Reservation", () => {
         )
       ).to.be.revertedWith("Transaction fee is too high")
     })
+    it("should succeed at the fee-bound boundary (amount - anchorAmount == txMaxFee)", async () => {
+      const boundaryAmount = anchorAmount + txMaxFee
+      expect(
+        await testReservation.callStatic.validateAnchorOutput(
+          singleOutput,
+          anchorPubKeyHash,
+          boundaryAmount,
+          txMaxFee
+        )
+      ).to.equal(anchorAmount)
+    })
+
+    it("should revert on underflow when amount < anchorAmount", async () => {
+      const underflowAmount = anchorAmount - 1
+      await expect(
+        testReservation.validateAnchorOutput(
+          singleOutput,
+          anchorPubKeyHash,
+          underflowAmount,
+          txMaxFee
+        )
+      ).to.be.reverted
+    })
+  })
+  describe("requireCurrentSourceAnchor", () => {
+    const reservationKey = 1
+    const requestNonce = 1
+    const anchorTxHash = `0x${"11".repeat(32)}`
+    const anchorTxOutputIndex = 1
+
+    it("should not revert when anchors match", async () => {
+      await testReservation.setReservationAnchor(
+        reservationKey,
+        anchorTxHash,
+        anchorTxOutputIndex
+      )
+      const expectedHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTxHash, anchorTxOutputIndex]
+      )
+      await testReservation.setActionSourceAnchorUtxoHash(
+        reservationKey,
+        requestNonce,
+        expectedHash
+      )
+      await testReservation.requireCurrentSourceAnchor(
+        reservationKey,
+        requestNonce
+      )
+    })
+
+    it("should revert when anchors mismatch", async () => {
+      await testReservation.setReservationAnchor(
+        reservationKey,
+        anchorTxHash,
+        anchorTxOutputIndex
+      )
+      const wrongHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTxHash, 2] // Wrong index
+      )
+      await testReservation.setActionSourceAnchorUtxoHash(
+        reservationKey,
+        requestNonce,
+        wrongHash
+      )
+      await expect(
+        testReservation.requireCurrentSourceAnchor(reservationKey, requestNonce)
+      ).to.be.revertedWith("Action source anchor is no longer current")
+    })
+  })
+  describe("strand functions", () => {
+    const reservationKey = 100
+    const requestNonce = 1
+    const walletPubKeyHash = `0x${"11".repeat(20)}`
+    const owner = `0x${"22".repeat(20)}`
+    const anchorAmount = 100000
+
+    it("should strand reservation when target wallet is closed", async () => {
+      // 1. Set wallet state to Closing (one of the three trigger states).
+      await testReservation.setWalletState(walletPubKeyHash, 3) // 3 = Closing
+      // 2. Set reservation state.
+      await testReservation.setReservationFullState(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      // 3. Seed the capacity counters strandReservation will decrement.
+      await testReservation.setWalletReservationsCounters(
+        walletPubKeyHash,
+        1,
+        anchorAmount
+      )
+      await testReservation.setGlobalReservationCounters(anchorAmount, 1)
+      // 4. Call strandIfTargetWalletClosed.
+      await testReservation.strandIfTargetWalletClosed(
+        reservationKey,
+        walletPubKeyHash
+      )
+      // 5. Assert counters were released to zero.
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(
+        await testReservation.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await testReservation.reservationTotalAmount()).to.equal(0)
+      expect(await testReservation.activeReservationsCount()).to.equal(0)
+    })
+
+    it("should strand an active reservation and release its capacity exactly once", async () => {
+      const strandKey = 101
+      await testReservation.setReservationFullState(
+        strandKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      await testReservation.setWalletReservationsCounters(
+        walletPubKeyHash,
+        1,
+        anchorAmount
+      )
+      await testReservation.setGlobalReservationCounters(anchorAmount, 1)
+
+      await testReservation.strandReservation(strandKey)
+
+      expect(await testReservation.reservationState(strandKey)).to.equal(4) // Stranded
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await testReservation.activeReservationsCount()).to.equal(0)
+
+      // Calling again on an already-Stranded reservation must not
+      // double-decrement the now-zero counters (would otherwise underflow).
+      await testReservation.strandReservation(strandKey)
+      expect(await testReservation.reservationState(strandKey)).to.equal(4)
+    })
+
+    it("should be a no-op when the settlement is not late", async () => {
+      const key = 102
+      await testReservation.setWalletState(walletPubKeyHash, 3) // 3 = Closing
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      await testReservation.setWalletReservationsCounters(
+        walletPubKeyHash,
+        1,
+        anchorAmount
+      )
+      await testReservation.strandLateSettlementIfTargetWalletClosed(
+        key,
+        false, // late
+        false // evidenceAlreadyEmitted
+      )
+      expect(await testReservation.reservationState(key)).to.equal(1) // still Active
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(1)
+    })
+
+    it("should not strand a late settlement whose target wallet is still Live", async () => {
+      const key = 103
+      await testReservation.setWalletState(walletPubKeyHash, 1) // 1 = Live
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      await testReservation.strandLateSettlementIfTargetWalletClosed(
+        key,
+        true, // late
+        false // evidenceAlreadyEmitted
+      )
+      expect(await testReservation.reservationState(key)).to.equal(1) // still Active
+    })
+
+    it("should strand a late settlement whose target wallet is Closing", async () => {
+      const key = 104
+      await testReservation.setWalletState(walletPubKeyHash, 3) // 3 = Closing
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      await testReservation.setWalletReservationsCounters(
+        walletPubKeyHash,
+        1,
+        anchorAmount
+      )
+      await testReservation.setGlobalReservationCounters(anchorAmount, 1)
+      await testReservation.strandLateSettlementIfTargetWalletClosed(
+        key,
+        true, // late
+        false // evidenceAlreadyEmitted
+      )
+      expect(await testReservation.reservationState(key)).to.equal(4) // Stranded
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(0)
+    })
+
+    it("should defer a late Terminated settlement to the permissionless cleanup path when not already stranded", async () => {
+      const key = 105
+      await testReservation.setWalletState(walletPubKeyHash, 5) // 5 = Terminated
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      await testReservation.strandLateSettlementIfTargetWalletClosed(
+        key,
+        true, // late
+        false // evidenceAlreadyEmitted
+      )
+      // Left Active: notifyReservationStranded is the intended cleanup path.
+      expect(await testReservation.reservationState(key)).to.equal(1)
+    })
+
+    it("should strand a late Terminated settlement without double-releasing when evidence was already emitted", async () => {
+      const key = 106
+      await testReservation.setWalletState(walletPubKeyHash, 5) // 5 = Terminated
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        2, // ActionPending (the pre-restore state; counters were already
+        // released once and must not be released again)
+        requestNonce
+      )
+      await testReservation.strandLateSettlementIfTargetWalletClosed(
+        key,
+        true, // late
+        true // evidenceAlreadyEmitted
+      )
+      expect(await testReservation.reservationState(key)).to.equal(4) // Stranded
+      // Counters default to zero and must stay zero: evidenceAlreadyEmitted
+      // means strandReservation must skip the decrement this time.
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(0)
+    })
+
+    it("prepareReservationForSettlement should no-op for a non-stranded settleable reservation", async () => {
+      const key = 500
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        1, // Active
+        requestNonce
+      )
+      await testReservation.prepareReservationForSettlement(key, false)
+      expect(await testReservation.reservationTotalAmount()).to.equal(0)
+    })
+
+    it("prepareReservationForSettlement should restore capacity for a late-settled stranded reservation", async () => {
+      const key = 501
+      await testReservation.setReservationAnchor(key, `0x${"33".repeat(32)}`, 0)
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        4, // Stranded
+        requestNonce
+      )
+      await testReservation.prepareReservationForSettlement(key, true)
+      expect(await testReservation.reservationTotalAmount()).to.equal(
+        anchorAmount
+      )
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(1)
+      expect(await testReservation.activeReservationsCount()).to.equal(1)
+    })
+
+    it("prepareReservationForSettlement should reject an on-time settlement of a stranded reservation", async () => {
+      const key = 502
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        4, // Stranded
+        requestNonce
+      )
+      await expect(
+        testReservation.prepareReservationForSettlement(key, false)
+      ).to.be.revertedWith("Reservation is not settleable")
+    })
+
+    it("prepareReservationForSettlement should reject an anchor that was already spent by another generation", async () => {
+      const key = 503
+      await testReservation.setReservationAnchor(key, `0x${"44".repeat(32)}`, 0)
+      await testReservation.setReservationFullState(
+        key,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        4, // Stranded
+        requestNonce
+      )
+      await testReservation.setSpentMainUtxo(key, true)
+      await expect(
+        testReservation.prepareReservationForSettlement(key, true)
+      ).to.be.revertedWith("Reservation anchor already spent")
+    })
+  })
+
+  describe("loadSettleableAction", () => {
+    const reservationKey = 300
+    const requestNonce = 1
+    const targetWalletPubKeyHash = `0x${"11".repeat(20)}`
+
+    it("should report a pending action as not late", async () => {
+      await testReservation.setFullAction(
+        reservationKey,
+        requestNonce,
+        3, // Reanchor
+        1, // Pending
+        1,
+        targetWalletPubKeyHash,
+        1000
+      )
+      expect(
+        await testReservation.callStatic.loadSettleableAction(
+          reservationKey,
+          requestNonce,
+          3 // Reanchor
+        )
+      ).to.equal(false)
+    })
+
+    it("should report a timed-out action as late", async () => {
+      await testReservation.setFullAction(
+        reservationKey,
+        requestNonce,
+        3, // Reanchor
+        3, // TimedOut
+        1,
+        targetWalletPubKeyHash,
+        1000
+      )
+      expect(
+        await testReservation.callStatic.loadSettleableAction(
+          reservationKey,
+          requestNonce,
+          3 // Reanchor
+        )
+      ).to.equal(true)
+    })
+
+    it("should revert on an action type mismatch", async () => {
+      await testReservation.setFullAction(
+        reservationKey,
+        requestNonce,
+        3, // Reanchor
+        1, // Pending
+        1,
+        targetWalletPubKeyHash,
+        1000
+      )
+      await expect(
+        testReservation.callStatic.loadSettleableAction(
+          reservationKey,
+          requestNonce,
+          1 // Acceptance
+        )
+      ).to.be.revertedWith("Action type mismatch")
+    })
+
+    it("should revert when the action is already settled", async () => {
+      await testReservation.setFullAction(
+        reservationKey,
+        requestNonce,
+        3, // Reanchor
+        2, // Settled
+        1,
+        targetWalletPubKeyHash,
+        1000
+      )
+      await expect(
+        testReservation.callStatic.loadSettleableAction(
+          reservationKey,
+          requestNonce,
+          3 // Reanchor
+        )
+      ).to.be.revertedWith("Action is not settleable")
+    })
+  })
+
+  describe("notifyReservationActionTimeout", () => {
+    it("should time out a pending acceptance and release its capacity", async () => {
+      const reservationKey = 400
+      const targetWalletPubKeyHash = `0x${"11".repeat(20)}`
+      const amount = 1000
+
+      // reservation.requestNonce defaults to 0, so the action must be keyed
+      // at requestNonce 0 to be the reservation's current generation.
+      await testReservation.setFullAction(
+        reservationKey,
+        0,
+        1, // Acceptance
+        1, // Pending
+        1, // timeoutAt: far in the past, so the timeout check passes
+        targetWalletPubKeyHash,
+        amount
+      )
+      await testReservation.setWalletReservationsCounters(
+        targetWalletPubKeyHash,
+        1,
+        amount
+      )
+      await testReservation.setGlobalReservationCounters(amount, 1)
+
+      await testReservation.notifyReservationActionTimeout(reservationKey)
+
+      expect(await testReservation.actionState(reservationKey, 0)).to.equal(3) // TimedOut
+      expect(
+        await testReservation.walletReservationsCount(targetWalletPubKeyHash)
+      ).to.equal(0)
+      expect(await testReservation.reservationTotalAmount()).to.equal(0)
+      expect(await testReservation.activeReservationsCount()).to.equal(0)
+      // Acceptance timeout reverts the position to Unknown (its
+      // pre-request state), not Active -- it was never a custodied
+      // reservation.
+      expect(await testReservation.reservationState(reservationKey)).to.equal(0) // Unknown
+    })
+  })
+
+  describe("requestReservationAcceptance", () => {
+    const reservationKey = 200
+    const walletPubKeyHash = `0x${"11".repeat(20)}`
+    const vault = `0x${"33".repeat(20)}`
+
+    it("should request reservation acceptance successfully", async () => {
+      const now = (await ethers.provider.getBlock("latest")).timestamp
+
+      // Preconditions: governance params (all extra caps default to 0 =
+      // disabled), a Live designated wallet, and a revealed deposit routed
+      // to the reservation vault with a signing window that clears both
+      // the deposit-age floor and the refund-deadline safety margin.
+      await testReservation.setGovernanceParameters(100, 100, 10000, 0)
+      await testReservation.setReservationVault(vault)
+      await testReservation.setWalletState(walletPubKeyHash, 1) // 1 = Live
+      await testReservation.setDeposit(
+        reservationKey,
+        1000,
+        now - 3 * 60 * 60,
+        vault
+      )
+      await testReservation.setPendingReservedDeposit(
+        reservationKey,
+        true,
+        walletPubKeyHash,
+        now + 200000
+      )
+
+      // Call
+      await testReservation.requestReservationAcceptance(
+        reservationKey,
+        walletPubKeyHash
+      )
+
+      // Assert
+      expect(
+        await testReservation.walletReservationsCount(walletPubKeyHash)
+      ).to.equal(1)
+      expect(
+        await testReservation.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(1000)
+      expect(await testReservation.activeReservationsCount()).to.equal(1)
+    })
   })
 })

--- a/solidity/test/bridge/ReservationProofs.test.ts
+++ b/solidity/test/bridge/ReservationProofs.test.ts
@@ -118,6 +118,7 @@ describe("ReservationProofs", () => {
       retryCredit: false,
       dissolutionEligibleAt: 1000 + termSeconds + dissolutionDelay,
       cumulativeReanchorFee: 0,
+      reanchorCooldownUntil: 0,
       ...overrides,
     }
   }
@@ -221,23 +222,11 @@ describe("ReservationProofs", () => {
       ).to.be.revertedWith("Unsupported reservation proof type")
     })
 
-    it("should revert if proof type is not Acceptance (Redemption, Reanchor, Dissolution)", async () => {
+    it("should revert if proof type is not supported (Redemption, Dissolution)", async () => {
       // ProofType.Redemption = 1
       await expect(
         testReservationProofs.submitReservationProof(
           1,
-          dummyTxInfo,
-          dummyProof,
-          dummyUtxo,
-          sampleReservationKey,
-          1
-        )
-      ).to.be.revertedWith("Unsupported reservation proof type")
-
-      // ProofType.Reanchor = 2
-      await expect(
-        testReservationProofs.submitReservationProof(
-          2,
           dummyTxInfo,
           dummyProof,
           dummyUtxo,
@@ -520,6 +509,18 @@ describe("ReservationProofs", () => {
         depositor.address,
         depositAmount,
         mockReservationVault.address
+      )
+
+      // Seed the reservation's current generation to match the settling
+      // request: settleAcceptance's on-time path requires the position's
+      // requestNonce to equal the generation being proven.
+      await testReservationProofs.setReservation(
+        sampleReservationKey,
+        buildReservationRequest({
+          owner: depositor.address,
+          state: 0, // Unknown
+          requestNonce,
+        })
       )
 
       // Action record created at request time
@@ -1641,6 +1642,14 @@ describe("ReservationProofs", () => {
         anchorAmount,
         mockReservationVault.address
       )
+      await testReservationProofs.setReservation(
+        anchorReservationKey,
+        buildReservationRequest({
+          owner: depositor.address,
+          state: 0, // Unknown
+          requestNonce: 1,
+        })
+      )
       await testReservationProofs.setReservationAction(
         anchorReservationKey,
         1,
@@ -1737,6 +1746,14 @@ describe("ReservationProofs", () => {
         depositor.address,
         depositAmount,
         vaultA.address // the deposit's immutable, reveal-time vault
+      )
+      await testReservationProofs.setReservation(
+        routingReservationKey,
+        buildReservationRequest({
+          owner: depositor.address,
+          state: 0, // Unknown
+          requestNonce: 1,
+        })
       )
       await testReservationProofs.setReservationAction(
         routingReservationKey,


### PR DESCRIPTION
The re-anchor request, proof and settlement path for UTXO reservations.

### What lands

| File | Change |
|---|---|
| `contracts/bridge/Reservation.sol` | new library: request/authorization side |
| `contracts/bridge/ReservationProofs.sol` | new library: SPV proof settlement side |
| `contracts/bridge/BridgeState.sol` | new reservation storage fields |
| `contracts/bridge/WalletProposalValidatorConstants.sol` | new shared timing constants |
| `contracts/vault/IReservationFeeFinancer.sol` | new interface, no implementation yet (lands with PR #F) |
| `contracts/test/TestReservation.sol` | new test harness for pure/internal library functions |

Request side: `requestReservationAcceptance`, `requestReservationReanchor`,
`notifyReservationActionTimeout`, `strandReservation`, plus the
`actionKey`/`anchorUtxoHash` helpers.
Proof and settlement: `submitReservationAcceptanceProof`,
`submitReservationReanchorProof`, `prepareReservationForSettlement`,
`requireCurrentSourceAnchor`, `consumeAnchor`, `settleAcceptance`,
`unwindPendingAction`, `strandIfTargetWalletClosed`,
`strandLateSettlementIfTargetWalletClosed`.

`IReservationFeeFinancer.sol` is the interface the settlement path calls to
finance the Bitcoin miner fee in kind. It has to be here because
`ReservationProofs.sol` imports it; the `ReservationVault` implementation
stays with PR #F.

### Scope correction

An earlier version of this description claimed the acceptance/settlement
surface was extracted byte-identical from PR #1094 and that functions such
as `actionKey`, `getAction`, `loadSettleableAction`, `parseSingleOutput`,
`unwindPendingAction`, `strandReservation` and
`strandLateSettlementIfTargetWalletClosed` were "already on the base from PR
#C and reused, not duplicated." That claim was false and has been corrected
here after review: this branch's actual git base
(`origin/reservations-upgrade`) does not contain `Reservation.sol`,
`ReservationProofs.sol`, or `WalletProposalValidatorConstants.sol` at all
(`git show origin/reservations-upgrade:solidity/contracts/bridge/Reservation.sol`
fails; `git ls-tree origin/reservations-upgrade solidity/contracts/bridge/`
lists neither file). The full acceptance request/settlement path shipped in
this PR is new on this branch, not carried forward from a prior extraction.
Any future PR-stack description should be verified against the actual merge
base rather than assumed from the source PR's own history.

### No fee cap, deliberately - and permissionless by design

Re-anchor accumulates no cumulative fee ceiling in milestone 1: that is a
deliberate scope decision, not an oversight, deferring a structural bound to
post-milestone-1 work. `ReservationRequest.cumulativeReanchorFee` is written
on every re-anchor hop so a future cap can read the true lifetime total,
including hops that predate the cap.

Review surfaced that the risk-acceptance rationale for this decision
originally overstated its own governance gate: the privileged
governance-only check applies only when the source wallet is `Live`. When
the source wallet is `MovingFunds` or `Closing` (the common case - wallets
retiring per their `walletMaxAge`/`walletClosureMinBtcBalance` policy),
re-anchor is fully permissionless by design, callable by anyone. This is
intentional (migration must not be blockable), but it is the dominant
exposure path, not the `Live`-wallet governance gate, and both the in-code
rationale and this description now say so explicitly.

### Testing

`contracts/test/TestReservation.sol` plus `test/bridge/Reservation.test.ts`
now cover, in addition to the previously-untested pure/internal functions
(`actionKey`, `anchorUtxoHash`, `parseSingleOutput`, `validateAnchorOutput`,
including the fee-bound equality boundary and the amount-underflow case):
`requestReservationAcceptance`, `notifyReservationActionTimeout`,
`strandReservation`, `loadSettleableAction`, `requireCurrentSourceAnchor`,
and `strandIfTargetWalletClosed` -- happy path, revert reasons, and exact
post-call counter/state assertions, following the repo's existing
thin-wrapper pattern (`TestEcdsaLib.sol`, `TestBitcoinTx.sol`).
`requestReservationReanchor` and `consumeAnchor` remain untested directly:
the former needs a full cooldown/timing/cap precondition chain and the
latter needs a valid Bitcoin input-vector fixture, both beyond a thin
wrapper in this pass. Full control-flow integration coverage is still
expected to land with the router (PR #B) and vault (PR #F).

### Verification

```
cd solidity
yarn build              # compiles clean, 183 files
yarn lint               # 0 errors (pre-existing ordering warnings only)
yarn format             # prettier clean
yarn test               # 3042 passing, 0 failing, 33 pending (pre-existing skips)
yarn test:integration   # 27 passing
yarn deploy:test        # clean dry run
```

This PR went through two internal multi-lens automated review rounds. The
first round fixed 34 confirmed findings (occupancy accounting, a
stale-generation settlement binding, CEI ordering, several inaccurate
comments, and the scope/permissionless-path corrections above). A second,
fresh-pass review round against the fixed code then found and fixed 38
more confirmed findings, including a P0 (an unconditional underflow revert
in `notifyReservationActionTimeout` that permanently bricked acceptance
timeouts) and four P1s (a stale-generation nonce check that made three
documented late-settlement branches dead code; a re-anchor capacity cap
missing the zero-disables-the-cap sentinel every sibling cap uses, which
bricked re-anchor under default configuration; a missing permissionless
`notifyReservationStranded` cleanup path for Terminated wallets; and the
test-coverage gap that let the first two ship undetected). See the review
artifacts for the full list if useful context is needed during human
review.
