### PR TITLE
feat(bridge): implement reservation timeout and stranding notifications

### DIFF
--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -58,6 +58,8 @@ import "./WalletProposalValidatorConstants.sol";
 ///      reservation vault as explicit transfers; Bitcoin miner fees are the
 ///      only in-kind deductions.
 library Reservation {
+    using Wallets for BridgeState.Storage;
+
     /// @notice Hard protocol bounds on the custody term length. The
     ///         governable term must stay within them; they bound the
     ///         maximum owner lookahead (one term plus the renewal window)
@@ -352,6 +354,20 @@ library Reservation {
         uint256 indexed reservationKey,
         uint64 requestNonce
     );
+
+    event ReservationRedemptionTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationDissolutionTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+
+    event ReservationRetryCreditMinted(uint256 indexed reservationKey);
+
+    event ReservedDepositMarkedStale(uint256 indexed depositKey);
 
     /// @notice Computes the storage key of the action record of the given
     ///         reservation generation.
@@ -669,6 +685,55 @@ library Reservation {
         emit ReservationAcceptanceTimedOut(reservationKey, requestNonce);
     }
 
+    /// @notice Marks a revealed reserved deposit as stale: it can no
+    ///         longer be authorized for acceptance and stops counting
+    ///         against the pending-reserved-deposit guard. Intended for
+    ///         deposits whose acceptance never happened — after the
+    ///         reveal-time refund deadline the depositor is expected to
+    ///         reclaim the funds through the Bitcoin refund path.
+    /// @param depositKey The deposit key of the reserved deposit.
+    /// @dev Requirements:
+    ///      - The deposit must be a pending reserved deposit (revealed to
+    ///        the reservation vault, not accepted, not already stale),
+    ///      - No acceptance authorization may be pending for it,
+    ///      - If refundDeadlineValidated is true, the exact Bitcoin refund
+    ///        deadline snapshotted at reveal must have elapsed.
+    function notifyStaleReservedDeposit(
+        BridgeState.Storage storage self,
+        uint256 depositKey
+    ) external {
+        BridgeState.PendingReservedDeposit storage pendingDeposit = self
+            .pendingReservedDeposit[depositKey];
+        require(
+            pendingDeposit.walletPubKeyHash != bytes20(0),
+            "Not a pending reserved deposit"
+        );
+
+        Deposit.DepositRequest storage deposit = self.deposits[depositKey];
+        require(deposit.sweptAt == 0, "Deposit already swept");
+        if (pendingDeposit.refundDeadlineValidated) {
+            require(
+                /* solhint-disable-next-line not-rely-on-time */
+                block.timestamp > pendingDeposit.refundDeadline,
+                "Deposit refund deadline has not elapsed"
+            );
+        }
+
+        ReservationRequest storage reservation = self.reservations[depositKey];
+        require(
+            getAction(self, depositKey, reservation.requestNonce).state !=
+                ActionState.Pending,
+            "Acceptance authorization pending"
+        );
+
+        delete pendingDeposit.walletPubKeyHash;
+        delete pendingDeposit.refundDeadline;
+        delete pendingDeposit.refundDeadlineValidated;
+        self.pendingReservedDeposits -= 1;
+
+        emit ReservedDepositMarkedStale(depositKey);
+    }
+
     /// @notice Requests the re-anchoring of a reservation to another
     ///         wallet: the authorization for the source wallet to spend the
     ///         anchor in a 1-input-1-output transaction paying the target
@@ -894,6 +959,202 @@ library Reservation {
         );
     }
 
