### PR TITLE
docs(solidity): preserve migration spike references

### DIFF
--- a/solidity/docs/hardhat-3-migration.md
+++ b/solidity/docs/hardhat-3-migration.md
@@ -107,7 +107,10 @@ had before:
 
 Item 1 above is the expensive one, and it forks. This section records a spike
 that migrated one real test file to viem so the fork could be priced instead of
-argued. The branch is `chore/solidity-viem-spike`.
+argued. The evidence is preserved in the immutable
+[`3cfc4e4`](https://github.com/threshold-network/tbtc-v2/commit/3cfc4e4e0b9d87f40ee12474f3a361ee1084366f)
+commit from [`#1066`](https://github.com/threshold-network/tbtc-v2/pull/1066);
+the live branch was later reset.
 
 ### A premise worth correcting first
 
@@ -378,10 +381,16 @@ Two things follow that are worth doing regardless of which way this goes:
 - The TypeScript 5 and `strict` work is worth scheduling on its own merits.
   If it lands first, this decision is worth revisiting — most of viem's cost
   is that chain, not viem.
-- `test/helpers/viem.ts` and the interop test should stay on the spike branch
-  rather than being deleted. If the decision is revisited, the matchers and the
-  proof that the mock needs no port are the two things that would otherwise be
-  redone.
+- `test/helpers/viem.ts` and the interop test are preserved in the immutable
+  [`3cfc4e4`](https://github.com/threshold-network/tbtc-v2/commit/3cfc4e4e0b9d87f40ee12474f3a361ee1084366f)
+  spike commit. If the decision is revisited, the matchers and the proof that
+  the mock needs no port are the two things that would otherwise be redone.
+- The incomplete ethers v6 migration is preserved at
+  [`c367c63`](https://github.com/threshold-network/tbtc-v2/commit/c367c63c00ddfaed91d6f14bb3c34714a02bad95)
+  from [`#1067`](https://github.com/threshold-network/tbtc-v2/pull/1067). It
+  reduced the compiler error count from 1,922 to 536 but never completed the
+  typecheck or ran the test suite; use it as migration evidence, not as a merge
+  candidate.
 
 ## What Hardhat 3 is actually worth here
 


### PR DESCRIPTION
## Summary

- replace the reset viem spike branch reference with its immutable pre-reset commit
- preserve the incomplete ethers v6 WIP head as migration evidence
- record that the ethers v6 spike never completed typechecking or ran the test suite

Refs: #1066, #1067

## Verification

- `git diff --check`
- `prettier --check solidity/docs/hardhat-3-migration.md`