### PR TITLE
fix: address PR #1110 review findings (M1/M2/I4/I5)

### DIFF
--- a/solidity/contracts/bridge/BridgeState.sol
+++ b/solidity/contracts/bridge/BridgeState.sol
@@ -34,7 +34,13 @@ library BridgeState {
     ///         permanent; the remaining fields are used by the reservation
     ///         action flow and may be cleared after acceptance or staleness.
     struct PendingReservedDeposit {
-        // Immutable reveal-time reservation classification.
+        // Immutable reveal-time reservation classification: set when a
+        // deposit is revealed to the reservation vault and never cleared.
+        // `notifyStaleReservedDeposit` wipes the three fields below but
+        // deliberately leaves this bit set, so the record stays recognizable
+        // as reservation-routed for the whole life of the deposit. The
+        // stale/acceptable partition is carried by `walletPubKeyHash`, not
+        // by this flag.
         bool isReserved;
         // Wallet committed by the deposit script and therefore the only
         // wallet that can be authorized to anchor the deposit.
@@ -481,7 +487,6 @@ library BridgeState {
         // updates from changing an ordinary deposit into a reservation or
         // making a reserved deposit eligible for an ordinary sweep.
         mapping(uint256 => PendingReservedDeposit) pendingReservedDeposit;
-
         // Collection of all reservation action generation records indexed
         // by `keccak256(reservationKey | requestNonce)`. Each record
         // snapshots every proof- and settlement-critical parameter of one
@@ -515,7 +520,6 @@ library BridgeState {
         // Index-plus-one of each reservation key inside its wallet's
         // `walletReservationKeys` array (zero means absent).
         mapping(uint256 => uint256) walletReservationKeyIndex;
-
         // Generation that minted a reservation's outstanding retry credit.
         // The terminal action record supplies the exact redemption amount
         // and whole/partial shape the fee-free retry must preserve. Zero

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -1039,6 +1039,12 @@ library Reservation {
             pendingDeposit.walletPubKeyHash != bytes20(0),
             "Not a pending reserved deposit"
         );
+        // A non-zero designated wallet implies reveal-time reservation
+        // routing, and no path clears `isReserved` once reveal sets it. Lock
+        // the implication here so a future refactor that re-purposes the flag
+        // - for instance as a not-yet-stale marker - fails loudly instead of
+        // silently redrawing the stale/acceptable partition.
+        assert(pendingDeposit.isReserved);
 
         Deposit.DepositRequest storage deposit = self.deposits[depositKey];
         require(deposit.sweptAt == 0, "Deposit already swept");
@@ -1079,6 +1085,9 @@ library Reservation {
     ///        for storage completeness; unread until renewal lands),
     ///      - `reservationActionTimeout` must exceed the wallet
     ///        validator's final signing safety margin,
+    ///      - `maxReservationsPerWallet` must be greater than zero, so that
+    ///        a parameter update can never become an undeclared halt of all
+    ///        new acceptances and re-anchors,
     ///      - The reservation vault can only be changed while there are no
     ///        active reservations (total reserved amount is zero).
     ///
@@ -1119,6 +1128,10 @@ library Reservation {
             reservationActionTimeout >
                 WalletProposalValidatorConstants.REQUEST_TIMEOUT_SAFETY_MARGIN,
             "Reservation action timeout must exceed the safety margin"
+        );
+        require(
+            maxReservationsPerWallet > 0,
+            "Max reservations per wallet must be greater than zero"
         );
 
         if (reservationVault != self.reservationVault) {

--- a/solidity/test/bridge/Bridge.RouterStorageParity.test.ts
+++ b/solidity/test/bridge/Bridge.RouterStorageParity.test.ts
@@ -1,0 +1,239 @@
+import { artifacts } from "hardhat"
+import { expect } from "chai"
+
+const BRIDGE_SOURCE = "contracts/bridge/Bridge.sol"
+const BRIDGE_CONTRACT = "Bridge"
+const ROUTER_SOURCE = "contracts/bridge/ReservationRouter.sol"
+const ROUTER_CONTRACT = "ReservationRouter"
+
+type StorageEntry = {
+  astId: number
+  contract: string
+  label: string
+  offset: number
+  slot: string
+  type: string
+}
+
+type StorageType = {
+  label: string
+  encoding: string
+  numberOfBytes: string
+  members?: StorageEntry[]
+  key?: string
+  value?: string
+  base?: string
+}
+
+type StorageLayout = {
+  storage: StorageEntry[]
+  types: Record<string, StorageType>
+}
+
+// A storage entry reduced to the facts that must hold across both contracts:
+// where the variable lives, how wide it is, and what it is. `astId` and
+// `contract` are excluded because they identify the declaration site and
+// therefore always differ between two distinct contracts. The raw `type` key
+// is excluded too - see resolveEntries().
+type SlotAssignment = {
+  label: string
+  slot: string
+  offset: number
+  type: string
+  encoding: string
+  numberOfBytes: string
+}
+
+type AstNode = {
+  nodeType: string
+  name?: string
+  nodes?: AstNode[]
+  stateVariable?: boolean
+  mutability?: string
+}
+
+type BuildInfo = NonNullable<Awaited<ReturnType<typeof artifacts.getBuildInfo>>>
+
+// Each contract's layout is read from the build-info job its own artifact
+// points at. Sharing one job between both contracts looks tidier but is
+// unsound: hardhat recompiles incrementally, so after a router-only edit the
+// router's fresh code lands in a new job while every untouched contract still
+// points at the previous one - which holds a stale copy of the router. A
+// comparison sourced from a single job would then silently compare the Bridge
+// against the pre-edit router and pass through exactly the drift it exists to
+// catch.
+async function getBuildInfo(
+  sourceName: string,
+  contractName: string
+): Promise<BuildInfo> {
+  const buildInfo = await artifacts.getBuildInfo(
+    `${sourceName}:${contractName}`
+  )
+  if (!buildInfo) {
+    throw new Error(`No build info for ${sourceName}:${contractName}`)
+  }
+  return buildInfo
+}
+
+function getStorageLayout(
+  buildInfo: BuildInfo,
+  sourceName: string,
+  contractName: string
+): StorageLayout {
+  const contract = buildInfo.output.contracts[sourceName]?.[contractName] as
+    | { storageLayout?: StorageLayout }
+    | undefined
+  if (!contract) {
+    throw new Error(`${sourceName}:${contractName} not in its own build info`)
+  }
+  if (!contract.storageLayout) {
+    throw new Error(`No storage layout for ${sourceName}:${contractName}`)
+  }
+  return contract.storageLayout
+}
+
+// Resolves each entry's type key against its own layout's type table. The keys
+// themselves are not comparable across build-info jobs: solc derives them from
+// AST node ids that are only unique within one compilation, so the very same
+// struct appears as `t_struct(Storage)19357_storage` in one job and
+// `t_struct(Storage)15676_storage` in another. The resolved description -
+// fully qualified name, encoding and width - is stable and is what actually
+// determines the slot a reference lands on.
+function resolveEntries(
+  layout: StorageLayout,
+  entries: StorageEntry[]
+): SlotAssignment[] {
+  return entries.map((entry) => {
+    const type = layout.types[entry.type]
+    if (!type) {
+      throw new Error(`Unknown storage type for \`${entry.label}\``)
+    }
+    return {
+      label: entry.label,
+      slot: entry.slot,
+      offset: entry.offset,
+      type: type.label,
+      encoding: type.encoding,
+      numberOfBytes: type.numberOfBytes,
+    }
+  })
+}
+
+function selfEntry(layout: StorageLayout): StorageEntry {
+  const self = layout.storage.find((entry) => entry.label === "self")
+  if (!self) {
+    throw new Error("BridgeState.Storage anchor `self` not found")
+  }
+  return self
+}
+
+function selfMembers(layout: StorageLayout): StorageEntry[] {
+  const members = layout.types[selfEntry(layout).type]?.members
+  if (!members) {
+    throw new Error("BridgeState.Storage members not found")
+  }
+  return members
+}
+
+// Names of the storage-bearing variables the contract declares itself, in
+// declaration order. Constants and immutables are excluded: they live in code,
+// not in storage, so they cannot shift a slot. Variables inherited from base
+// contracts are excluded too - those are covered by the slot comparison, which
+// sees the fully resolved layout.
+function declaredStateVariables(
+  buildInfo: BuildInfo,
+  sourceName: string,
+  contractName: string
+): string[] {
+  const ast = buildInfo.output.sources[sourceName]?.ast as AstNode | undefined
+  if (!ast?.nodes) {
+    throw new Error(`No AST for ${sourceName}`)
+  }
+  const contract = ast.nodes.find(
+    (node) =>
+      node.nodeType === "ContractDefinition" && node.name === contractName
+  )
+  if (!contract?.nodes) {
+    throw new Error(`Contract definition ${contractName} not found`)
+  }
+  return contract.nodes
+    .filter(
+      (node) =>
+        node.nodeType === "VariableDeclaration" &&
+        node.stateVariable === true &&
+        node.mutability === "mutable"
+    )
+    .map((node) => node.name as string)
+}
+
+// The Bridge routes every call carrying an unmatched selector to the router via
+// `delegatecall`, so router code reads and writes Bridge storage. Any
+// divergence between the layouts the two contracts resolve - a base-contract
+// change on one side, a state variable added to the router - silently corrupts
+// Bridge state on the first routed call. These assertions are the executable
+// form of the storage-parity invariant documented in ReservationRouter.sol.
+describe("Bridge and ReservationRouter storage parity", () => {
+  let bridgeLayout: StorageLayout
+  let routerLayout: StorageLayout
+  let routerBuildInfo: BuildInfo
+
+  before(async () => {
+    const bridgeBuildInfo = await getBuildInfo(BRIDGE_SOURCE, BRIDGE_CONTRACT)
+    routerBuildInfo = await getBuildInfo(ROUTER_SOURCE, ROUTER_CONTRACT)
+
+    bridgeLayout = getStorageLayout(
+      bridgeBuildInfo,
+      BRIDGE_SOURCE,
+      BRIDGE_CONTRACT
+    )
+    routerLayout = getStorageLayout(
+      routerBuildInfo,
+      ROUTER_SOURCE,
+      ROUTER_CONTRACT
+    )
+  })
+
+  it("assigns every storage variable to the same slot in both contracts", async () => {
+    // Element-wise and order-sensitive: equal length rejects a variable added
+    // to either side, and equal entries at equal indices reject a reorder, a
+    // repacking or a type change. Deep equality rather than an upgrade-safety
+    // check, because the router needs strict identity with the Bridge, not the
+    // weaker "safe to append" relation an upgrade check permits.
+    expect(resolveEntries(routerLayout, routerLayout.storage)).to.deep.equal(
+      resolveEntries(bridgeLayout, bridgeLayout.storage)
+    )
+  })
+
+  it("resolves BridgeState.Storage to the same member layout in both contracts", async () => {
+    // Both contracts compile the same BridgeState.sol, so this can only
+    // diverge when one of the two build-info jobs is stale. Comparing the
+    // members turns that staleness into a loud failure instead of a
+    // comparison quietly made against outdated slots.
+    expect(
+      resolveEntries(routerLayout, selfMembers(routerLayout))
+    ).to.deep.equal(resolveEntries(bridgeLayout, selfMembers(bridgeLayout)))
+  })
+
+  it("declares BridgeState.Storage self as the router's only state variable", async () => {
+    // Guards the router side of the invariant on its own terms: new
+    // reservation state belongs in BridgeState.Storage, appended against its
+    // `__gap`, never in a router-local variable.
+    expect(
+      declaredStateVariables(routerBuildInfo, ROUTER_SOURCE, ROUTER_CONTRACT)
+    ).to.deep.equal(["self"])
+  })
+
+  it("anchors self at the same slot and offset in both contracts", async () => {
+    // Redundant with the element-wise comparison today, but pinned separately
+    // because `self` is the single anchor every storage reference in the
+    // reservation code resolves through.
+    const bridgeSelf = selfEntry(bridgeLayout)
+    const routerSelf = selfEntry(routerLayout)
+
+    expect(routerSelf.slot).to.equal(bridgeSelf.slot)
+    expect(routerSelf.offset).to.equal(bridgeSelf.offset)
+    expect(routerLayout.types[routerSelf.type].label).to.equal(
+      bridgeLayout.types[bridgeSelf.type].label
+    )
+  })
+})


### PR DESCRIPTION
## Problem

The consolidated review of PR #1110 (report `20260902070324-pr-1110-review/consolidated-review.md` in the workspace review folder) surfaced six findings across the reservation router extraction. Two are addressed here on top of the reviewed branch; a third (I4, the duplicate `require` in `requestReservationAcceptance`) was already collapsed to a single check by an intermediate commit on the PR head, so it needs nothing further; a fourth (I3, permissionless MovingFunds re-anchor target selection) is a design decision the reviewer flagged as needing human confirmation and is deliberately left untouched here; the fifth is a remark-only (Y2106).

M1 flagged that storage-layout parity between `ReservationRouter` and `Bridge` was asserted only by prose. Because the Bridge fallback delegatecalls into the router, any base-contract shift or a router-local state variable would silently redraw the slot map Bridge storage lives on, latent until the integration PR wires the router in, then permanent-fund-loss risk. M2 flagged that `updateReservationParameters` validated every parameter except `maxReservationsPerWallet`, so a governance update carrying an unset field could freeze all new acceptances without emitting a pause event. I5 flagged that `notifyStaleReservedDeposit` clears three fields of the pending-reserved-deposit record but leaves `isReserved` set, with the invariant living only in a struct-level docstring and no executable lock at the call site.

## Solution

For M1 this stack adds `solidity/test/bridge/Bridge.RouterStorageParity.test.ts`. The test resolves each contract's storage layout from its own build-info job, on the observation that hardhat's incremental compile can leave a router-only edit sitting in a fresh job while every sibling artifact still points at the previous one — comparing through a single shared job would then silently pass the drift the test exists to catch. Layout entries are compared element-wise on label, slot, offset and resolved type description (the raw type keys are not comparable across jobs because solc derives them from AST node ids unique to one compilation), the flattened `BridgeState.Storage` members are compared the same way, the router's AST-declared state variables must equal exactly `["self"]`, and the `self` anchor slot and offset must match on both sides.

For M2 the setter now requires `maxReservationsPerWallet > 0` with a clear revert reason, and the `@dev` NatSpec adds the corresponding invariant bullet. The pre-init zero short-circuits already present in the enforcement paths are deliberately left in place so a fresh `Storage` still behaves as "cap disabled" before the first setter call — the new guard only rejects `0` at the governance entry point.

For I5 the field-level NatSpec on `BridgeState.PendingReservedDeposit.isReserved` now states explicitly that the flag is set at reveal, is never cleared, and that `notifyStaleReservedDeposit` wipes the other three fields but leaves this one set on purpose, so the stale-vs-acceptable partition is carried by `walletPubKeyHash`, not by this flag. `notifyStaleReservedDeposit` also gains a self-documenting `assert(pendingDeposit.isReserved)` so any future refactor that repurposes the flag fails loudly there instead of silently redrawing that partition.

## Tests

`yarn build` succeeds. `yarn test` runs the same suite as before with four additional passing tests from the new parity file — `3139 passing, 38 pending, 2 failing`, where the two failures are pre-existing on the PR head in `Bridge.ReservationCaps.test.ts` (a Decision-1 slot-capacity require the maintainer ported into `updateReservationCaps` but not into `updateReservationParameters`) and are untouched by this stack. `yarn lint` shows the same two pre-existing errors on `Reservation.sol:853` (no-unused-vars) and `ReservationProofs.sol:200` (not-rely-on-time), and prettier is clean on every file this stack changes.

The new parity test was hand-mutated across six scenarios during development — inserting a fake router state variable, reordering an entry, shifting a slot, repacking, retyping, and dropping a field — and every mutation failed at least one of the four assertions. That is not part of the committed test surface; it is the reasoning that establishes the assertions are non-vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWdEVh1gBRqDyTVATnAoEy