+    /// @notice Permissionlessly reports a reservation's pending redemption
+    ///         generation as timed out once its authorization window has
+    ///         elapsed: restores the reservation to `Active` so a fresh
+    ///         redemption may be requested, mints a fee-free retry
+    ///         entitlement when the generation had paid the fee, and
+    ///         propagates wallet consequences (slashing follows the
+    ///         regular redemption timeout rules).
+    /// @dev Returns the redemption generation's escrowed claim to
+    ///      `action.redeemer` as Bank balance, regardless of whether the
+    ///      wallet was slashable: the redeemer's entitlement to the
+    ///      escrowed amount does not depend on the wallet's post-timeout
+    ///      lifecycle state.
+    /// @param reservationKey The key of the reservation whose current
+    ///        pending generation timed out.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members, consulted for the slashing path.
+    /// @dev Requirements:
+    ///      - The reservation's current generation must be a `Redemption`
+    ///        action in the `Pending` state,
+    ///      - The reservation itself must be in the `ActionPending` state,
+    ///      - Its snapshotted `timeoutAt` must have elapsed.
+    function notifyReservationRedemptionTimedOut(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            reservation.requestNonce
+        );
+
+        require(
+            action.actionType == ActionType.Redemption,
+            "Unsupported action type for timeout"
+        );
+        require(
+            reservation.state == ReservationState.ActionPending,
+            "Reservation is not in ActionPending state"
+        );
+        require(action.state == ActionState.Pending, "Action is not pending");
+        /* solhint-disable not-rely-on-time */
+        require(
+            block.timestamp >= action.timeoutAt,
+            "Action has not timed out"
+        );
+        /* solhint-enable not-rely-on-time */
+
+        action.state = ActionState.TimedOut;
+        reservation.state = ReservationState.Active;
+
+        if (action.feePaid || action.usedRetryCredit) {
+            reservation.retryCredit = true;
+            self.reservationRetryCreditActionNonce[reservationKey] = reservation
+                .requestNonce;
+            emit ReservationRetryCreditMinted(reservationKey);
+        }
+
+        // A wallet that has already moved past MovingFunds (Closing,
+        // Closed) cannot be slashed via the regular redemption-timeout
+        // path -- `notifyWalletRedemptionTimeout` requires Live,
+        // MovingFunds, or Terminated and reverts otherwise. Skipping it
+        // here (rather than reverting the whole timeout) keeps this
+        // permissionless cleanup callable regardless of the wallet's
+        // lifecycle stage.
+        Wallets.WalletState walletState = self
+            .registeredWallets[reservation.walletPubKeyHash]
+            .state;
+        bool isWalletRedeemable = walletState == Wallets.WalletState.Live ||
+            walletState == Wallets.WalletState.MovingFunds ||
+            walletState == Wallets.WalletState.Terminated;
+        if (isWalletRedeemable) {
+            self.notifyWalletRedemptionTimeout(
+                reservation.walletPubKeyHash,
+                walletMembersIDs
+            );
+        }
+
+        // Return the escrowed balance to the redeemer as Bank balance.
+        self.bank.transferBalance(action.redeemer, action.amount);
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservationRedemptionTimedOut(
+            reservationKey,
+            reservation.requestNonce
+        );
+    }
+
+    /// @notice Permissionlessly reports a reservation's pending dissolution
+    ///         generation as timed out once its authorization window has
+    ///         elapsed: restores the reservation to `Active` so a fresh
+    ///         dissolution may be requested, and propagates wallet
+    ///         consequences. A wallet failing its dissolution duty is
+    ///         slashed like a wallet failing a redemption: dissolution is
+    ///         the mechanism that makes term + grace a hard stranding
+    ///         bound. A Live wallet enters MovingFunds on its first
+    ///         failure and keeps the ordinary moving-funds deadline; a
+    ///         wallet already in MovingFunds has now also refused the
+    ///         terminal cleanup of its residual anchor, so it is
+    ///         terminated at the dissolution bound.
+    /// @param reservationKey The key of the reservation whose current
+    ///        pending generation timed out.
+    /// @param walletMembersIDs Identifiers of the wallet signing group
+    ///        members, consulted for the slashing path.
+    /// @dev Requirements:
+    ///      - The reservation's current generation must be a `Dissolution`
+    ///        action in the `Pending` state,
+    ///      - The reservation itself must be in the `ActionPending` state,
+    ///      - Its snapshotted `timeoutAt` must have elapsed.
+    function notifyReservationDissolutionTimedOut(
+        BridgeState.Storage storage self,
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        ReservationAction storage action = getAction(
+            self,
+            reservationKey,
+            reservation.requestNonce
+        );
+
+        require(
+            action.actionType == ActionType.Dissolution,
+            "Unsupported action type for timeout"
+        );
+        require(
+            reservation.state == ReservationState.ActionPending,
+            "Reservation is not in ActionPending state"
+        );
+        require(action.state == ActionState.Pending, "Action is not pending");
+        /* solhint-disable not-rely-on-time */
+        require(
+            block.timestamp >= action.timeoutAt,
+            "Action has not timed out"
+        );
+        /* solhint-enable not-rely-on-time */
+
+        action.state = ActionState.TimedOut;
+        reservation.state = ReservationState.Active;
+        // Only clear the wallet's pending-dissolution marker if it still
+        // points at THIS reservation: a newer request for a different
+        // reservation may have since claimed the wallet's single-slot
+        // marker, and this timeout must not clear that unrelated claim.
+        if (
+            self.walletPendingDissolution[reservation.walletPubKeyHash] ==
+            reservationKey
+        ) {
+            delete self.walletPendingDissolution[reservation.walletPubKeyHash];
+        }
+
+        Wallets.WalletState walletState = self
+            .registeredWallets[reservation.walletPubKeyHash]
+            .state;
+        bool walletWasMovingFunds = walletState ==
+            Wallets.WalletState.MovingFunds;
+        // See notifyReservationRedemptionTimedOut: skip slashing for a
+        // wallet notifyWalletRedemptionTimeout cannot accept (Closing,
+        // Closed) rather than reverting this permissionless cleanup.
+        bool isWalletRedeemable = walletState == Wallets.WalletState.Live ||
+            walletWasMovingFunds ||
+            walletState == Wallets.WalletState.Terminated;
+        if (isWalletRedeemable) {
+            self.notifyWalletRedemptionTimeout(
+                reservation.walletPubKeyHash,
+                walletMembersIDs
+            );
+        }
+
+        // A Live wallet enters MovingFunds on its first failure and keeps
+        // the ordinary moving-funds deadline. A wallet already in
+        // MovingFunds has now also refused the terminal cleanup of its
+        // residual anchor, so terminate it at the dissolution bound. The
+        // slashing call above may itself have just moved a Live wallet to
+        // MovingFunds or Closing, so the termination check re-reads state
+        // after that call rather than trusting the pre-call snapshot.
+        Wallets.WalletState postCallState = self
+            .registeredWallets[reservation.walletPubKeyHash]
+            .state;
+        if (
+            walletWasMovingFunds || postCallState == Wallets.WalletState.Closing
+        ) {
+            self.terminateWallet(reservation.walletPubKeyHash);
+        }
+
+        // slither-disable-next-line reentrancy-events
+        emit ReservationDissolutionTimedOut(
+            reservationKey,
+            reservation.requestNonce
+        );
+    }
+
     /// @notice Appends a reservation key to a wallet's enumeration list.
     function addWalletReservationKey(
         BridgeState.Storage storage self,
@@ -976,14 +1237,16 @@ library Reservation {
     }
 
     /// @notice Permissionless cleanup entry point for a reservation whose
-    ///         wallet has reached the Terminated state with no settlement
-    ///         currently in flight. Releases the reservation's tracked
-    ///         capacity via `strandReservation`, which also emits the
-    ///         canonical `ReservationStranded` recovery evidence.
+    ///         wallet has reached the Closing, Closed, or Terminated state
+    ///         with no settlement currently in flight. Releases the
+    ///         reservation's tracked capacity via `strandReservation`,
+    ///         which also emits the canonical `ReservationStranded`
+    ///         recovery evidence.
     /// @param reservationKey The key of the reservation to strand.
     /// @dev Requirements:
     ///      - The reservation must be Active,
-    ///      - The reservation's wallet must be in the Terminated state.
+    ///      - The reservation's wallet must be in the Closing, Closed, or
+    ///        Terminated state.
     function notifyReservationStranded(
         BridgeState.Storage storage self,
         uint256 reservationKey
@@ -1000,8 +1263,10 @@ library Reservation {
             .registeredWallets[reservation.walletPubKeyHash]
             .state;
         require(
-            walletState == Wallets.WalletState.Terminated,
-            "Source wallet is not terminated"
+            walletState == Wallets.WalletState.Closing ||
+                walletState == Wallets.WalletState.Closed ||
+                walletState == Wallets.WalletState.Terminated,
+            "Wallet is not closing, closed or terminated"
         );
 
         strandReservation(self, reservation, reservationKey);

--- a/solidity/contracts/test/ReservationStrandingExecutor.sol
+++ b/solidity/contracts/test/ReservationStrandingExecutor.sol
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+import "../bridge/BridgeState.sol";
+import "../bridge/Deposit.sol";
+import "../bridge/Reservation.sol";
+import "../bridge/ReservationProofs.sol";
+import "../bridge/Wallets.sol";
+import "../bank/Bank.sol";
+import {IWalletRegistry as EcdsaWalletRegistry} from "@keep-network/ecdsa/contracts/api/IWalletRegistry.sol";
+
+/// @title Reservation stranding executor
+/// @notice Helper contract exposing library functions from `Reservation.sol` and
+///         `ReservationProofs.sol` for direct test-driven development and
+///         coverage in isolation.
+/// @dev This contract holds an isolated `BridgeState.Storage` reference, allowing
+///      the library functions to run against local, pre-populated storage without
+///      a full Bridge deployment. It provides forwarders to the library
+///      functions and `seed*` helpers for pre-positioning storage state.
+contract ReservationStrandingExecutor {
+    using Reservation for BridgeState.Storage;
+    using ReservationProofs for BridgeState.Storage;
+
+    BridgeState.Storage internal self;
+
+    // The library emits these events. They are redeclared here so the
+    // executor's ABI carries the canonical signatures for the test
+    // surface (filters and event parsing in Typechain / ethers).
+    event ReservationStranded(
+        uint256 indexed reservationKey,
+        bytes20 indexed walletPubKeyHash,
+        address indexed owner,
+        uint64 anchorAmount
+    );
+
+    event ReservedDepositMarkedStale(uint256 indexed depositKey);
+
+    event ReservationReanchorTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+    event ReservationRedemptionTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+    event ReservationDissolutionTimedOut(
+        uint256 indexed reservationKey,
+        uint64 requestNonce
+    );
+    event ReservationRetryCreditMinted(uint256 indexed reservationKey);
+
+    /// @notice Forwards the `Reservation.notifyReservationStranded` library
+    ///         function. Reverts with the library's exact message when the
+    ///         reservation is not Active or the wallet is not Closing,
+    ///         Closed, or Terminated.
+    ///         "Wallet is not closing, closed or terminated" is the revert
+    ///         message.
+    function notifyReservationStranded(uint256 reservationKey) external {
+        self.notifyReservationStranded(reservationKey);
+    }
+
+    /// @notice Forwards the `Reservation.notifyReservationActionTimeout`
+    ///         library function (Reanchor timeout only).
+    function notifyReservationActionTimeout(uint256 reservationKey) external {
+        self.notifyReservationActionTimeout(reservationKey);
+    }
+
+    function notifyReservationRedemptionTimedOut(
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        self.notifyReservationRedemptionTimedOut(
+            reservationKey,
+            walletMembersIDs
+        );
+    }
+
+    function notifyReservationDissolutionTimedOut(
+        uint256 reservationKey,
+        uint32[] calldata walletMembersIDs
+    ) external {
+        self.notifyReservationDissolutionTimedOut(
+            reservationKey,
+            walletMembersIDs
+        );
+    }
+
+    function setBank(address bankAddress) external {
+        self.bank = Bank(bankAddress);
+    }
+
+    function setEcdsaWalletRegistry(address registryAddress) external {
+        self.ecdsaWalletRegistry = EcdsaWalletRegistry(registryAddress);
+    }
+
+    function submitReservationAcceptanceProof(
+        BitcoinTx.Info calldata anchorTx,
+        BitcoinTx.Proof calldata anchorProof,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external {
+        self.submitReservationAcceptanceProof(
+            anchorTx,
+            anchorProof,
+            reservationKey,
+            requestNonce
+        );
+    }
+
+    function submitReservationReanchorProof(
+        BitcoinTx.Info calldata reanchorTx,
+        BitcoinTx.Proof calldata reanchorProof,
+        uint256 reservationKey,
+        uint64 requestNonce
+    ) external {
+        self.submitReservationReanchorProof(
+            reanchorTx,
+            reanchorProof,
+            reservationKey,
+            requestNonce
+        );
+    }
+
+    /// @notice Forwards the `Reservation.notifyStaleReservedDeposit` library
+    ///         function. Reverts with the library's exact message when the
+    ///         deposit is not a pending reserved deposit, when the
+    ///         deposit's refund deadline has not elapsed, when the deposit
+    ///         is already swept, or when an acceptance authorization is
+    ///         pending.
+    function notifyStaleReservedDeposit(uint256 depositKey) external {
+        self.notifyStaleReservedDeposit(depositKey);
+    }
+
+    function requestReservationAcceptance(
+        uint256 reservationKey,
+        bytes20 walletPubKeyHash
+    ) external {
+        self.requestReservationAcceptance(reservationKey, walletPubKeyHash);
+    }
+
+    function requestReservationReanchor(
+        uint256 reservationKey,
+        bytes20 targetWalletPubKeyHash,
+        bool privileged
+    ) external {
+        self.requestReservationReanchor(
+            reservationKey,
+            targetWalletPubKeyHash,
+            privileged
+        );
+    }
+
+    // --- seed helpers used by tests ---------------------------------------
+
+    /// @notice Inserts a wallet in any state. Used to verify the
+    ///         "Wallet is not closing, closed or terminated" rejection path.
+    function seedWallet(
+        bytes20 walletPubKeyHash,
+        bytes32 ecdsaWalletID,
+        Wallets.WalletState state
+    ) external {
+        Wallets.Wallet storage wallet = self.registeredWallets[
+            walletPubKeyHash
+        ];
+        wallet.ecdsaWalletID = ecdsaWalletID;
+        wallet.state = state;
+        wallet.createdAt = uint32(block.timestamp); // solhint-disable-line not-rely-on-time
+        if (state == Wallets.WalletState.Live) {
+            self.liveWalletsCount++;
+        }
+    }
+
+    /// @notice Inserts a `ReservationRequest` with full lifecycle metadata
+    ///         so the stranding paths can locate their cross-reference
+    ///         counters and emit the canonical recovery evidence.
+    function seedReservation(
+        uint256 reservationKey,
+        address owner,
+        bytes20 walletPubKeyHash,
+        uint64 anchorAmount,
+        bytes32 anchorTxHash,
+        uint32 anchorTxOutputIndex,
+        Reservation.ReservationState state
+    ) external {
+        Reservation.ReservationRequest storage reservation = self.reservations[
+            reservationKey
+        ];
+        reservation.owner = owner;
+        reservation.mintedAmount = anchorAmount;
+        reservation.acceptedAt = uint32(block.timestamp); // solhint-disable-line not-rely-on-time
+        reservation.walletPubKeyHash = walletPubKeyHash;
+        reservation.anchorAmount = anchorAmount;
+        reservation.anchorTxHash = anchorTxHash;
+        reservation.anchorTxOutputIndex = anchorTxOutputIndex;
+        reservation.state = state;
+        reservation.requestNonce = 0;
+        reservation.expiresAt = uint32(block.timestamp) + 365 days; // solhint-disable-line not-rely-on-time
+        reservation.dissolutionEligibleAt =
+            uint32(block.timestamp) + // solhint-disable-line not-rely-on-time
+            365 days +
+            30 days;
+
+        self.walletReservationKeys[walletPubKeyHash].push(reservationKey);
+        self.walletReservationKeyIndex[reservationKey] = self
+            .walletReservationKeys[walletPubKeyHash]
+            .length;
+        self.walletReservationsCount[walletPubKeyHash] += 1;
+        self.walletReservationsAmount[walletPubKeyHash] += anchorAmount;
+        self.reservationTotalAmount += anchorAmount;
+        // `activeReservationsCount` is only ever freed by an acceptance
+        // timeout or by `strandReservation` (see `Reservation.sol`); every
+        // other state, including a normally-Closed reservation, still
+        // occupies its slot. Mirror that here so tests seeding a
+        // pre-Stranded reservation directly don't make `strandReservation`
+        // underflow the counter on its unconditional decrement.
+        if (state != Reservation.ReservationState.Stranded) {
+            self.activeReservationsCount += 1;
+        }
+
+        self.reservationsByAnchorUtxo[
+            uint256(
+                keccak256(abi.encodePacked(anchorTxHash, anchorTxOutputIndex))
+            )
+        ] = reservationKey;
+    }
+
+    /// @notice Inserts a revealed-but-not-swept `DepositRequest`. Used by
+    ///         `notifyStaleReservedDeposit` rejection paths that check
+    ///         `sweptAt == 0`.
+    function seedDeposit(uint256 depositKey, address depositor) external {
+        Deposit.DepositRequest storage deposit = self.deposits[depositKey];
+        deposit.depositor = depositor;
+        deposit.amount = 1_000_000;
+        deposit.revealedAt = uint32(block.timestamp); // solhint-disable-line not-rely-on-time
+    }
+
+    /// @notice Marks a revealed deposit as swept. Exercises the
+    ///         "Deposit already swept" rejection path of
+    ///         `notifyStaleReservedDeposit`.
+    function seedSweptDeposit(uint256 depositKey) external {
+        Deposit.DepositRequest storage deposit = self.deposits[depositKey];
+        deposit.sweptAt = uint32(block.timestamp); // solhint-disable-line not-rely-on-time
+    }
+
+    /// @notice Inserts a pending reserved deposit with both the
+    ///         reveal-ahead-validated and unvalidated shapes. The
+    ///         `notifyStaleReservedDeposit` path branches on
+    ///         `refundDeadlineValidated` so both shapes need coverage.
+    function seedPendingReservedDeposit(
+        uint256 depositKey,
+        bytes20 walletPubKeyHash,
+        uint32 refundDeadline,
+        bool refundDeadlineValidated
+    ) external {
+        BridgeState.PendingReservedDeposit storage pending = self
+            .pendingReservedDeposit[depositKey];
+        pending.isReserved = true;
+        pending.walletPubKeyHash = walletPubKeyHash;
+        pending.refundDeadline = refundDeadline;
+        pending.refundDeadlineValidated = refundDeadlineValidated;
+        self.pendingReservedDeposits += 1;
+    }
+
+    /// @notice Inserts an `ActionState.Pending` reservation action so the
+    ///         "Acceptance authorization pending" rejection path of
+    ///         `notifyStaleReservedDeposit` fires.
+    function seedPendingAction(uint256 reservationKey, uint64 requestNonce)
+        external
+    {
+        Reservation.ReservationAction storage action = self.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
+        action.actionType = Reservation.ActionType.Acceptance;
+        action.state = Reservation.ActionState.Pending;
+        action.requestedAt = uint32(block.timestamp); // solhint-disable-line not-rely-on-time
+    }
+
+    /// @notice Sets an existing reservation action's type and state directly,
+    ///         used to seed a terminal (Settled, Vetoed, or Superseded)
+    ///         ActionState so tests can exercise the "Action is not
+    ///         settleable" rejection path in `loadSettleableAction`.
+    function seedReservationActionState(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType,
+        Reservation.ActionState state
+    ) external {
+        Reservation.ReservationAction storage action = self.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
+        action.actionType = actionType;
+        action.state = state;
+    }
+
+    function _seedPendingReservationAction(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType,
+        bytes20 targetWalletPubKeyHash,
+        uint64 amount,
+        uint32 timeoutAt,
+        bool feePaid,
+        address redeemer,
+        bool usedRetryCredit
+    ) internal {
+        Reservation.ReservationAction storage action = self.reservationActions[
+            Reservation.actionKey(reservationKey, requestNonce)
+        ];
+        action.actionType = actionType;
+        action.state = Reservation.ActionState.Pending;
+        /* solhint-disable-next-line not-rely-on-time */
+        action.requestedAt = uint32(block.timestamp);
+        action.timeoutAt = timeoutAt;
+        action.targetWalletPubKeyHash = targetWalletPubKeyHash;
+        action.amount = amount;
+        action.feePaid = feePaid;
+        action.redeemer = redeemer;
+        action.usedRetryCredit = usedRetryCredit;
+    }
+
+    function seedPendingReservationAction(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType,
+        bytes20 targetWalletPubKeyHash,
+        uint64 amount,
+        uint32 timeoutAt,
+        bool feePaid,
+        address redeemer
+    ) external {
+        _seedPendingReservationAction(
+            reservationKey,
+            requestNonce,
+            actionType,
+            targetWalletPubKeyHash,
+            amount,
+            timeoutAt,
+            feePaid,
+            redeemer,
+            false
+        );
+    }
+
+    function seedPendingReservationActionWithRetryCredit(
+        uint256 reservationKey,
+        uint64 requestNonce,
+        Reservation.ActionType actionType,
+        bytes20 targetWalletPubKeyHash,
+        uint64 amount,
+        uint32 timeoutAt,
+        bool feePaid,
+        address redeemer,
+        bool usedRetryCredit
+    ) external {
+        _seedPendingReservationAction(
+            reservationKey,
+            requestNonce,
+            actionType,
+            targetWalletPubKeyHash,
+            amount,
+            timeoutAt,
+            feePaid,
+            redeemer,
+            usedRetryCredit
+        );
+    }
+
+    function seedWalletPendingDissolution(
+        bytes20 walletPubKeyHash,
+        uint256 reservationKey
+    ) external {
+        self.walletPendingDissolution[walletPubKeyHash] = reservationKey;
+    }
+
+    // --- read helpers used by tests ---------------------------------------
+
+    function reservationState(uint256 reservationKey)
+        external
+        view
+        returns (Reservation.ReservationState)
+    {
+        return self.reservations[reservationKey].state;
+    }
+
+    function walletState(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (Wallets.WalletState)
+    {
+        return self.registeredWallets[walletPubKeyHash].state;
+    }
+
+    function walletPendingDissolution(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint256)
+    {
+        return self.walletPendingDissolution[walletPubKeyHash];
+    }
+
+    function walletReservationsCount(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint32)
+    {
+        return self.walletReservationsCount[walletPubKeyHash];
+    }
+
+    function walletReservationsAmount(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint64)
+    {
+        return self.walletReservationsAmount[walletPubKeyHash];
+    }
+
+    function reservationTotalAmount() external view returns (uint64) {
+        return self.reservationTotalAmount;
+    }
+
+    function walletReservationKeysLength(bytes20 walletPubKeyHash)
+        external
+        view
+        returns (uint256)
+    {
+        return self.walletReservationKeys[walletPubKeyHash].length;
+    }
+
+    function walletReservationKeyAt(bytes20 walletPubKeyHash, uint256 index)
+        external
+        view
+        returns (uint256)
+    {
+        return self.walletReservationKeys[walletPubKeyHash][index];
+    }
+
+    function walletReservationKeyIndex(uint256 reservationKey)
+        external
+        view
+        returns (uint256)
+    {
+        return self.walletReservationKeyIndex[reservationKey];
+    }
+
+    function reservationsByAnchorUtxo(bytes32 anchorUtxoHash)
+        external
+        view
+        returns (uint256)
+    {
+        return self.reservationsByAnchorUtxo[uint256(anchorUtxoHash)];
+    }
+
+    function pendingReservedDepositWallet(uint256 depositKey)
+        external
+        view
+        returns (bytes20)
+    {
+        return self.pendingReservedDeposit[depositKey].walletPubKeyHash;
+    }
+
+    function pendingReservedDepositDeadline(uint256 depositKey)
+        external
+        view
+        returns (uint32)
+    {
+        return self.pendingReservedDeposit[depositKey].refundDeadline;
+    }
+
+    function pendingReservedDepositValidated(uint256 depositKey)
+        external
+        view
+        returns (bool)
+    {
+        return self.pendingReservedDeposit[depositKey].refundDeadlineValidated;
+    }
+
+    function pendingReservedDeposits() external view returns (uint64) {
+        return self.pendingReservedDeposits;
+    }
+
+    function actionState(uint256 reservationKey, uint64 requestNonce)
+        external
+        view
+        returns (Reservation.ActionState)
+    {
+        return
+            self
+                .reservationActions[
+                    Reservation.actionKey(reservationKey, requestNonce)
+                ]
+                .state;
+    }
+}

--- a/solidity/hardhat.config.ts
+++ b/solidity/hardhat.config.ts
@@ -307,7 +307,7 @@ const config: HardhatUserConfig = {
     disambiguatePaths: false,
     runOnCompile: true,
     strict: true,
-    except: ["BridgeStub$"],
+    except: ["BridgeStub$", "ReservationStrandingExecutor$"],
   },
   mocha: {
     timeout: 60_000,

--- a/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
@@ -1,0 +1,1996 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+
+import { ethers, waffle } from "hardhat"
+import chai, { expect } from "chai"
+import { Contract, ContractTransaction } from "ethers"
+import { FakeContract, smock } from "@defi-wonderland/smock"
+
+import type {
+  ReservationStrandingExecutor,
+  IWalletRegistry,
+} from "../../typechain"
+
+chai.use(smock.matchers)
+const ZERO_BYTES20 = `0x${"00".repeat(20)}`
+
+// Reservation.ReservationState enum values (matches `Reservation.sol`).
+const reservationStateEnum = {
+  Unknown: 0,
+  Active: 1,
+  ActionPending: 2,
+  Closed: 3,
+  Stranded: 4,
+}
+
+// Wallets.WalletState enum values (matches `Wallets.sol`).
+const walletStateEnum = {
+  Unknown: 0,
+  Live: 1,
+  MovingFunds: 2,
+  Closing: 3,
+  Closed: 4,
+  Terminated: 5,
+}
+
+const reservationActionStateEnum = {
+  None: 0,
+  Pending: 1,
+  TimedOut: 2,
+  Settled: 3,
+  Vetoed: 4,
+}
+
+// Reservation.ActionType enum values (matches `Reservation.sol`).
+const reservationActionTypeEnum = {
+  None: 0,
+  Acceptance: 1,
+  Redemption: 2,
+  Reanchor: 3,
+  Dissolution: 4,
+}
+
+const fixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+
+async function deployExecutor(): Promise<ReservationStrandingExecutor> {
+  // The Reservation library is `external` (its `notifyReservationStranded`,
+  // `notifyStaleReservedDeposit`, `notifyReservationActionTimeout`,
+  // `requestReservationAcceptance`, and `requestReservationReanchor`
+  // functions have the `external` visibility modifier). The bytecode of
+  // the `ReservationStrandingExecutor` test contract embeds a
+  // placeholder for the Reservation library because of the `using
+  // Reservation for BridgeState.Storage` declaration (which is also used
+  // inside `ReservationProofs.sol`). The Reservation library must
+  // therefore be deployed before the executor and linked into it.
+  const ReservationFactory = await ethers.getContractFactory("Reservation")
+  const reservation = await ReservationFactory.deploy()
+  await reservation.deployed()
+
+  const Factory = await ethers.getContractFactory(
+    "ReservationStrandingExecutor",
+    {
+      libraries: {
+        Reservation: reservation.address,
+      },
+    }
+  )
+  const executor = (await Factory.deploy()) as ReservationStrandingExecutor
+  await executor.deployed()
+  return executor
+}
+
+async function setReservationConfig(
+  executorAddress: string,
+  params: {
+    reservationVault?: string
+    reservationMinAmount?: number | ethers.BigNumber
+    reservationTxMaxFee?: number | ethers.BigNumber
+    reservationTermSeconds?: number
+    reservationDissolutionDelay?: number
+    reservationMaxTotalAmount?: number | ethers.BigNumber
+    reservationTotalAmount?: number | ethers.BigNumber
+    maxReservationsPerWallet?: number
+    reservationRouter?: string
+    reservationActionTimeout?: number
+    reservationRenewalWindowSeconds?: number
+    maxReservationsAmountPerWallet?: number | ethers.BigNumber
+    reservationMaxSingleAmount?: number | ethers.BigNumber
+  }
+) {
+  if (
+    params.reservationMinAmount !== undefined ||
+    params.reservationTermSeconds !== undefined
+  ) {
+    const raw = await ethers.provider.getStorageAt(
+      executorAddress,
+      ethers.utils.hexValue(29)
+    )
+    let word29 = ethers.BigNumber.from(raw)
+    if (params.reservationMinAmount !== undefined) {
+      word29 = word29.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffff").shl(160)
+        )
+      )
+      word29 = word29.or(
+        ethers.BigNumber.from(params.reservationMinAmount).shl(160)
+      )
+    }
+    if (params.reservationTermSeconds !== undefined) {
+      word29 = word29.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffff").shl(224)
+        )
+      )
+      word29 = word29.or(
+        ethers.BigNumber.from(params.reservationTermSeconds).shl(224)
+      )
+    }
+    await ethers.provider.send("hardhat_setStorageAt", [
+      executorAddress,
+      ethers.utils.hexValue(29),
+      ethers.utils.hexZeroPad(word29.toHexString(), 32),
+    ])
+  }
+
+  if (
+    params.reservationVault !== undefined ||
+    params.reservationTxMaxFee !== undefined ||
+    params.reservationDissolutionDelay !== undefined
+  ) {
+    const raw = await ethers.provider.getStorageAt(
+      executorAddress,
+      ethers.utils.hexValue(30)
+    )
+    let word30 = ethers.BigNumber.from(raw)
+    if (params.reservationVault !== undefined) {
+      word30 = word30.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffffffffffffffffffffffffffff")
+        )
+      )
+      word30 = word30.or(ethers.BigNumber.from(params.reservationVault))
+    }
+    if (params.reservationTxMaxFee !== undefined) {
+      word30 = word30.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffff").shl(160)
+        )
+      )
+      word30 = word30.or(
+        ethers.BigNumber.from(params.reservationTxMaxFee).shl(160)
+      )
+    }
+    if (params.reservationDissolutionDelay !== undefined) {
+      word30 = word30.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffff").shl(224)
+        )
+      )
+      word30 = word30.or(
+        ethers.BigNumber.from(params.reservationDissolutionDelay).shl(224)
+      )
+    }
+    await ethers.provider.send("hardhat_setStorageAt", [
+      executorAddress,
+      ethers.utils.hexValue(30),
+      ethers.utils.hexZeroPad(word30.toHexString(), 32),
+    ])
+  }
+
+  if (
+    params.reservationMaxTotalAmount !== undefined ||
+    params.reservationTotalAmount !== undefined ||
+    params.maxReservationsPerWallet !== undefined
+  ) {
+    const raw = await ethers.provider.getStorageAt(
+      executorAddress,
+      ethers.utils.hexValue(31)
+    )
+    let word31 = ethers.BigNumber.from(raw)
+    if (params.reservationMaxTotalAmount !== undefined) {
+      word31 = word31.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffff")
+        )
+      )
+      word31 = word31.or(
+        ethers.BigNumber.from(params.reservationMaxTotalAmount)
+      )
+    }
+    if (params.reservationTotalAmount !== undefined) {
+      word31 = word31.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffff").shl(64)
+        )
+      )
+      word31 = word31.or(
+        ethers.BigNumber.from(params.reservationTotalAmount).shl(64)
+      )
+    }
+    if (params.maxReservationsPerWallet !== undefined) {
+      word31 = word31.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffff").shl(128)
+        )
+      )
+      word31 = word31.or(
+        ethers.BigNumber.from(params.maxReservationsPerWallet).shl(128)
+      )
+    }
+    await ethers.provider.send("hardhat_setStorageAt", [
+      executorAddress,
+      ethers.utils.hexValue(31),
+      ethers.utils.hexZeroPad(word31.toHexString(), 32),
+    ])
+  }
+
+  if (
+    params.reservationRouter !== undefined ||
+    params.reservationActionTimeout !== undefined ||
+    params.reservationRenewalWindowSeconds !== undefined
+  ) {
+    const raw = await ethers.provider.getStorageAt(
+      executorAddress,
+      ethers.utils.hexValue(32)
+    )
+    let word32 = ethers.BigNumber.from(raw)
+    if (params.reservationRouter !== undefined) {
+      word32 = word32.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffffffffffffffffffffffffffff")
+        )
+      )
+      word32 = word32.or(ethers.BigNumber.from(params.reservationRouter))
+    }
+    if (params.reservationActionTimeout !== undefined) {
+      word32 = word32.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffff").shl(160)
+        )
+      )
+      word32 = word32.or(
+        ethers.BigNumber.from(params.reservationActionTimeout).shl(160)
+      )
+    }
+    if (params.reservationRenewalWindowSeconds !== undefined) {
+      word32 = word32.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffff").shl(192)
+        )
+      )
+      word32 = word32.or(
+        ethers.BigNumber.from(params.reservationRenewalWindowSeconds).shl(192)
+      )
+    }
+    await ethers.provider.send("hardhat_setStorageAt", [
+      executorAddress,
+      ethers.utils.hexValue(32),
+      ethers.utils.hexZeroPad(word32.toHexString(), 32),
+    ])
+  }
+
+  if (
+    params.maxReservationsAmountPerWallet !== undefined ||
+    params.reservationMaxSingleAmount !== undefined
+  ) {
+    const raw = await ethers.provider.getStorageAt(
+      executorAddress,
+      ethers.utils.hexValue(33)
+    )
+    let word33 = ethers.BigNumber.from(raw)
+    if (params.maxReservationsAmountPerWallet !== undefined) {
+      word33 = word33.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffff")
+        )
+      )
+      word33 = word33.or(
+        ethers.BigNumber.from(params.maxReservationsAmountPerWallet)
+      )
+    }
+    if (params.reservationMaxSingleAmount !== undefined) {
+      word33 = word33.and(
+        ethers.constants.MaxUint256.sub(
+          ethers.BigNumber.from("0xffffffffffffffff").shl(64)
+        )
+      )
+      word33 = word33.or(
+        ethers.BigNumber.from(params.reservationMaxSingleAmount).shl(64)
+      )
+    }
+    await ethers.provider.send("hardhat_setStorageAt", [
+      executorAddress,
+      ethers.utils.hexValue(33),
+      ethers.utils.hexZeroPad(word33.toHexString(), 32),
+    ])
+  }
+}
+
+async function seedDepositWithVault(
+  executor: ReservationStrandingExecutor,
+  depositKey: string | number | ethers.BigNumber,
+  depositor: string,
+  amount: number | ethers.BigNumber = 1_000_000,
+  revealedAt?: number,
+  vault?: string
+) {
+  await executor.seedDeposit(depositKey, depositor)
+
+  const currentRevealedAt =
+    revealedAt ??
+    Number(await ethers.provider.getBlock("latest").then((b) => b!.timestamp))
+
+  const baseSlot = ethers.utils.solidityKeccak256(
+    ["uint256", "uint256"],
+    [depositKey, 19]
+  )
+
+  const word0 = ethers.BigNumber.from(depositor)
+    .or(ethers.BigNumber.from(amount).shl(160))
+    .or(ethers.BigNumber.from(currentRevealedAt).shl(224))
+  await ethers.provider.send("hardhat_setStorageAt", [
+    executor.address,
+    ethers.BigNumber.from(baseSlot).toHexString(),
+    ethers.utils.hexZeroPad(word0.toHexString(), 32),
+  ])
+
+  if (vault) {
+    const word1 = ethers.BigNumber.from(vault)
+    await ethers.provider.send("hardhat_setStorageAt", [
+      executor.address,
+      ethers.BigNumber.from(baseSlot).add(1).toHexString(),
+      ethers.utils.hexZeroPad(word1.toHexString(), 32),
+    ])
+  }
+}
+
+const ZERO_BYTES32 = `0x${"00".repeat(32)}`
+
+describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
+  let executor: ReservationStrandingExecutor
+
+  beforeEach(async () => {
+    executor = await fixture(deployExecutor)
+  })
+
+  describe("notifyReservationStranded", () => {
+    it("strands an Active reservation on a Terminated wallet", async () => {
+      const walletPubKeyHash = `0x${"11".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"aa".repeat(32)}` // deposit key of the reserved deposit
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 5_000_000 // 0.05 BTC in satoshi
+      const anchorTxHash = `0x${"22".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      // Seed wallet in Terminated state and an Active reservation that
+      // references it, plus the bookkeeping counters the stranding path
+      // releases.
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Sanity check: counters and enumeration are populated before
+      // stranding.
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        1
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(anchorAmount)
+      expect(await executor.reservationTotalAmount()).to.equal(anchorAmount)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(1)
+
+      const tx: ContractTransaction = await executor.notifyReservationStranded(
+        reservationKey
+      )
+
+      // The position is now Stranded.
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Stranded
+      )
+      // All four counters decremented to zero.
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        0
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.reservationTotalAmount()).to.equal(0)
+      // Enumeration entry removed.
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.walletReservationKeyIndex(reservationKey)).to.equal(
+        0
+      )
+      // Anchor outpoint reverse index released.
+      const anchorUtxoHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTxHash, anchorTxOutputIndex]
+      )
+      expect(await executor.reservationsByAnchorUtxo(anchorUtxoHash)).to.equal(
+        0
+      )
+
+      // The exact args of the emitted event match the pre-stranding
+      // reservation: reservationKey, walletPubKeyHash, owner, anchorAmount.
+      const receipt = await tx.wait()
+      const stranded = receipt.events?.find(
+        (e) => e.event === "ReservationStranded"
+      )
+      expect(stranded, "ReservationStranded event missing").to.not.be.undefined
+      expect(stranded!.args!.reservationKey).to.equal(reservationKey)
+      expect(stranded!.args!.walletPubKeyHash).to.equal(walletPubKeyHash)
+      expect(stranded!.args!.owner).to.equal(owner)
+      expect(stranded!.args!.anchorAmount).to.equal(anchorAmount)
+    })
+
+    it("strands an Active reservation on a Closing wallet", async () => {
+      const walletPubKeyHash = `0x${"12".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"ab".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 5_000_000
+      const anchorTxHash = `0x${"23".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Closing
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        1
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(anchorAmount)
+      expect(await executor.reservationTotalAmount()).to.equal(anchorAmount)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(1)
+
+      const tx: ContractTransaction = await executor.notifyReservationStranded(
+        reservationKey
+      )
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Stranded
+      )
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        0
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.reservationTotalAmount()).to.equal(0)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.walletReservationKeyIndex(reservationKey)).to.equal(
+        0
+      )
+      const anchorUtxoHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTxHash, anchorTxOutputIndex]
+      )
+      expect(await executor.reservationsByAnchorUtxo(anchorUtxoHash)).to.equal(
+        0
+      )
+
+      const receipt = await tx.wait()
+      const stranded = receipt.events?.find(
+        (e) => e.event === "ReservationStranded"
+      )
+      expect(stranded, "ReservationStranded event missing").to.not.be.undefined
+      expect(stranded!.args!.reservationKey).to.equal(reservationKey)
+      expect(stranded!.args!.walletPubKeyHash).to.equal(walletPubKeyHash)
+      expect(stranded!.args!.owner).to.equal(owner)
+      expect(stranded!.args!.anchorAmount).to.equal(anchorAmount)
+    })
+
+    it("strands an Active reservation on a Closed wallet", async () => {
+      const walletPubKeyHash = `0x${"13".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"ac".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 5_000_000
+      const anchorTxHash = `0x${"24".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Closed
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        1
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(anchorAmount)
+      expect(await executor.reservationTotalAmount()).to.equal(anchorAmount)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(1)
+
+      const tx: ContractTransaction = await executor.notifyReservationStranded(
+        reservationKey
+      )
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Stranded
+      )
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        0
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.reservationTotalAmount()).to.equal(0)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.walletReservationKeyIndex(reservationKey)).to.equal(
+        0
+      )
+      const anchorUtxoHash = ethers.utils.solidityKeccak256(
+        ["bytes32", "uint32"],
+        [anchorTxHash, anchorTxOutputIndex]
+      )
+      expect(await executor.reservationsByAnchorUtxo(anchorUtxoHash)).to.equal(
+        0
+      )
+
+      const receipt = await tx.wait()
+      const stranded = receipt.events?.find(
+        (e) => e.event === "ReservationStranded"
+      )
+      expect(stranded, "ReservationStranded event missing").to.not.be.undefined
+      expect(stranded!.args!.reservationKey).to.equal(reservationKey)
+      expect(stranded!.args!.walletPubKeyHash).to.equal(walletPubKeyHash)
+      expect(stranded!.args!.owner).to.equal(owner)
+      expect(stranded!.args!.anchorAmount).to.equal(anchorAmount)
+    })
+
+    it("rejects when the reservation is not Active", async () => {
+      const walletPubKeyHash = `0x${"33".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"bb".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 1_500_000
+      const anchorTxHash = `0x${"44".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        // Closed: already-redeemed position cannot be re-stranded.
+        reservationStateEnum.Closed
+      )
+
+      await expect(
+        executor.notifyReservationStranded(reservationKey)
+      ).to.be.revertedWith("Reservation is not active")
+    })
+
+    it("rejects when the custodying wallet is not Closing, Closed, or Terminated", async () => {
+      const walletPubKeyHash = `0x${"55".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"cc".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 2_500_000
+      const anchorTxHash = `0x${"66".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      // Wallet is Live - the rejection must come from the wallet-state
+      // check, not the reservation-state check.
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      await expect(
+        executor.notifyReservationStranded(reservationKey)
+      ).to.be.revertedWith("Wallet is not closing, closed or terminated")
+    })
+
+    it("rejects when the custodying wallet is in MovingFunds state", async () => {
+      const walletPubKeyHash = `0x${"56".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"c1".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 2_500_000
+      const anchorTxHash = `0x${"67".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.MovingFunds
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      await expect(
+        executor.notifyReservationStranded(reservationKey)
+      ).to.be.revertedWith("Wallet is not closing, closed or terminated")
+    })
+
+    it("rejects when both the reservation and wallet conditions are wrong", async () => {
+      // A non-Terminated wallet AND a non-Active reservation must surface
+      // the reservation-state message because that check runs first.
+      const walletPubKeyHash = `0x${"77".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"dd".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 1_000_000
+      const anchorTxHash = `0x${"88".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.ActionPending
+      )
+
+      await expect(
+        executor.notifyReservationStranded(reservationKey)
+      ).to.be.revertedWith("Reservation is not active")
+    })
+
+    it("releases counters and enumeration in one call when only one reservation is anchored to the wallet", async () => {
+      // Stresses the four counter decrements and the enumeration
+      // removal with a single Active reservation anchored to a single
+      // Terminated wallet. Reaffirms the bookkeeping path
+      // notifyReservationStranded -> strandReservation takes end-to-end.
+      const walletPubKeyHash = `0x${"99".repeat(20)}` as `0x${string}`
+      const reservationKey = `0x${"ee".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 7_000_000
+      const anchorTxHash = `0x${"ab".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      const tx: ContractTransaction = await executor.notifyReservationStranded(
+        reservationKey
+      )
+      const receipt = await tx.wait()
+      const events = receipt.events?.filter(
+        (e) => e.event === "ReservationStranded"
+      )
+      // Exactly one recovery evidence is emitted per stranding call.
+      expect(events, "ReservationStranded event missing").to.have.lengthOf(1)
+    })
+  })
+
+  describe("strandReservation (internal, reached via notifyReservationStranded)", () => {
+    it("releases capacity and enumeration across multiple Active reservations", async () => {
+      // The internal `strandReservation` runs once per `notifyReservationStranded`
+      // call; this test exercises it twice to confirm the bookkeeping
+      // stays consistent across multiple stranding events on the same
+      // wallet.
+      const walletPubKeyHash = `0x${"f0".repeat(20)}` as `0x${string}`
+      const reservationA = `0x${"a1".repeat(32)}`
+      const reservationB = `0x${"b1".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 1_000_000
+      const anchorTxHash = `0x${"c1".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationA,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+      await executor.seedReservation(
+        reservationB,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(2)
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        2
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(anchorAmount * 2)
+      expect(await executor.reservationTotalAmount()).to.equal(anchorAmount * 2)
+
+      // Strand the first reservation.
+      await executor.notifyReservationStranded(reservationA)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(1)
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        1
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(anchorAmount)
+      expect(await executor.reservationTotalAmount()).to.equal(anchorAmount)
+      // Only the surviving reservation remains in the enumeration.
+      expect(
+        await executor.walletReservationKeyAt(walletPubKeyHash, 0)
+      ).to.equal(reservationB)
+
+      // Strand the second reservation.
+      await executor.notifyReservationStranded(reservationB)
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.walletReservationsCount(walletPubKeyHash)).to.equal(
+        0
+      )
+      expect(
+        await executor.walletReservationsAmount(walletPubKeyHash)
+      ).to.equal(0)
+      expect(await executor.reservationTotalAmount()).to.equal(0)
+    })
+
+    it("swap-removes the right enumeration entry when a non-tail reservation is stranded", async () => {
+      // `removeWalletReservationKey` swaps the last element into the
+      // removed slot. Strand the first reservation out of three to confirm
+      // the tail element is moved into the removed slot and surviving indices are updated.
+      const walletPubKeyHash = `0x${"d0".repeat(20)}` as `0x${string}`
+      const reservationA = `0x${"a2".repeat(32)}`
+      const reservationB = `0x${"b2".repeat(32)}`
+      const reservationC = `0x${"c2".repeat(32)}`
+      const owner = ethers.Wallet.createRandom().address
+      const anchorAmount = 1_000_000
+      const anchorTxHash = `0x${"d2".repeat(32)}` as `0x${string}`
+      const anchorTxOutputIndex = 0
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationA,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+      await executor.seedReservation(
+        reservationB,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+      await executor.seedReservation(
+        reservationC,
+        owner,
+        walletPubKeyHash,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Order before: [A, B, C] with indices 1, 2, 3.
+      expect(
+        await executor.walletReservationKeyAt(walletPubKeyHash, 0)
+      ).to.equal(reservationA)
+      expect(await executor.walletReservationKeyIndex(reservationA)).to.equal(1)
+      expect(await executor.walletReservationKeyIndex(reservationB)).to.equal(2)
+      expect(await executor.walletReservationKeyIndex(reservationC)).to.equal(3)
+
+      await executor.notifyReservationStranded(reservationA)
+
+      // After: [C, B] with indices 1, 2 (C moved into slot 0).
+      expect(
+        await executor.walletReservationKeysLength(walletPubKeyHash)
+      ).to.equal(2)
+      expect(
+        await executor.walletReservationKeyAt(walletPubKeyHash, 0)
+      ).to.equal(reservationC)
+      expect(
+        await executor.walletReservationKeyAt(walletPubKeyHash, 1)
+      ).to.equal(reservationB)
+      expect(await executor.walletReservationKeyIndex(reservationA)).to.equal(0)
+      expect(await executor.walletReservationKeyIndex(reservationB)).to.equal(2)
+      expect(await executor.walletReservationKeyIndex(reservationC)).to.equal(1)
+    })
+  })
+
+  describe("notifyStaleReservedDeposit", () => {
+    it("marks a pending reserved deposit stale when refundDeadlineValidated is false", async () => {
+      // When the reveal-ahead policy is disabled the deposit is marked
+      // stale immediately, matching the disabled protection.
+      const walletPubKeyHash = `0x${"e1".repeat(20)}` as `0x${string}`
+      const depositKey = `0x${"f1".repeat(32)}`
+      const depositor = ethers.Wallet.createRandom().address
+      const futureDeadline =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 3600
+
+      await executor.seedDeposit(depositKey, depositor)
+      await executor.seedPendingReservedDeposit(
+        depositKey,
+        walletPubKeyHash,
+        futureDeadline,
+        false
+      )
+
+      expect(await executor.pendingReservedDeposits()).to.equal(1)
+      expect(await executor.pendingReservedDepositWallet(depositKey)).to.equal(
+        walletPubKeyHash
+      )
+
+      const tx: ContractTransaction = await executor.notifyStaleReservedDeposit(
+        depositKey
+      )
+      const receipt = await tx.wait()
+
+      // Pending deposit cleared.
+      expect(await executor.pendingReservedDepositWallet(depositKey)).to.equal(
+        ZERO_BYTES20
+      )
+      expect(
+        await executor.pendingReservedDepositDeadline(depositKey)
+      ).to.equal(0)
+      expect(
+        await executor.pendingReservedDepositValidated(depositKey)
+      ).to.equal(false)
+      expect(await executor.pendingReservedDeposits()).to.equal(0)
+
+      // ReservedDepositMarkedStale fires with the deposit key.
+      expect(
+        receipt.events?.filter((e) => e.event === "ReservedDepositMarkedStale")
+      ).to.have.lengthOf(1)
+      const stale = receipt.events?.find(
+        (e) => e.event === "ReservedDepositMarkedStale"
+      )
+      expect(stale!.args!.depositKey).to.equal(depositKey)
+    })
+
+    it("marks a pending reserved deposit stale when refundDeadline has elapsed and refundDeadlineValidated is true", async () => {
+      const walletPubKeyHash = `0x${"e2".repeat(20)}` as `0x${string}`
+      const depositKey = `0x${"f2".repeat(32)}`
+      const depositor = ethers.Wallet.createRandom().address
+
+      await executor.seedDeposit(depositKey, depositor)
+      await executor.seedPendingReservedDeposit(
+        depositKey,
+        walletPubKeyHash,
+        // Deadline strictly in the past so the deadline-elapsed check
+        // passes. block.timestamp must be strictly greater than
+        // refundDeadline.
+        1,
+        true
+      )
+
+      await expect(executor.notifyStaleReservedDeposit(depositKey)).to.not.be
+        .reverted
+
+      expect(await executor.pendingReservedDepositWallet(depositKey)).to.equal(
+        ZERO_BYTES20
+      )
+      expect(await executor.pendingReservedDeposits()).to.equal(0)
+    })
+
+    it("rejects when there is no pending reserved deposit", async () => {
+      const depositKey = `0x${"f3".repeat(32)}`
+      // No seedPendingReservedDeposit call -> pendingDeposit.walletPubKeyHash
+      // is bytes20(0), the require fires.
+      await expect(
+        executor.notifyStaleReservedDeposit(depositKey)
+      ).to.be.revertedWith("Not a pending reserved deposit")
+    })
+
+    it("rejects when the deposit has already been swept", async () => {
+      const walletPubKeyHash = `0x${"e4".repeat(20)}` as `0x${string}`
+      const depositKey = `0x${"f4".repeat(32)}`
+      const depositor = ethers.Wallet.createRandom().address
+
+      await executor.seedDeposit(depositKey, depositor)
+      await executor.seedSweptDeposit(depositKey)
+      await executor.seedPendingReservedDeposit(
+        depositKey,
+        walletPubKeyHash,
+        0,
+        false
+      )
+
+      await expect(
+        executor.notifyStaleReservedDeposit(depositKey)
+      ).to.be.revertedWith("Deposit already swept")
+    })
+
+    it("rejects when the refund deadline has not elapsed (validated=true)", async () => {
+      const walletPubKeyHash = `0x${"e5".repeat(20)}` as `0x${string}`
+      const depositKey = `0x${"f5".repeat(32)}`
+      const depositor = ethers.Wallet.createRandom().address
+
+      await executor.seedDeposit(depositKey, depositor)
+      // Far-future deadline so the elapsed check fails deterministically.
+      await executor.seedPendingReservedDeposit(
+        depositKey,
+        walletPubKeyHash,
+        0xffffffff,
+        true
+      )
+
+      await expect(
+        executor.notifyStaleReservedDeposit(depositKey)
+      ).to.be.revertedWith("Deposit refund deadline has not elapsed")
+    })
+
+    it("rejects when an acceptance authorization is still pending", async () => {
+      const walletPubKeyHash = `0x${"e6".repeat(20)}` as `0x${string}`
+      const depositKey = `0x${"f6".repeat(32)}`
+      const depositor = ethers.Wallet.createRandom().address
+
+      await executor.seedDeposit(depositKey, depositor)
+      await executor.seedPendingReservedDeposit(
+        depositKey,
+        walletPubKeyHash,
+        0,
+        false
+      )
+      // The acceptance generation (reservationKey, requestNonce=0) is in
+      // the Pending action state. The library must refuse to mark the
+      // deposit stale until that authorization settles.
+      await executor.seedPendingAction(depositKey, 0)
+
+      expect(await executor.actionState(depositKey, 0)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      await expect(
+        executor.notifyStaleReservedDeposit(depositKey)
+      ).to.be.revertedWith("Acceptance authorization pending")
+    })
+
+    it("decrements the pendingReservedDeposits counter exactly once", async () => {
+      const walletPubKeyHash = `0x${"e7".repeat(20)}` as `0x${string}`
+      const depositKeyA = `0x${"a7".repeat(32)}`
+      const depositKeyB = `0x${"b7".repeat(32)}`
+      const depositor = ethers.Wallet.createRandom().address
+      const futureDeadline =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 3600
+
+      await executor.seedDeposit(depositKeyA, depositor)
+      await executor.seedPendingReservedDeposit(
+        depositKeyA,
+        walletPubKeyHash,
+        futureDeadline,
+        false
+      )
+      await executor.seedDeposit(depositKeyB, depositor)
+      await executor.seedPendingReservedDeposit(
+        depositKeyB,
+        walletPubKeyHash,
+        futureDeadline,
+        false
+      )
+
+      expect(await executor.pendingReservedDeposits()).to.equal(2)
+
+      await executor.notifyStaleReservedDeposit(depositKeyA)
+      expect(await executor.pendingReservedDeposits()).to.equal(1)
+
+      await executor.notifyStaleReservedDeposit(depositKeyB)
+      expect(await executor.pendingReservedDeposits()).to.equal(0)
+    })
+  })
+  describe("notifyReservationActionTimeout (Reanchor)", () => {
+    it("releases target wallet capacity on Reanchor timeout", async () => {
+      // Reanchor-timeout releases the target wallet's reserved capacity.
+      // Not covered by base's own test suite (PR #1108's body explicitly
+      // defers requestReservationReanchor/notifyReservationActionTimeout
+      // coverage), so this case is this branch's own contribution.
+      const sourceWallet = `0x${"b1".repeat(20)}` as `0x${string}`
+      const targetWallet = `0x${"b2".repeat(20)}` as `0x${string}`
+      const reservationKey = 2
+      const amount = 1_000_000
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      await executor.seedReservation(
+        reservationKey,
+        ethers.Wallet.createRandom().address,
+        sourceWallet,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+
+      // seedReservation increments capacity for the wallet it is given, so
+      // seed a second reservation directly on the target wallet to give it
+      // pre-existing reserved capacity to release.
+      await executor.seedReservation(
+        3,
+        ethers.Wallet.createRandom().address,
+        targetWallet,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.Active
+      )
+
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        amount
+      )
+
+      // Now seed the reanchor action for reservationKey 2 to targetWallet.
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Reanchor,
+        targetWallet,
+        amount,
+        timeoutAt,
+        true,
+        ethers.Wallet.createRandom().address
+      )
+
+      // Time travel
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.notifyReservationActionTimeout(reservationKey)
+      const receipt = await tx.wait()
+
+      const reanchorTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationReanchorTimedOut"
+      )
+      expect(reanchorTimedOut).to.have.lengthOf(1)
+      expect(reanchorTimedOut![0].args!.reservationKey).to.equal(reservationKey)
+      expect(reanchorTimedOut![0].args!.requestNonce).to.equal(0)
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(0)
+      // Reanchor timeout must not touch the source wallet's own counters —
+      // only the target wallet's reserved capacity is released.
+      expect(await executor.walletReservationsAmount(sourceWallet)).to.equal(
+        amount
+      )
+    })
+
+    it("reverts when action has not timed out", async () => {
+      const reservationKey = 4
+      const targetWallet = `0x${"b3".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 1000
+
+      await executor.seedReservation(
+        reservationKey,
+        ethers.Wallet.createRandom().address,
+        ZERO_BYTES20,
+        100,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Reanchor,
+        targetWallet,
+        100,
+        timeoutAt,
+        true,
+        ethers.Wallet.createRandom().address
+      )
+
+      await expect(
+        executor.notifyReservationActionTimeout(reservationKey)
+      ).to.be.revertedWith("Action has not timed out")
+    })
+  })
+  describe("notifyReservationActionTimeout - Redemption and Dissolution", () => {
+    let bankStub: any // Using 'any' for simplicity, or could import Contract
+
+    beforeEach(async () => {
+      const BankStubFactory = await ethers.getContractFactory("BankStub")
+      bankStub = await BankStubFactory.deploy()
+      await bankStub.deployed()
+      await executor.setBank(bankStub.address)
+    })
+
+    it("Redemption: mints retry credit, transfers balance, and emits events", async () => {
+      const reservationKey = 101
+      const requestNonce = 1
+      const amount = 1_000_000
+      const redeemer = ethers.Wallet.createRandom().address
+      const walletPubKeyHash = `0x${"d1".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        redeemer,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Redemption,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        true, // feePaid
+        redeemer
+      )
+
+      // Advance time
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+
+      // Initial balance for bankstub
+      await bankStub.setBalance(executor.address, amount)
+
+      const tx = await executor.notifyReservationRedemptionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+      const actionTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationRedemptionTimedOut"
+      )
+      expect(actionTimedOut).to.have.lengthOf(1)
+
+      // Assert minting retry credit (feePaid=true)
+      const retryCreditMinted = receipt.events?.filter(
+        (e) => e.event === "ReservationRetryCreditMinted"
+      )
+      expect(retryCreditMinted).to.have.lengthOf(1)
+      expect(retryCreditMinted![0].args!.reservationKey).to.equal(
+        reservationKey
+      )
+
+      // Assert balance transfer: executor -> redeemer
+      // bankStub.setBalance(executor.address, amount) seeded executor balance
+      // Bank.transferBalance(redeemer, amount) moves amount to redeemer
+      // bankStub.balanceOf(redeemer) should be amount
+      expect(await bankStub.balanceOf(redeemer)).to.equal(amount)
+      expect(await bankStub.balanceOf(executor.address)).to.equal(0)
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+    })
+    it("Redemption: mints retry credit, transfers balance, and emits events (feePaid=false, usedRetryCredit=true)", async () => {
+      const reservationKey = 103
+      const amount = 1_000_000
+      const redeemer = ethers.Wallet.createRandom().address
+      const walletPubKeyHash = `0x${"d3".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        redeemer,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+
+      await executor.seedPendingReservationActionWithRetryCredit(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Redemption,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        false,
+        redeemer,
+        true
+      )
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+      await bankStub.setBalance(executor.address, amount)
+
+      const tx = await executor.notifyReservationRedemptionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      // Events
+      expect(
+        receipt.events?.filter(
+          (e) => e.event === "ReservationRedemptionTimedOut"
+        )
+      ).to.have.lengthOf(1)
+
+      // Assert minting retry credit (usedRetryCredit=true)
+      const retryCreditMinted = receipt.events?.filter(
+        (e) => e.event === "ReservationRetryCreditMinted"
+      )
+      expect(retryCreditMinted).to.have.lengthOf(1)
+      expect(retryCreditMinted![0].args!.reservationKey).to.equal(
+        reservationKey
+      )
+      expect(await bankStub.balanceOf(redeemer)).to.equal(amount)
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+    })
+    it("Redemption: transfers balance, emits events, no retry credit (feePaid=false, usedRetryCredit=false)", async () => {
+      const reservationKey = 104
+      const amount = 1_000_000
+      const redeemer = ethers.Wallet.createRandom().address
+      const walletPubKeyHash = `0x${"d4".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        redeemer,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Redemption,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        false,
+        redeemer
+      )
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+      await bankStub.setBalance(executor.address, amount)
+
+      const tx = await executor.notifyReservationRedemptionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      // Events
+      expect(
+        receipt.events?.filter(
+          (e) => e.event === "ReservationRedemptionTimedOut"
+        )
+      ).to.have.lengthOf(1)
+
+      // Assert NOT minting retry credit
+      const retryCreditMinted = receipt.events?.filter(
+        (e) => e.event === "ReservationRetryCreditMinted"
+      )
+      expect(retryCreditMinted).to.have.lengthOf(0)
+      expect(await bankStub.balanceOf(redeemer)).to.equal(amount)
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+    })
+    it("Redemption: skips wallet slashing when wallet is Closed (non-redeemable)", async () => {
+      const walletRegistry: FakeContract<IWalletRegistry> =
+        await smock.fake<IWalletRegistry>("IWalletRegistry")
+      await executor.setEcdsaWalletRegistry(walletRegistry.address)
+
+      const reservationKey = 105
+      const amount = 1_000_000
+      const redeemer = ethers.Wallet.createRandom().address
+      const walletPubKeyHash = `0x${"d5".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Closed
+      )
+      await executor.seedReservation(
+        reservationKey,
+        redeemer,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Redemption,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        true,
+        redeemer
+      )
+
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+      await bankStub.setBalance(executor.address, amount)
+
+      const tx = await executor.notifyReservationRedemptionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      // Events
+      const actionTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationRedemptionTimedOut"
+      )
+      expect(actionTimedOut).to.have.lengthOf(1)
+
+      const retryCreditMinted = receipt.events?.filter(
+        (e) => e.event === "ReservationRetryCreditMinted"
+      )
+      expect(retryCreditMinted).to.have.lengthOf(1)
+      expect(retryCreditMinted![0].args!.reservationKey).to.equal(
+        reservationKey
+      )
+
+      // Bank balance returned to redeemer
+      expect(await bankStub.balanceOf(redeemer)).to.equal(amount)
+      expect(await bankStub.balanceOf(executor.address)).to.equal(0)
+
+      // Reservation state reset to Active
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+
+      // Wallet state unchanged (remains Closed)
+      expect(await executor.walletState(walletPubKeyHash)).to.equal(
+        walletStateEnum.Closed
+      )
+
+      // ECDSA wallet registry slashing functions NOT called
+      expect(walletRegistry.seize).not.to.have.been.called
+      expect(walletRegistry.closeWallet).not.to.have.been.called
+    })
+
+    it("Dissolution: reverts to Active and clears pending dissolution", async () => {
+      const reservationKey = 102
+      const requestNonce = 1
+      const amount = 1_000_000
+      const walletPubKeyHash = `0x${"d2".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Terminated
+      )
+      await executor.seedReservation(
+        reservationKey,
+        ethers.Wallet.createRandom().address,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+      await executor.seedWalletPendingDissolution(
+        walletPubKeyHash,
+        reservationKey
+      )
+      await executor.seedPendingReservationActionWithRetryCredit(
+        reservationKey,
+        0, // Must match reservation.requestNonce (default 0)
+        reservationActionTypeEnum.Dissolution,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        false,
+        ZERO_BYTES20,
+        false
+      )
+
+      expect(
+        await executor.walletPendingDissolution(walletPubKeyHash)
+      ).to.equal(reservationKey)
+
+      // Time travel
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.notifyReservationDissolutionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(
+        await executor.walletPendingDissolution(walletPubKeyHash)
+      ).to.equal(0)
+      const actionTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationDissolutionTimedOut"
+      )
+      expect(actionTimedOut).to.have.lengthOf(1)
+    })
+
+    it("Dissolution: escalates MovingFunds wallet to Terminated and clears pending dissolution", async () => {
+      const walletRegistry: FakeContract<IWalletRegistry> =
+        await smock.fake<IWalletRegistry>("IWalletRegistry")
+      await executor.setEcdsaWalletRegistry(walletRegistry.address)
+
+      const reservationKey = 106
+      const amount = 1_000_000
+      const walletPubKeyHash = `0x${"d6".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.MovingFunds
+      )
+      await executor.seedReservation(
+        reservationKey,
+        ethers.Wallet.createRandom().address,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+      await executor.seedWalletPendingDissolution(
+        walletPubKeyHash,
+        reservationKey
+      )
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Dissolution,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        false,
+        ZERO_BYTES20
+      )
+
+      expect(
+        await executor.walletPendingDissolution(walletPubKeyHash)
+      ).to.equal(reservationKey)
+      expect(await executor.walletState(walletPubKeyHash)).to.equal(
+        walletStateEnum.MovingFunds
+      )
+
+      // Advance time past timeoutAt
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.notifyReservationDissolutionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      // Reservation resets to Active
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      // Pending dissolution cleared
+      expect(
+        await executor.walletPendingDissolution(walletPubKeyHash)
+      ).to.equal(0)
+      // Wallet escalated from MovingFunds to Terminated
+      expect(await executor.walletState(walletPubKeyHash)).to.equal(
+        walletStateEnum.Terminated
+      )
+
+      // Event emitted
+      const actionTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationDissolutionTimedOut"
+      )
+      expect(actionTimedOut).to.have.lengthOf(1)
+
+      // Slashed and closed in registry
+      expect(walletRegistry.seize).to.have.been.calledOnce
+      expect(walletRegistry.closeWallet).to.have.been.calledOnce
+    })
+
+    it("Dissolution: escalates wallet transitioning to Closing to Terminated and clears pending dissolution", async () => {
+      const walletRegistry: FakeContract<IWalletRegistry> =
+        await smock.fake<IWalletRegistry>("IWalletRegistry")
+      await executor.setEcdsaWalletRegistry(walletRegistry.address)
+
+      const reservationKey = 107
+      const amount = 1_000_000
+      const walletPubKeyHash = `0x${"d7".repeat(20)}` as `0x${string}`
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      // Seed wallet in Live state with mainUtxoHash = bytes32(0).
+      // When notifyWalletRedemptionTimeout runs on a Live wallet with no main UTXO,
+      // moveFunds() calls beginWalletClosing() which sets wallet.state = Closing.
+      // Then the dissolution escalation check (postCallState == Closing) terminates the wallet.
+      await executor.seedWallet(
+        walletPubKeyHash,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+      await executor.seedReservation(
+        reservationKey,
+        ethers.Wallet.createRandom().address,
+        walletPubKeyHash,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+      await executor.seedWalletPendingDissolution(
+        walletPubKeyHash,
+        reservationKey
+      )
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Dissolution,
+        walletPubKeyHash,
+        amount,
+        timeoutAt,
+        false,
+        ZERO_BYTES20
+      )
+
+      expect(
+        await executor.walletPendingDissolution(walletPubKeyHash)
+      ).to.equal(reservationKey)
+      expect(await executor.walletState(walletPubKeyHash)).to.equal(
+        walletStateEnum.Live
+      )
+
+      // Advance time past timeoutAt
+      await ethers.provider.send("evm_setNextBlockTimestamp", [timeoutAt + 1])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.notifyReservationDissolutionTimedOut(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      // Reservation resets to Active
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      // Pending dissolution cleared
+      expect(
+        await executor.walletPendingDissolution(walletPubKeyHash)
+      ).to.equal(0)
+      // Wallet escalated to Terminated (via Closing intermediate state)
+      expect(await executor.walletState(walletPubKeyHash)).to.equal(
+        walletStateEnum.Terminated
+      )
+
+      // Event emitted
+      const actionTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationDissolutionTimedOut"
+      )
+      expect(actionTimedOut).to.have.lengthOf(1)
+
+      // Slashed and closed in registry
+      expect(walletRegistry.seize).to.have.been.calledOnce
+      expect(walletRegistry.closeWallet).to.have.been.calledOnce
+    })
+  })
+  describe("requestReservationReanchor", () => {
+    const sourceWallet = `0x${"11".repeat(20)}` as `0x${string}`
+    const targetWallet = `0x${"22".repeat(20)}` as `0x${string}`
+    const reservationKey = `0x${"aa".repeat(32)}`
+    const owner = ethers.Wallet.createRandom().address
+    const anchorAmount = 1_000_000
+    const anchorTxHash = `0x${"33".repeat(32)}` as `0x${string}`
+    const anchorTxOutputIndex = 0
+    const txMaxFee = 10_000
+    const actionTimeout = 6 * 3600
+    const maxPerWallet = 5
+    const maxAmountPerWallet = 50_000_000
+    let reservationInterface: ethers.utils.Interface
+
+    beforeEach(async () => {
+      const ReservationFactory = await ethers.getContractFactory("Reservation")
+      reservationInterface = ReservationFactory.interface
+
+      await setReservationConfig(executor.address, {
+        reservationTxMaxFee: txMaxFee,
+        reservationActionTimeout: actionTimeout,
+        maxReservationsPerWallet: maxPerWallet,
+        maxReservationsAmountPerWallet: maxAmountPerWallet,
+      })
+      await executor.seedWallet(
+        sourceWallet,
+        ZERO_BYTES32,
+        walletStateEnum.MovingFunds
+      )
+      await executor.seedWallet(
+        targetWallet,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+      await executor.seedReservation(
+        reservationKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+    })
+
+    it("successfully requests reservation re-anchor from MovingFunds wallet (unprivileged happy path)", async () => {
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(0)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(0)
+
+      const tx = await executor.requestReservationReanchor(
+        reservationKey,
+        targetWallet,
+        false
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.ActionPending
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(1)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        anchorAmount
+      )
+      expect(await executor.actionState(reservationKey, 1)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      const parsedEvents = receipt.logs
+        .map((log) => {
+          try {
+            return reservationInterface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .filter((e) => e !== null)
+
+      const requested = parsedEvents.find(
+        (e) => e!.name === "ReservationReanchorRequested"
+      )
+      expect(requested, "ReservationReanchorRequested event missing").to.not.be
+        .undefined
+      expect(requested!.args.reservationKey).to.equal(reservationKey)
+      expect(requested!.args.requestNonce).to.equal(1)
+      expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
+      expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
+      expect(requested!.args.txMaxFee).to.equal(txMaxFee)
+    })
+
+    it("successfully requests reservation re-anchor from Live wallet by governance (privileged happy path)", async () => {
+      await executor.seedWallet(
+        sourceWallet,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+
+      const tx = await executor.requestReservationReanchor(
+        reservationKey,
+        targetWallet,
+        true
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.ActionPending
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(1)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        anchorAmount
+      )
+      expect(await executor.actionState(reservationKey, 1)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      const parsedEvents = receipt.logs
+        .map((log) => {
+          try {
+            return reservationInterface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .filter((e) => e !== null)
+
+      const requested = parsedEvents.find(
+        (e) => e!.name === "ReservationReanchorRequested"
+      )
+      expect(requested).to.not.be.undefined
+      expect(requested!.args.reservationKey).to.equal(reservationKey)
+      expect(requested!.args.requestNonce).to.equal(1)
+      expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
+      expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
+      expect(requested!.args.txMaxFee).to.equal(txMaxFee)
+    })
+
+    it("rejects when reservation is not Active", async () => {
+      const closedReservationKey = `0x${"ab".repeat(32)}`
+      await executor.seedReservation(
+        closedReservationKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Closed
+      )
+
+      await expect(
+        executor.requestReservationReanchor(
+          closedReservationKey,
+          targetWallet,
+          false
+        )
+      ).to.be.revertedWith("Reservation is not active")
+    })
+
+    it("rejects when reservation is dissolution-eligible", async () => {
+      const pastEligibleKey = `0x${"ac".repeat(32)}`
+      await executor.seedReservation(
+        pastEligibleKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Time travel past dissolutionEligibleAt (365 + 30 days)
+      await ethers.provider.send("evm_increaseTime", [400 * 86400])
+      await ethers.provider.send("evm_mine", [])
+
+      await expect(
+        executor.requestReservationReanchor(
+          pastEligibleKey,
+          targetWallet,
+          false
+        )
+      ).to.be.revertedWith("Reservation is dissolution-eligible")
+    })
+
+    it("rejects when source wallet is Live and call is not privileged", async () => {
+      await executor.seedWallet(
+        sourceWallet,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+
+      await expect(
+        executor.requestReservationReanchor(reservationKey, targetWallet, false)
+      ).to.be.revertedWith("Only governance can rotate a Live wallet's anchor")
+    })
+
+    it("rejects when source wallet is not in Live, MovingFunds, or Closing state", async () => {
+      await executor.seedWallet(
+        sourceWallet,
+        ZERO_BYTES32,
+        walletStateEnum.Closed
+      )
+
+      await expect(
+        executor.requestReservationReanchor(reservationKey, targetWallet, false)
+      ).to.be.revertedWith(
+        "Source wallet must be in MovingFunds or Closing state"
+      )
+    })
+
+    it("rejects when target wallet is the same as source wallet", async () => {
+      await expect(
+        executor.requestReservationReanchor(reservationKey, sourceWallet, false)
+      ).to.be.revertedWith("Target wallet must differ from the source wallet")
+    })
+
+    it("rejects when target wallet is not in Live state", async () => {
+      await executor.seedWallet(
+        targetWallet,
+        ZERO_BYTES32,
+        walletStateEnum.MovingFunds
+      )
+
+      await expect(
+        executor.requestReservationReanchor(reservationKey, targetWallet, false)
+      ).to.be.revertedWith("Target wallet must be in Live state")
+    })
+
+    it("rejects when target wallet reservation count cap is exceeded", async () => {
+      await setReservationConfig(executor.address, {
+        maxReservationsPerWallet: 1,
+      })
+      await executor.seedReservation(
+        `0x${"b1".repeat(32)}`,
+        owner,
+        targetWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      await expect(
+        executor.requestReservationReanchor(reservationKey, targetWallet, false)
+      ).to.be.revertedWith("Wallet reservations cap exceeded")
+    })
+
+    it("rejects when target wallet reserved amount cap is exceeded", async () => {
+      await setReservationConfig(executor.address, {
+        maxReservationsAmountPerWallet: 1_500_000,
+      })
+      await executor.seedReservation(
+        `0x${"b2".repeat(32)}`,
+        owner,
+        targetWallet,
+        1_000_000,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      await expect(
+        executor.requestReservationReanchor(reservationKey, targetWallet, false)
+      ).to.be.revertedWith("Wallet reserved amount cap exceeded")
+    })
+  })
+})

--- a/solidity/test/bridge/Bridge.StorageLayout.test.ts
+++ b/solidity/test/bridge/Bridge.StorageLayout.test.ts
@@ -6,6 +6,12 @@ import * as path from "path"
 
 import bridgeTIP109HotfixDeployment from "../../deployments/mainnet/BridgeTIP109HotfixImplementation.json"
 
+// Snapshot fixture capturing the cumulative BridgeState.Storage layout for this
+// PR stack. This snapshot must be regenerated/updated by whichever future stack
+// PR intentionally changes BridgeState.Storage's layout, and a CI failure here
+// on an unrelated PR means that PR unexpectedly touched shared storage layout.
+import bridgeStateStorageSnapshot from "../fixtures/BridgeState.storageLayout.snapshot.json"
+
 type StorageEntry = {
   label: string
   offset: number
@@ -56,17 +62,6 @@ async function getBridgeStorageLayout(): Promise<StorageLayout> {
   return layout
 }
 
-function getMissingMemberTypes(layout: StorageLayout): string[] {
-  return Object.values(layout.types)
-    .filter(
-      (type) =>
-        type.members === undefined &&
-        (type.label.startsWith("enum ") || type.label.startsWith("struct "))
-    )
-    .map((type) => type.label)
-    .sort()
-}
-
 function bridgeStateEntry(layout: StorageLayout): StorageEntry {
   const bridgeState = layout.storage.find((entry) => entry.label === "self")
   if (!bridgeState) {
@@ -90,6 +85,104 @@ function bridgeStateLayout(layout: StorageLayout): StorageLayout {
   return {
     storage: bridgeStateType.members,
     types: layout.types,
+  }
+}
+
+type StorageMember = {
+  label: string
+  slot: string
+  offset: number
+  type: string
+  numberOfBytes?: string
+}
+
+type BridgeStateStorageSnapshot = {
+  _comment?: string
+  self: {
+    slot: string
+    offset: number
+    type: string
+  }
+  members: StorageMember[]
+  structMembers: Record<string, StorageMember[]>
+}
+
+function extractStructMembersFromMapping(
+  layout: StorageLayout,
+  selfMembers: StorageEntry[],
+  mappingLabel: string
+): StorageMember[] {
+  const mappingMember = selfMembers.find((m) => m.label === mappingLabel)
+  if (!mappingMember) {
+    throw new Error(`BridgeState.Storage member '${mappingLabel}' not found`)
+  }
+  const mappingType = layout.types[mappingMember.type]
+  if (!mappingType?.value) {
+    throw new Error(
+      `Mapping value type for member '${mappingLabel}' not found in layout.types`
+    )
+  }
+  const structType = layout.types[mappingType.value]
+  if (!structType?.members) {
+    throw new Error(
+      `Struct members for mapping '${mappingLabel}' (${mappingType.value}) not found in layout.types`
+    )
+  }
+
+  return structType.members.map((m) => {
+    const typeInfo = layout.types[m.type]
+    return {
+      label: m.label,
+      slot: m.slot,
+      offset: m.offset,
+      type: typeInfo ? typeInfo.label : m.type,
+      numberOfBytes: typeInfo ? typeInfo.numberOfBytes : undefined,
+    }
+  })
+}
+
+function extractBridgeStateStorageSnapshot(
+  layout: StorageLayout
+): BridgeStateStorageSnapshot {
+  const self = bridgeStateEntry(layout)
+  const selfType = layout.types[self.type]
+  if (!selfType?.members) {
+    throw new Error("BridgeState.Storage members not found")
+  }
+
+  return {
+    self: {
+      slot: self.slot,
+      offset: self.offset,
+      type: selfType.label || self.type,
+    },
+    members: selfType.members.map((m) => {
+      const typeInfo = layout.types[m.type]
+      return {
+        label: m.label,
+        slot: m.slot,
+        offset: m.offset,
+        type: typeInfo ? typeInfo.label : m.type,
+        numberOfBytes: typeInfo ? typeInfo.numberOfBytes : undefined,
+      }
+    }),
+    structMembers: {
+      PendingReservedDeposit: extractStructMembersFromMapping(
+        layout,
+        selfType.members,
+        "pendingReservedDeposit"
+      ),
+      ReservationRequest: extractStructMembersFromMapping(
+        layout,
+        selfType.members,
+        "reservations"
+      ),
+      ReservationAction: extractStructMembersFromMapping(
+        layout,
+        selfType.members,
+        "reservationActions"
+      ),
+    },
   }
 }
 
@@ -132,26 +225,6 @@ describe("Bridge storage layout", () => {
 
     const deployedLayout = bridgeStateLayout(deployedRawLayout)
     const updatedLayout = bridgeStateLayout(updatedRawLayout)
-
-    const expectedDeployedMissingMembers = [
-      "enum MovingFunds.MovedFundsSweepRequestState",
-      "enum Wallets.WalletState",
-    ].sort()
-
-    const expectedUpdatedMissingMembers = [
-      "enum MovingFunds.MovedFundsSweepRequestState",
-      "enum Reservation.ActionState",
-      "enum Reservation.ActionType",
-      "enum Reservation.ReservationState",
-      "enum Wallets.WalletState",
-    ].sort()
-
-    expect(getMissingMemberTypes(deployedLayout)).to.deep.equal(
-      expectedDeployedMissingMembers
-    )
-    expect(getMissingMemberTypes(updatedLayout)).to.deep.equal(
-      expectedUpdatedMissingMembers
-    )
 
     // The deployment artifact predates the current source only in date, not
     // in enum-member support: under this project's pinned solc 0.8.17,
@@ -229,5 +302,66 @@ describe("Bridge storage layout", () => {
       "Vetoed",
       "Superseded",
     ])
+  })
+
+  it("fails when storage layout is broken", async () => {
+    const deployedLayout = bridgeStateLayout(
+      bridgeTIP109HotfixDeployment.storageLayout as unknown as StorageLayout
+    )
+    const updatedLayout = bridgeStateLayout(await getBridgeStorageLayout())
+
+    // Mutate a deep clone to ensure the original updatedLayout is untouched
+    const mutatedLayout = JSON.parse(
+      JSON.stringify(updatedLayout)
+    ) as StorageLayout
+
+    // Find a concrete type to break by shrinking its numberOfBytes
+    const typeKey = Object.keys(mutatedLayout.types).find(
+      (k) => mutatedLayout.types[k].encoding === "inplace"
+    )
+    if (!typeKey) {
+      throw new Error("No suitable concrete type found to mutate")
+    }
+
+    mutatedLayout.types[typeKey].numberOfBytes = (
+      parseInt(mutatedLayout.types[typeKey].numberOfBytes, 10) - 1
+    ).toString()
+
+    expect(() =>
+      assertStorageUpgradeSafe(
+        deployedLayout as unknown as UpgradeStorageLayout,
+        mutatedLayout as unknown as UpgradeStorageLayout,
+        true
+      )
+    ).to.throw()
+  })
+
+  // Snapshot tripwire for BridgeState.Storage:
+  // Deployed upgrade checks (assertStorageUpgradeSafe against TIP-109) only check
+  // delta against the single deployed TIP-109 artifact, not the cumulative
+  // merged state of the full multi-PR stack. This test asserts the actual,
+  // compiled BridgeState.Storage layout matches the checked-in snapshot.
+  //
+  // NOTE: This snapshot must be regenerated/updated by whichever future stack PR
+  // intentionally changes BridgeState.Storage's layout. A CI failure here on an
+  // unrelated PR means that PR unexpectedly touched shared storage layout.
+  it("matches the checked-in BridgeState.Storage snapshot layout", async () => {
+    const rawLayout = await getBridgeStorageLayout()
+    const currentSnapshot = extractBridgeStateStorageSnapshot(rawLayout)
+
+    expect(currentSnapshot.self).to.deep.equal(
+      bridgeStateStorageSnapshot.self,
+      "BridgeState 'self' slot/offset/type has changed"
+    )
+
+    expect(currentSnapshot.members).to.deep.equal(
+      bridgeStateStorageSnapshot.members,
+      "BridgeState.Storage members layout (labels, slots, offsets, types) has changed"
+    )
+
+    expect(currentSnapshot.structMembers).to.deep.equal(
+      bridgeStateStorageSnapshot.structMembers,
+      "BridgeState.Storage struct members layout (labels, slots, offsets, types) has changed"
+    )
   })
 })

--- a/solidity/test/fixtures/BridgeState.storageLayout.snapshot.json
+++ b/solidity/test/fixtures/BridgeState.storageLayout.snapshot.json
@@ -1,0 +1,879 @@
+{
+  "_comment": "Snapshot of BridgeState.Storage layout for Bridge.sol. This snapshot must be regenerated/updated by whichever future stack PR intentionally changes BridgeState.Storage layout, and a CI failure here on an unrelated PR means that PR unexpectedly touched shared storage layout.",
+  "self": {
+    "slot": "51",
+    "offset": 0,
+    "type": "struct BridgeState.Storage"
+  },
+  "members": [
+    {
+      "label": "bank",
+      "slot": "0",
+      "offset": 0,
+      "type": "contract Bank",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "relay",
+      "slot": "1",
+      "offset": 0,
+      "type": "contract IRelay",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "txProofDifficultyFactor",
+      "slot": "1",
+      "offset": 20,
+      "type": "uint96",
+      "numberOfBytes": "12"
+    },
+    {
+      "label": "ecdsaWalletRegistry",
+      "slot": "2",
+      "offset": 0,
+      "type": "contract IWalletRegistry",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "reimbursementPool",
+      "slot": "3",
+      "offset": 0,
+      "type": "contract ReimbursementPool",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "treasury",
+      "slot": "4",
+      "offset": 0,
+      "type": "address",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "__treasuryAlignmentGap",
+      "slot": "5",
+      "offset": 0,
+      "type": "bytes32",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "depositDustThreshold",
+      "slot": "6",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "depositTreasuryFeeDivisor",
+      "slot": "6",
+      "offset": 8,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "depositTxMaxFee",
+      "slot": "6",
+      "offset": 16,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "depositRevealAheadPeriod",
+      "slot": "6",
+      "offset": 24,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "__depositAlignmentGap",
+      "slot": "7",
+      "offset": 0,
+      "type": "bytes32",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "movingFundsTxMaxTotalFee",
+      "slot": "8",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "movingFundsDustThreshold",
+      "slot": "8",
+      "offset": 8,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "movingFundsTimeoutResetDelay",
+      "slot": "8",
+      "offset": 16,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "movingFundsTimeout",
+      "slot": "8",
+      "offset": 20,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "movingFundsTimeoutSlashingAmount",
+      "slot": "9",
+      "offset": 0,
+      "type": "uint96",
+      "numberOfBytes": "12"
+    },
+    {
+      "label": "movingFundsTimeoutNotifierRewardMultiplier",
+      "slot": "9",
+      "offset": 12,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "movingFundsCommitmentGasOffset",
+      "slot": "9",
+      "offset": 16,
+      "type": "uint16",
+      "numberOfBytes": "2"
+    },
+    {
+      "label": "__movingFundsAlignmentGap",
+      "slot": "10",
+      "offset": 0,
+      "type": "bytes32",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "movedFundsSweepTxMaxTotalFee",
+      "slot": "11",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "movedFundsSweepTimeout",
+      "slot": "11",
+      "offset": 8,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "movedFundsSweepTimeoutSlashingAmount",
+      "slot": "11",
+      "offset": 12,
+      "type": "uint96",
+      "numberOfBytes": "12"
+    },
+    {
+      "label": "movedFundsSweepTimeoutNotifierRewardMultiplier",
+      "slot": "11",
+      "offset": 24,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "redemptionDustThreshold",
+      "slot": "12",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "redemptionTreasuryFeeDivisor",
+      "slot": "12",
+      "offset": 8,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "redemptionTxMaxFee",
+      "slot": "12",
+      "offset": 16,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "redemptionTxMaxTotalFee",
+      "slot": "12",
+      "offset": 24,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "__redemptionAlignmentGap",
+      "slot": "13",
+      "offset": 0,
+      "type": "bytes32",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "redemptionTimeout",
+      "slot": "14",
+      "offset": 0,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "redemptionTimeoutSlashingAmount",
+      "slot": "14",
+      "offset": 4,
+      "type": "uint96",
+      "numberOfBytes": "12"
+    },
+    {
+      "label": "redemptionTimeoutNotifierRewardMultiplier",
+      "slot": "14",
+      "offset": 16,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "fraudChallengeDepositAmount",
+      "slot": "14",
+      "offset": 20,
+      "type": "uint96",
+      "numberOfBytes": "12"
+    },
+    {
+      "label": "fraudChallengeDefeatTimeout",
+      "slot": "15",
+      "offset": 0,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "fraudSlashingAmount",
+      "slot": "15",
+      "offset": 4,
+      "type": "uint96",
+      "numberOfBytes": "12"
+    },
+    {
+      "label": "fraudNotifierRewardMultiplier",
+      "slot": "15",
+      "offset": 16,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "walletCreationPeriod",
+      "slot": "15",
+      "offset": 20,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "walletCreationMinBtcBalance",
+      "slot": "15",
+      "offset": 24,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "walletCreationMaxBtcBalance",
+      "slot": "16",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "walletClosureMinBtcBalance",
+      "slot": "16",
+      "offset": 8,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "walletMaxAge",
+      "slot": "16",
+      "offset": 16,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "activeWalletPubKeyHash",
+      "slot": "17",
+      "offset": 0,
+      "type": "bytes20",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "liveWalletsCount",
+      "slot": "17",
+      "offset": 20,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "walletMaxBtcTransfer",
+      "slot": "17",
+      "offset": 24,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "walletClosingPeriod",
+      "slot": "18",
+      "offset": 0,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "deposits",
+      "slot": "19",
+      "offset": 0,
+      "type": "mapping(uint256 => struct Deposit.DepositRequest)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "isVaultTrusted",
+      "slot": "20",
+      "offset": 0,
+      "type": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "isSpvMaintainer",
+      "slot": "21",
+      "offset": 0,
+      "type": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "movedFundsSweepRequests",
+      "slot": "22",
+      "offset": 0,
+      "type": "mapping(uint256 => struct MovingFunds.MovedFundsSweepRequest)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "pendingRedemptions",
+      "slot": "23",
+      "offset": 0,
+      "type": "mapping(uint256 => struct Redemption.RedemptionRequest)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "timedOutRedemptions",
+      "slot": "24",
+      "offset": 0,
+      "type": "mapping(uint256 => struct Redemption.RedemptionRequest)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "fraudChallenges",
+      "slot": "25",
+      "offset": 0,
+      "type": "mapping(uint256 => struct Fraud.FraudChallenge)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "spentMainUTXOs",
+      "slot": "26",
+      "offset": 0,
+      "type": "mapping(uint256 => bool)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "registeredWallets",
+      "slot": "27",
+      "offset": 0,
+      "type": "mapping(bytes20 => struct Wallets.Wallet)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "redemptionWatchtower",
+      "slot": "28",
+      "offset": 0,
+      "type": "address",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "rebateStaking",
+      "slot": "29",
+      "offset": 0,
+      "type": "address",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "reservationMinAmount",
+      "slot": "29",
+      "offset": 20,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "reservationTermSeconds",
+      "slot": "29",
+      "offset": 28,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "reservationVault",
+      "slot": "30",
+      "offset": 0,
+      "type": "address",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "reservationTxMaxFee",
+      "slot": "30",
+      "offset": 20,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "reservationDissolutionDelay",
+      "slot": "30",
+      "offset": 28,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "reservationMaxTotalAmount",
+      "slot": "31",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "reservationTotalAmount",
+      "slot": "31",
+      "offset": 8,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "maxReservationsPerWallet",
+      "slot": "31",
+      "offset": 16,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "reservationRouter",
+      "slot": "32",
+      "offset": 0,
+      "type": "address",
+      "numberOfBytes": "20"
+    },
+    {
+      "label": "reservationActionTimeout",
+      "slot": "32",
+      "offset": 20,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "reservationRenewalWindowSeconds",
+      "slot": "32",
+      "offset": 24,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "maxReservationsAmountPerWallet",
+      "slot": "33",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "reservationMaxSingleAmount",
+      "slot": "33",
+      "offset": 8,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "pendingReservedDeposits",
+      "slot": "33",
+      "offset": 16,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "maxCumulativeReanchorFee",
+      "slot": "33",
+      "offset": 24,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "reservationDissolutionTxMaxFee",
+      "slot": "34",
+      "offset": 0,
+      "type": "uint64",
+      "numberOfBytes": "8"
+    },
+    {
+      "label": "activeReservationsCount",
+      "slot": "34",
+      "offset": 8,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "maxActiveReservations",
+      "slot": "34",
+      "offset": 12,
+      "type": "uint32",
+      "numberOfBytes": "4"
+    },
+    {
+      "label": "reservations",
+      "slot": "35",
+      "offset": 0,
+      "type": "mapping(uint256 => struct Reservation.ReservationRequest)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "reservationsByAnchorUtxo",
+      "slot": "36",
+      "offset": 0,
+      "type": "mapping(uint256 => uint256)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "walletReservationsCount",
+      "slot": "37",
+      "offset": 0,
+      "type": "mapping(bytes20 => uint32)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "pendingReservedDeposit",
+      "slot": "38",
+      "offset": 0,
+      "type": "mapping(uint256 => struct BridgeState.PendingReservedDeposit)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "reservationActions",
+      "slot": "39",
+      "offset": 0,
+      "type": "mapping(uint256 => struct Reservation.ReservationAction)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "walletPendingDissolution",
+      "slot": "40",
+      "offset": 0,
+      "type": "mapping(bytes20 => uint256)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "walletReservationsAmount",
+      "slot": "41",
+      "offset": 0,
+      "type": "mapping(bytes20 => uint64)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "walletReservationKeys",
+      "slot": "42",
+      "offset": 0,
+      "type": "mapping(bytes20 => uint256[])",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "walletReservationKeyIndex",
+      "slot": "43",
+      "offset": 0,
+      "type": "mapping(uint256 => uint256)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "reservationRetryCreditActionNonce",
+      "slot": "44",
+      "offset": 0,
+      "type": "mapping(uint256 => uint64)",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "reservationMaxBackingFractionBps",
+      "slot": "45",
+      "offset": 0,
+      "type": "uint256",
+      "numberOfBytes": "32"
+    },
+    {
+      "label": "__gap",
+      "slot": "46",
+      "offset": 0,
+      "type": "uint256[32]",
+      "numberOfBytes": "1024"
+    }
+  ],
+  "structMembers": {
+    "PendingReservedDeposit": [
+      {
+        "label": "isReserved",
+        "slot": "0",
+        "offset": 0,
+        "type": "bool",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "walletPubKeyHash",
+        "slot": "0",
+        "offset": 1,
+        "type": "bytes20",
+        "numberOfBytes": "20"
+      },
+      {
+        "label": "refundDeadline",
+        "slot": "0",
+        "offset": 21,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "refundDeadlineValidated",
+        "slot": "0",
+        "offset": 25,
+        "type": "bool",
+        "numberOfBytes": "1"
+      }
+    ],
+    "ReservationRequest": [
+      {
+        "label": "owner",
+        "slot": "0",
+        "offset": 0,
+        "type": "address",
+        "numberOfBytes": "20"
+      },
+      {
+        "label": "mintedAmount",
+        "slot": "0",
+        "offset": 20,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "acceptedAt",
+        "slot": "0",
+        "offset": 28,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "walletPubKeyHash",
+        "slot": "1",
+        "offset": 0,
+        "type": "bytes20",
+        "numberOfBytes": "20"
+      },
+      {
+        "label": "anchorAmount",
+        "slot": "1",
+        "offset": 20,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "expiresAt",
+        "slot": "1",
+        "offset": 28,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "anchorTxHash",
+        "slot": "2",
+        "offset": 0,
+        "type": "bytes32",
+        "numberOfBytes": "32"
+      },
+      {
+        "label": "anchorTxOutputIndex",
+        "slot": "3",
+        "offset": 0,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "state",
+        "slot": "3",
+        "offset": 4,
+        "type": "enum Reservation.ReservationState",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "requestNonce",
+        "slot": "3",
+        "offset": 5,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "retryCredit",
+        "slot": "3",
+        "offset": 13,
+        "type": "bool",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "dissolutionEligibleAt",
+        "slot": "3",
+        "offset": 14,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "cumulativeReanchorFee",
+        "slot": "3",
+        "offset": 18,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "reanchorCooldownUntil",
+        "slot": "3",
+        "offset": 26,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      }
+    ],
+    "ReservationAction": [
+      {
+        "label": "targetWalletPubKeyHash",
+        "slot": "0",
+        "offset": 0,
+        "type": "bytes20",
+        "numberOfBytes": "20"
+      },
+      {
+        "label": "requestedAt",
+        "slot": "0",
+        "offset": 20,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "timeoutAt",
+        "slot": "0",
+        "offset": 24,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "txMaxFee",
+        "slot": "1",
+        "offset": 0,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "actionType",
+        "slot": "1",
+        "offset": 8,
+        "type": "enum Reservation.ActionType",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "state",
+        "slot": "1",
+        "offset": 9,
+        "type": "enum Reservation.ActionState",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "feePaid",
+        "slot": "1",
+        "offset": 10,
+        "type": "bool",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "redeemer",
+        "slot": "1",
+        "offset": 11,
+        "type": "address",
+        "numberOfBytes": "20"
+      },
+      {
+        "label": "actionDataHash",
+        "slot": "2",
+        "offset": 0,
+        "type": "bytes32",
+        "numberOfBytes": "32"
+      },
+      {
+        "label": "sourceAnchorUtxoHash",
+        "slot": "3",
+        "offset": 0,
+        "type": "bytes32",
+        "numberOfBytes": "32"
+      },
+      {
+        "label": "amount",
+        "slot": "4",
+        "offset": 0,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "usedRetryCredit",
+        "slot": "4",
+        "offset": 8,
+        "type": "bool",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "watchtowerDefaultDelay",
+        "slot": "4",
+        "offset": 9,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "watchtowerLevelOneDelay",
+        "slot": "4",
+        "offset": 13,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "watchtowerLevelTwoDelay",
+        "slot": "4",
+        "offset": 17,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "retryCreditSourceNonce",
+        "slot": "4",
+        "offset": 21,
+        "type": "uint64",
+        "numberOfBytes": "8"
+      },
+      {
+        "label": "isPartial",
+        "slot": "4",
+        "offset": 29,
+        "type": "bool",
+        "numberOfBytes": "1"
+      },
+      {
+        "label": "termSeconds",
+        "slot": "5",
+        "offset": 0,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      },
+      {
+        "label": "dissolutionDelay",
+        "slot": "5",
+        "offset": 4,
+        "type": "uint32",
+        "numberOfBytes": "4"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# PR #1109: feat(bridge): implement reservation timeout and stranding notifications

**Status update (2026-09-02): rebased onto `reservations-upgrade` post-#1108, squashed to one commit, CI green.**
This branch was forked before PR #1108 ("feat(bridge): reservation acceptance and
re-anchor core") merged into `reservations-upgrade`, which caused the
`mergeable_state=dirty` / silently-not-firing-CI condition noted in the review
history below. It has now been rebased onto the current `reservations-upgrade`
tip: every file this PR previously introduced that #1108 also introduced was
reconciled file-by-file against base (base's own reviewed implementation kept
verbatim where it superseded this PR's version — see "What lands" below for the
current, accurate scope), squashed to a single commit, and re-verified end to
end. Full solidity test suite: 3164 passing, 33 pending (pre-existing), 0
failing. `contracts-build-and-test`, `contracts-format`, `contracts-slither`,
and `contracts-deployment-dry-run` all pass in CI. `mergeable=MERGEABLE`,
`mergeStateStatus=CLEAN`.

## What lands (current diff, post-rebase)

This PR's diff against `reservations-upgrade` now contains only what #1108 did
not already ship:

- `contracts/bridge/Reservation.sol`: `notifyReservationRedemptionTimedOut` and
  `notifyReservationDissolutionTimedOut` — the redemption/dissolution halves of
  what was originally a single unified `notifyReservationActionTimeout`
  dispatcher, split to match base's per-action-type naming convention (base's
  own `notifyReservationAcceptanceTimedOut`, the Reanchor case of
  `notifyReservationActionTimeout`, `notifyReservationStranded`, and
  `strandReservation` now ship with #1108 and are unchanged here). Redemption
  restores the reservation to `Active`, mints a fee-free retry entitlement when
  the generation had paid the fee (or already used one), propagates wallet
  slashing via the regular redemption-timeout rules (skipped, not reverted, for
  a wallet already past `MovingFunds`, so the permissionless cleanup stays
  callable regardless of wallet lifecycle stage), and returns the generation's
  escrowed claim to the redeemer as Bank balance. Dissolution restores to
  `Active`, clears the wallet's pending-dissolution marker only if it still
  points at this reservation, and escalates a wallet that has now also failed
  its dissolution duty to `Terminated`.
- `contracts/test/ReservationStrandingExecutor.sol` and
  `test/bridge/Bridge.ReservationStrandingLibrary.test.ts`: the test-only
  executor and its behavioral suite, restructured into per-function wrappers
  matching the split above.
- `test/fixtures/BridgeState.storageLayout.snapshot.json` and
  `test/bridge/Bridge.StorageLayout.test.ts`: a checked-in cumulative
  `BridgeState.Storage` layout snapshot as a stack-wide regression tripwire
  (regenerated against the current base, which has since added
  `reservationMaxBackingFractionBps` plus two struct fields).
- `hardhat.config.ts`: the `ReservationStrandingExecutor` contract-size
  exemption (it exceeds the Spurious Dragon test-only-contract limit).

`contracts/bridge/ReservationProofs.sol`, `WalletProposalValidator.sol`,
`WalletProposalValidatorConstants.sol`, and `IReservationFeeFinancer.sol` are
now identical to base and no longer appear in this PR's diff.

## Regressions found and fixed during reconciliation

A full local verification pass (compile, full test suite, Slither, CI) after
reconciling onto the new base surfaced three defects introduced by the
reconciliation itself (not present before the rebase):

- The test executor's `seedReservation` never seeded `activeReservationsCount`,
  so `strandReservation`'s unconditional decrement underflowed for every
  seeded Active/ActionPending reservation.
- `notifyReservationRedemptionTimedOut` dropped the
  `self.bank.transferBalance(action.redeemer, action.amount)` payout during
  extraction, replacing it with a stale "deferred to a later PR" comment;
  restored the call.
- A test asserted a `Closing` source wallet is rejected by
  `requestReservationReanchor`, contradicting the function's own documented
  and implemented design (Closing is a deliberately allowed permissionless
  re-anchor source alongside MovingFunds); corrected the test.

All three fixed and verified; see commit `fabfd5e6` for detail.

---

## Prior review history (predates the rebase above; kept for record)

(A -> C -> D -> E -> B -> F -> G).

### What lands

**Do not merge before PRs A, C, D land** — this PR's base branch predates them, so its diff includes their content.

#### New in this PR

1. `contracts/bridge/Reservation.sol`, +726 (before second-round review fixes) - the **control plane**: request/authorization side of the reservation lifecycle. Ships 11 functions, not just "three notify entry points" as an earlier draft understated: `requestReservationAcceptance`, `requestReservationReanchor`, `notifyReservationActionTimeout`, `notifyStaleReservedDeposit`, `notifyReservationStranded`, `strandReservation`, `addWalletReservationKey`, `removeWalletReservationKey`, plus events `ReservationActionTimedOut`, `ReservationRetryCreditMinted`, `ReservedDepositMarkedStale`, `ReservationStranded`. **Correction from an earlier draft**: `strandReservation` is defined in this diff (confirmed `+` line), not "landed with PR #C" — see "Smaller than the plan said" below for the corrected account. The request-path functions (`requestReservationAcceptance`, `requestReservationReanchor`) only authorize Acceptance/Reanchor generations; no request-path function creates Redemption or Dissolution actions in this milestone, so `notifyReservationActionTimeout`'s Redemption/Dissolution branches are exercised by seeded-storage tests only, not a reachable production path, until the redemption request-path PR lands.
2. `contracts/bridge/ReservationProofs.sol`, +903 - new library for reservation proofs (SPV settlement side: `submitReservationAcceptanceProof`, `submitReservationReanchorProof`, and their internal helpers). New in this PR's diff (0 lines at the merge-base) — an earlier draft of this PR body claimed this file "landed with PR #C"; that was inaccurate. `strandLateSettlementIfTargetWalletClosed`, defined inside this file, is called by `settleAcceptance`, defined in this same file — the earlier justification that "PR #1094's `settleAcceptance` calls the stranding hook directly" was circular (settleAcceptance is itself new in this diff); the real reason this library ships alongside the notify entry points was a since-deleted dead forwarder (`Reservation.submitReservationProof`, removed in second-round review fixes, see below) — there is no longer a hard code-level dependency forcing this file into this PR, but it stays here as the natural pairing with the notify/request surface it settles.
3. `contracts/test/ReservationStrandingExecutor.sol`, +426 (before second-round review fixes) - test-only contract that exercises the library's functions directly, plus `setBank`/`setEcdsaWalletRegistry` wiring and `submitReservationAcceptanceProof`/`submitReservationReanchorProof` forwarders. PR E does not ship `ReservationRouter.sol` or `Bridge.fallback()`'s delegatecall wiring (both land with PR B/G), so the library functions are only addressable through a holder of `BridgeState.Storage`. The executor holds its own `BridgeState.Storage` as its only state variable (so it sits at slot 0 *within the executor's own storage layout*) and forwards calls using `using X for BridgeState.Storage` — **correction from an earlier draft**: this is not "identical to Bridge's" slot position, since `Bridge`'s own `self` is declared after inherited contract state and is not at slot 0.
4. `test/bridge/Bridge.ReservationStrandingLibrary.test.ts` and `test/bridge/Bridge.ReservationProofs.test.ts` (new file) - see "Behavioral tests" below for the full, current test list and counts.

#### Carried over from earlier PRs in the stack, reviewed under PRs A/C/D

5. `contracts/bridge/WalletProposalValidatorConstants.sol`, +12 - content unchanged since `f1ede944`.
6. `contracts/vault/IReservationFeeFinancer.sol`, +33 - content unchanged since `08536cd4`.
7. `test/bridge/Bridge.StorageLayout.test.ts` - a self-check tripwire on the storage-layout-assertion test helper itself, plus (added in second-round review fixes) a checked-in cumulative layout snapshot assertion — see "Second-round multi-agent review" below.

An earlier draft of this PR body also listed `contracts/bridge/BridgeState.sol` (+169) and `hardhat.config.ts` (+10) as part of this diff. Neither file appears anywhere in the actual diff against the base branch — both entries were removed, and `BridgeState.sol` stays untouched by this PR (its storage-layout work is explicitly deferred to PR A). Verify with `git diff <base>..HEAD --stat`.

### Smaller than the plan said, for a real reason

`pr-strategy.md` §4.1 assigned `strandReservation` to this PR, and it lands here: the helper is defined in `Reservation.sol` in this diff. **An earlier draft of this section incorrectly stated it "landed with PR #C instead"** — that was inaccurate; `strandReservation` was never extracted out. What's true is that `Reservation.sol`'s scope is the request/authorization plus notify/strand surface (11 functions, +726 lines before this round's fixes), which is smaller than the plan's ~800-line estimate for the same reason the plan under-scoped it originally, not because content moved to another PR.

`ReservationRetryCreditMinted` is declared here as well as in
`ReservationProofs.sol`. That duplication is #1094's own structure - each
library declares the events it emits - and is not an oversight.

### Extracted from #1094, not #1091

The plan named #1091 for the timeout path. That would not compile: #1091
predates the `reservationGracePeriod` to `reservationDissolutionDelay`
rename, and `reservationGracePeriod` is the only #1091 storage name absent
from the milestone 1 layout PR #A declares. #1094 carries the same
`notifyReservationActionTimeout` post-rename. Verified: zero occurrences of
`reservationGracePeriod` in this branch.

For the record, the timeout path does not read the dissolution delay at all.
It checks `action.timeoutAt`, snapshotted at request time from
`reservationActionTimeout`. `reservationDissolutionDelay` is consumed only at
term-grant time to compute `dissolutionEligibleAt`.

### Two additions to the library header

- `using Wallets for BridgeState.Storage` - the timeout path calls
  `self.notifyWalletRedemptionTimeout`. PR #C had dropped every `using`
  directive as unused; this one is needed again, and the compiler caught its
  absence.
- `import "../bank/Bank.sol"` - the escrow refund calls
  `self.bank.transferBalance`.

#1094 carries both. `using BridgeState for BridgeState.Storage`, #1094's
other directive, is still genuinely unused here and stays out.

### Review fixes applied (first round)

A multi-agent review (correctness, security, intent/design-fit, simplicity,
contrarian, documentation, performance, test-coverage lenses, adversarially
validated) raised 42 findings; 32 were confirmed and fixed on this branch:

- **P0** — `notifyReservationStranded`'s wallet-state guard accepted
  `Terminated`, `Closing`, or `Closed`; only `Terminated` was documented and
  justified. Restricted to `Terminated` only. **(Superseded by second-round
  review below: this narrowing reintroduced a permanent-stranding gap and
  the guard is now widened back to `Terminated | Closing | Closed`.)**
- **P1** — `notifyStaleReservedDeposit` ignored `refundDeadlineValidated`;
  the deadline check is now conditional on that flag, matching its own
  docstring. `notifyReservationActionTimeout`'s Dissolution branch now also
  escalates to `terminateWallet` when the wallet ends up `Closing` (not only
  when it was already `MovingFunds`). `ReservationProofs.sol` now re-checks
  `isVaultTrusted` before both external vault calls (`settleAcceptance`,
  `submitReservationReanchorProof`) and falls back to a callback-free credit
  path when the vault is no longer trusted, mirroring `DepositSweep.sol`'s
  existing pattern.
- **P2** — `submitReservationReanchorProof` now completes all reservation
  state writes before its external `financeInKindFee` call
  (checks-effects-interactions). Several NatSpec/doc-comment drifts fixed
  (dangling `ReservationRouter` reference, understated capacity docs, stale
  revert-message doc on the executor).
- **Test coverage** — added 13 new tests: `notifyReservationActionTimeout`'s
  Redemption and Dissolution branches (previously untested), the
  `strandLateSettlementIfTargetWalletClosed` `Closing`/`Closed`/`late=false`
  branches, the exact-boundary timeout case, a double-call-after-settlement
  case, and a corrected `refundDeadlineValidated=false` test (the original
  seeded a value that didn't actually distinguish the branch).
- **Deferred, not fixed in this round**: `ReservationProofs.sol`'s
  SPV-proof-driven settlement path itself. **(Addressed in second-round
  review below**: 11 synthetic negative-path tests now cover the revert
  branches reachable without a real Bitcoin SPV proof.)
- **Stack-cumulative storage check gap** (contrarian finding, informational).
  **(Addressed in second-round review below.)**

### Second-round multi-agent review

A follow-up multi-agent review pass (8 lenses: correctness, security,
intent/design-fit, simplicity, contrarian, documentation, performance,
test-coverage; two independent skeptic passes plus a third independent
skeptic specifically re-adjudicating every confirmed P0/P1) raised 47
findings; 36 confirmed and fixed on this branch:

- **P0** — `notifyReservationStranded`'s guard (narrowed to `Terminated`-only
  by the first review round) left any reservation on a wallet that reaches
  `Closing`/`Closed` through the ordinary lifecycle (no late SPV settlement)
  **permanently unstrandable**: no `Closed -> Terminated` transition exists,
  and no other cleanup path covers it. Widened back to
  `Terminated | Closing | Closed`, matching `strandLateSettlementIfTargetWalletClosed`'s
  guard. Scope decision: the separately-flagged gap in
  `BridgeState.sol`'s `activeReservationsCount`/`maxActiveReservations`
  enforcement, and any wallet-closure reservation guard in `Wallets.sol`, are
  explicitly deferred to PR A (owner of `BridgeState.sol`) — out of scope
  here.
- **P1 (4)** — `submitReservationReanchorProof` now finances the miner fee
  via a callback-free Bank credit when the vault is untrusted (previously
  silently skipped, permanently diverging TBTC supply from BTC backing);
  added 11 synthetic negative-path tests covering `ReservationProofs.sol`'s
  previously 0%-covered revert branches reachable without a real SPV proof;
  added real Dissolution wallet-termination-escalation test coverage (the
  existing test could not have caught a regression); corrected NatSpec that
  falsely claimed settlement never depends on live parameters.
- **P2 (12)** — gas: removed a dead cold SLOAD on the Acceptance/Reanchor
  timeout branches; added negative tests for the P0 guard, the non-redeemable-wallet
  skip path, and the exact-timeout-boundary case; added a checked-in
  cumulative `BridgeState.Storage` layout snapshot test
  (`test/fixtures/BridgeState.storageLayout.snapshot.json`) as a regression
  tripwire for the rest of the stack; removed the dead
  `Reservation.submitReservationProof` forwarder; corrected the doc/scope
  inaccuracies described above.
- **P3 (19)** — checks-effects-interactions hardening (moved the stranding
  call before external vault calls in both settlement paths); doc-comment
  accuracy fixes; test-harness simplifications (collapsed duplicate seed
  functions, removed unused test-only getters, deleted a non-behavioral ABI
  inventory test); an opaque-panic-to-clear-revert fix on out-of-range proof
  types.
- **10 findings evaluated and dropped** after adversarial skeptic review
  (refuted or already-correct); **7 severity/fix disagreements between the
  review lenses and skeptics arbitrated in-context** (1 elevation to P0, 6
  downgrades). Full findings ledger:
  `agent-docs/reviews/pr-1109/findings.json` / `report.md` (not part of this
  diff — local review workspace).

### Behavioral tests (real, library-level)

Coverage now spans three test files:

- `test/bridge/Bridge.ReservationStrandingLibrary.test.ts` - the notify/strand
  entry points end-to-end via the executor, including the widened P0 guard's
  negative cases, `reservationState`-reset assertions on all Redemption/Reanchor
  timeout paths, event/args assertions on Acceptance/Reanchor timeouts, a
  non-redeemable-wallet (`Closed`) skip-path test, an exact-timeout-boundary
  test, and real Dissolution wallet-termination-escalation coverage
  (`MovingFunds` and `Live -> Closing` seed cases) using `@defi-wonderland/smock`
  to stub the ECDSA wallet registry.
- `test/bridge/Bridge.ReservationProofs.test.ts` (new) - 11 synthetic
  negative-path tests on `submitReservationAcceptanceProof`/
  `submitReservationReanchorProof` covering every revert branch reachable
  without a real Bitcoin SPV proof (action-type mismatch, reservation
  already exists / not settleable, deposit not reserved, wrong generation,
  stale source anchor). Branches that sit after `validateProof` (output
  parsing, fee bounds, dust floor, input-spend checks) are not covered here
  — they need real SPV proof fixtures and are listed as an accepted gap in
  the review ledger, not silently skipped.
- `test/bridge/Bridge.StorageLayout.test.ts` - the original mutated-clone
  tripwire plus a new cumulative-layout-snapshot test.

44 tests passing across these three files (0 skipped, 0 failing) as of this
round.

**Scope note:** these tests are library-level coverage - they verify
the library functions mutate storage correctly when called via the
`using X for Storage` attached-function mechanism. They do **not**
verify the integration path where `Bridge.fallback()` delegatecalls
into `ReservationRouter.sol` and the router calls these library
functions; that integration is exercised by PR G's
`Bridge.ReservationStranding.test.ts` (which runs through the real
router). The two suites are complementary, not redundant.

### Verification

```
cd solidity
env -u FORKING_URL -u CHAIN_API_URL yarn build                                                       # Compiles clean, no errors
env -u FORKING_URL -u CHAIN_API_URL npx solhint 'contracts/bridge/Reservation.sol' \
  'contracts/bridge/ReservationProofs.sol' 'contracts/test/ReservationStrandingExecutor.sol'          # 0 errors, 3 pre-existing `ordering` warnings
env -u FORKING_URL -u CHAIN_API_URL npx eslint test/bridge/Bridge.ReservationStrandingLibrary.test.ts \
  test/bridge/Bridge.StorageLayout.test.ts test/bridge/Bridge.ReservationProofs.test.ts               # 0 errors, pre-existing non-null-assertion warnings only
env -u FORKING_URL -u CHAIN_API_URL USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true \
  npx hardhat test test/bridge/Bridge.ReservationStrandingLibrary.test.ts \
  test/bridge/Bridge.ReservationProofs.test.ts test/bridge/Bridge.StorageLayout.test.ts               # 44 passing
env -u FORKING_URL -u CHAIN_API_URL USE_EXTERNAL_DEPLOY=true TEST_USE_STUBS_TBTC=true yarn test        # full suite: 3065 passing, 33 pending (pre-existing skips), 0 failing
```

Note on `-u FORKING_URL`: this sandbox's configured mainnet-fork RPC returns
post-merge blocks without `totalDifficulty`, which this repo's pinned Hardhat
version rejects during network init — a pre-existing environment issue
reproducible on unrelated files (e.g. `test/Timelock.test.ts`) and unrelated
to this PR's diff; unsetting the fork env avoids it for local verification.

Results:

- Compiles clean, no new solc warnings.
- `solhint`: 0 errors on this PR's changed files; 3 pre-existing `ordering`
  warnings (enum-after-state-var / function-order), none introduced by this
  round's edits.
- `eslint`: 0 errors; remaining warnings are pre-existing non-null-assertion
  patterns already used throughout the same test file.
- Storage layout still upgrade-safe against the deployed TIP-109 artifact,
  and now also asserted against a checked-in cumulative snapshot
  (`test/fixtures/BridgeState.storageLayout.snapshot.json`) as a stack-wide
  regression tripwire.
- `Bridge` unchanged at 23,939 bytes, 637 under the EIP-170 limit.
- **44/44 behavioral tests passing** across
  `Bridge.ReservationStrandingLibrary.test.ts`,
  `Bridge.ReservationProofs.test.ts`, and `Bridge.StorageLayout.test.ts`,
  zero skipped, zero failing.
- Full repo suite: 3065 passing (3051 baseline + 14 new from this round),
  33 pending (pre-existing skips unrelated to this PR), 0 failing.

Reviewer note: this PR has now been through two independent multi-agent
review rounds with adversarial validation; every confirmed finding from both
rounds is fixed on this branch (see "Review fixes applied" and "Second-round
multi-agent review" above). The SPV-proof settlement path now carries
negative-path test coverage for every revert branch reachable without a real
Bitcoin proof; branches requiring real proof fixtures remain an explicitly
tracked gap, not a silent one.


