### PR TITLE
fix(bridge): remove dissolution-eligibility gate from requestReservationReanchor

### DIFF
--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -205,6 +205,17 @@ library Reservation {
         // sum would exceed the uint32 ceiling - starting somewhat before
         // February 7th 2106, proportional to the delay applied on top of
         // expiresAt's own margin.
+        // As of this milestone, this field's only on-chain reader —
+        // re-anchor's `< dissolutionEligibleAt` gate in
+        // `requestReservationReanchor` — has been removed. The field is
+        // written by `settleAcceptance` (ReservationProofs.sol:579) but
+        // read by nothing in m1. It must continue to be written anyway: per
+        // m1-b-implementation.md §4.4, storage-complete means written, not
+        // merely declared, and this field is a commitment held in storage
+        // for m2's dissolution feature to honour. m2 must independently
+        // decide whether to restore an eligibility gate on re-anchor when
+        // dissolution ships; this PR's removal defers that design decision
+        // without answering it.
         uint32 dissolutionEligibleAt;
         // Cumulative satoshi lost to Bitcoin miner fees across all
         // re-anchor hops of this reservation. Will be written on every
@@ -716,7 +727,6 @@ library Reservation {
     ///        away from Live wallets.
     /// @dev Requirements:
     ///      - The reservation must be Active,
-    ///      - The reservation must not yet be dissolution-eligible,
     ///      - The source wallet must be in the MovingFunds or Closing state
     ///        (the primary re-anchor path for MovingFunds/Closing is
     ///        permissionless by design, not gated), or Live with the
@@ -729,6 +739,10 @@ library Reservation {
     ///        move; the capacity is reserved by this call and released if
     ///        the authorization times out,
     ///      - The target wallet's amount capacity must allow the move.
+    /// @dev Re-anchor is intentionally unbounded in time in milestone 1,
+    ///      with no dissolution path available yet. Milestone 2 must
+    ///      decide whether to reintroduce a time-based eligibility gate on
+    ///      re-anchor when dissolution ships (see m1-b-implementation.md §6).
     function requestReservationReanchor(
         BridgeState.Storage storage self,
         uint256 reservationKey,

--- a/solidity/contracts/bridge/Reservation.sol
+++ b/solidity/contracts/bridge/Reservation.sol
@@ -749,10 +749,6 @@ library Reservation {
                 "Reanchor cooldown in effect"
             );
         }
-        require(
-            block.timestamp < reservation.dissolutionEligibleAt,
-            "Reservation is dissolution-eligible"
-        );
         /* solhint-enable not-rely-on-time */
 
         {

--- a/solidity/contracts/test/ReservationStrandingExecutor.sol
+++ b/solidity/contracts/test/ReservationStrandingExecutor.sol
@@ -451,6 +451,13 @@ contract ReservationStrandingExecutor {
         self.walletPendingDissolution[walletPubKeyHash] = reservationKey;
     }
 
+    function seedReservationCooldown(
+        uint256 reservationKey,
+        uint32 cooldownUntil
+    ) external {
+        self.reservations[reservationKey].reanchorCooldownUntil = cooldownUntil;
+    }
+
     // --- read helpers used by tests ---------------------------------------
 
     function reservationState(uint256 reservationKey)

--- a/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
@@ -2793,7 +2793,7 @@ describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
       ).to.be.revertedWith("Reservation is not active")
     })
 
-    it("succeeds when reservation is dissolution-eligible (re-anchor is unbounded in time per m1-b-implementation.md §6)", async () => {
+    it("succeeds when reservation is dissolution-eligible (re-anchor is unbounded in time per m1-b-implementation.md §4.4)", async () => {
       const pastEligibleKey = `0x${"ac".repeat(32)}`
       await executor.seedReservation(
         pastEligibleKey,

--- a/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
@@ -2715,7 +2715,7 @@ describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
       ).to.be.revertedWith("Reservation is not active")
     })
 
-    it("rejects when reservation is dissolution-eligible", async () => {
+    it("succeeds when reservation is dissolution-eligible (re-anchor is unbounded in time, m1-b-implementation.md section 1.5)", async () => {
       const pastEligibleKey = `0x${"ac".repeat(32)}`
       await executor.seedReservation(
         pastEligibleKey,
@@ -2727,17 +2727,50 @@ describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
         reservationStateEnum.Active
       )
 
-      // Time travel past dissolutionEligibleAt (365 + 30 days)
+      // Time travel past dissolutionEligibleAt (365 + 30 days). Variant B
+      // deletes the dissolution-eligibility timing gate on re-anchor, so
+      // this must still succeed.
       await ethers.provider.send("evm_increaseTime", [400 * 86400])
       await ethers.provider.send("evm_mine", [])
 
-      await expect(
-        executor.requestReservationReanchor(
-          pastEligibleKey,
-          targetWallet,
-          false
-        )
-      ).to.be.revertedWith("Reservation is dissolution-eligible")
+      const tx = await executor.requestReservationReanchor(
+        pastEligibleKey,
+        targetWallet,
+        false
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(pastEligibleKey)).to.equal(
+        reservationStateEnum.ActionPending
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(1)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        anchorAmount
+      )
+      expect(await executor.actionState(pastEligibleKey, 1)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      const parsedEvents = receipt.logs
+        .map((log) => {
+          try {
+            return reservationInterface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .filter((e) => e !== null)
+
+      const requested = parsedEvents.find(
+        (e) => e!.name === "ReservationReanchorRequested"
+      )
+      expect(requested, "ReservationReanchorRequested event missing").to.not.be
+        .undefined
+      expect(requested!.args.reservationKey).to.equal(pastEligibleKey)
+      expect(requested!.args.requestNonce).to.equal(1)
+      expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
+      expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
+      expect(requested!.args.txMaxFee).to.equal(txMaxFee)
     })
 
     it("rejects when source wallet is Live and call is not privileged", async () => {

--- a/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
+++ b/solidity/test/bridge/Bridge.ReservationStrandingLibrary.test.ts
@@ -1143,6 +1143,84 @@ describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
         executor.notifyReservationActionTimeout(reservationKey, [])
       ).to.be.revertedWith("Action has not timed out")
     })
+
+    it("releases target wallet capacity on Reanchor timeout even after the reservation is dissolution-eligible", async () => {
+      // Confirms that the timeout path is not gated by dissolutionEligibleAt,
+      // mirroring the removal of that gate from requestReservationReanchor.
+      const sourceWallet = `0x${"c1".repeat(20)}` as `0x${string}`
+      const targetWallet = `0x${"c2".repeat(20)}` as `0x${string}`
+      const reservationKey = 5
+      const amount = 1_000_000
+      const timeoutAt =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 100
+
+      await executor.seedReservation(
+        reservationKey,
+        ethers.Wallet.createRandom().address,
+        sourceWallet,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.ActionPending
+      )
+
+      // Seed a second reservation directly on the target wallet to give it
+      // pre-existing reserved capacity to release.
+      await executor.seedReservation(
+        6,
+        ethers.Wallet.createRandom().address,
+        targetWallet,
+        amount,
+        ZERO_BYTES32,
+        0,
+        reservationStateEnum.Active
+      )
+
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        amount
+      )
+
+      // Seed the reanchor action for reservationKey 5 to targetWallet.
+      await executor.seedPendingReservationAction(
+        reservationKey,
+        0,
+        reservationActionTypeEnum.Reanchor,
+        targetWallet,
+        amount,
+        timeoutAt,
+        true,
+        ethers.Wallet.createRandom().address
+      )
+
+      // Time travel past both dissolutionEligibleAt and timeoutAt.
+      await ethers.provider.send("evm_increaseTime", [400 * 86400])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.notifyReservationActionTimeout(
+        reservationKey,
+        []
+      )
+      const receipt = await tx.wait()
+
+      const reanchorTimedOut = receipt.events?.filter(
+        (e) => e.event === "ReservationReanchorTimedOut"
+      )
+      expect(reanchorTimedOut).to.have.lengthOf(1)
+      expect(reanchorTimedOut![0].args!.reservationKey).to.equal(reservationKey)
+      expect(reanchorTimedOut![0].args!.requestNonce).to.equal(0)
+
+      expect(await executor.reservationState(reservationKey)).to.equal(
+        reservationStateEnum.Active
+      )
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(0)
+      // Reanchor timeout must not touch the source wallet's own counters —
+      // only the target wallet's reserved capacity is released.
+      expect(await executor.walletReservationsAmount(sourceWallet)).to.equal(
+        amount
+      )
+    })
   })
   describe("notifyReservationRedemptionTimedOut and notifyReservationDissolutionTimedOut", () => {
     let bankStub: any // Using 'any' for simplicity, or could import Contract
@@ -2715,7 +2793,7 @@ describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
       ).to.be.revertedWith("Reservation is not active")
     })
 
-    it("succeeds when reservation is dissolution-eligible (re-anchor is unbounded in time, m1-b-implementation.md section 1.5)", async () => {
+    it("succeeds when reservation is dissolution-eligible (re-anchor is unbounded in time per m1-b-implementation.md §6)", async () => {
       const pastEligibleKey = `0x${"ac".repeat(32)}`
       await executor.seedReservation(
         pastEligibleKey,
@@ -2771,6 +2849,214 @@ describe("Bridge - Reservation Stranding (PR E library coverage)", () => {
       expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
       expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
       expect(requested!.args.txMaxFee).to.equal(txMaxFee)
+    })
+
+    it("succeeds with re-anchor unbounded far into the future (10 years past dissolution eligibility)", async () => {
+      const farFutureKey = `0x${"ad".repeat(32)}`
+      await executor.seedReservation(
+        farFutureKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Time travel 10 years past dissolutionEligibleAt. Proves re-anchor
+      // is unbounded by time, not just past one arbitrary boundary.
+      await ethers.provider.send("evm_increaseTime", [3650 * 86400])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.requestReservationReanchor(
+        farFutureKey,
+        targetWallet,
+        false
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(farFutureKey)).to.equal(
+        reservationStateEnum.ActionPending
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(1)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        anchorAmount
+      )
+      expect(await executor.actionState(farFutureKey, 1)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      const parsedEvents = receipt.logs
+        .map((log) => {
+          try {
+            return reservationInterface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .filter((e) => e !== null)
+
+      const requested = parsedEvents.find(
+        (e) => e!.name === "ReservationReanchorRequested"
+      )
+      expect(requested, "ReservationReanchorRequested event missing").to.not.be
+        .undefined
+      expect(requested!.args.reservationKey).to.equal(farFutureKey)
+      expect(requested!.args.requestNonce).to.equal(1)
+      expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
+      expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
+      expect(requested!.args.txMaxFee).to.equal(txMaxFee)
+    })
+
+    it("succeeds when reservation is dissolution-eligible and source wallet is Live with a privileged caller", async () => {
+      const pastEligibleKey = `0x${"ae".repeat(32)}`
+      await executor.seedWallet(
+        sourceWallet,
+        ZERO_BYTES32,
+        walletStateEnum.Live
+      )
+      await executor.seedReservation(
+        pastEligibleKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Time travel past dissolutionEligibleAt (365 + 30 days).
+      await ethers.provider.send("evm_increaseTime", [400 * 86400])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.requestReservationReanchor(
+        pastEligibleKey,
+        targetWallet,
+        true
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(pastEligibleKey)).to.equal(
+        reservationStateEnum.ActionPending
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(1)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        anchorAmount
+      )
+      expect(await executor.actionState(pastEligibleKey, 1)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      const parsedEvents = receipt.logs
+        .map((log) => {
+          try {
+            return reservationInterface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .filter((e) => e !== null)
+
+      const requested = parsedEvents.find(
+        (e) => e!.name === "ReservationReanchorRequested"
+      )
+      expect(requested, "ReservationReanchorRequested event missing").to.not.be
+        .undefined
+      expect(requested!.args.reservationKey).to.equal(pastEligibleKey)
+      expect(requested!.args.requestNonce).to.equal(1)
+      expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
+      expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
+      expect(requested!.args.txMaxFee).to.equal(txMaxFee)
+    })
+
+    it("succeeds when reservation is dissolution-eligible and source wallet is Closing", async () => {
+      const pastEligibleKey = `0x${"af".repeat(32)}`
+      await executor.seedWallet(
+        sourceWallet,
+        ZERO_BYTES32,
+        walletStateEnum.Closing
+      )
+      await executor.seedReservation(
+        pastEligibleKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Time travel past dissolutionEligibleAt (365 + 30 days).
+      await ethers.provider.send("evm_increaseTime", [400 * 86400])
+      await ethers.provider.send("evm_mine", [])
+
+      const tx = await executor.requestReservationReanchor(
+        pastEligibleKey,
+        targetWallet,
+        false
+      )
+      const receipt = await tx.wait()
+
+      expect(await executor.reservationState(pastEligibleKey)).to.equal(
+        reservationStateEnum.ActionPending
+      )
+      expect(await executor.walletReservationsCount(targetWallet)).to.equal(1)
+      expect(await executor.walletReservationsAmount(targetWallet)).to.equal(
+        anchorAmount
+      )
+      expect(await executor.actionState(pastEligibleKey, 1)).to.equal(
+        reservationActionStateEnum.Pending
+      )
+
+      const parsedEvents = receipt.logs
+        .map((log) => {
+          try {
+            return reservationInterface.parseLog(log)
+          } catch {
+            return null
+          }
+        })
+        .filter((e) => e !== null)
+
+      const requested = parsedEvents.find(
+        (e) => e!.name === "ReservationReanchorRequested"
+      )
+      expect(requested, "ReservationReanchorRequested event missing").to.not.be
+        .undefined
+      expect(requested!.args.reservationKey).to.equal(pastEligibleKey)
+      expect(requested!.args.requestNonce).to.equal(1)
+      expect(requested!.args.sourceWalletPubKeyHash).to.equal(sourceWallet)
+      expect(requested!.args.targetWalletPubKeyHash).to.equal(targetWallet)
+      expect(requested!.args.txMaxFee).to.equal(txMaxFee)
+    })
+    it("rejects when reanchor cooldown is in effect", async () => {
+      const cooldownKey = `0x${"b0".repeat(32)}`
+      await executor.seedReservation(
+        cooldownKey,
+        owner,
+        sourceWallet,
+        anchorAmount,
+        anchorTxHash,
+        anchorTxOutputIndex,
+        reservationStateEnum.Active
+      )
+
+      // Time travel past dissolutionEligibleAt first, then set the cooldown
+      // to a timestamp still in the future relative to the new block time,
+      // so the cooldown genuinely outlives the dissolution-eligibility
+      // boundary instead of expiring before the call under test.
+      await ethers.provider.send("evm_increaseTime", [400 * 86400])
+      await ethers.provider.send("evm_mine", [])
+
+      const futureTimestamp =
+        Number(
+          await ethers.provider.getBlock("latest").then((b) => b!.timestamp)
+        ) + 1000
+      await executor.seedReservationCooldown(cooldownKey, futureTimestamp)
+
+      await expect(
+        executor.requestReservationReanchor(cooldownKey, targetWallet, false)
+      ).to.be.revertedWith("Reanchor cooldown in effect")
     })
 
     it("rejects when source wallet is Live and call is not privileged", async () => {


### PR DESCRIPTION
## Summary
Variant B's design (`m1-b-implementation.md` §4.4/§6, `m1-tbtc-v2-readiness/03-followup-pr-spec.md` "PR I") makes re-anchor unbounded in time. The `require(block.timestamp < reservation.dissolutionEligibleAt, "Reservation is dissolution-eligible")` gate in `requestReservationReanchor` contradicts that design: once a reservation ages past its dissolution eligibility window, it can never be re-anchored again (not even governance-privileged), until its custodying wallet itself terminates — which is the only path the gate does not block.

Since m1 ships no dissolution or redemption path, that position has no exit for the duration of m1. The gate must go.

## What changed
- **Remove** the `dissolutionEligibleAt` timing gate from `requestReservationReanchor` (`solidity/contracts/bridge/Reservation.sol`, 4 lines deleted).
- `dissolutionEligibleAt`'s struct declaration and its write in `settleAcceptance` (`ReservationProofs.sol:579`) are intentionally **untouched** — m2's dissolution feature still needs to compute and store the value. This PR removes a reader, not the field.
- The neighboring `reanchorCooldownUntil` check stays; the `solhint-disable not-rely-on-time` pair around it is preserved.
- The wallet-state gate below (`Live` requires `privileged`, else `MovingFunds`/`Closing`) is untouched (confirmed correct against D-9).

## Test
- Rewrote the one existing test exercising the removed revert (`Bridge.ReservationStrandingLibrary.test.ts`, "rejects when reservation is dissolution-eligible") to assert success instead: an aged-past-eligibility reservation successfully re-anchors, state moves to `ActionPending`, target wallet counts/amounts update, `ReservationReanchorRequested` event fires with the correct nonce (1) and field values.
- `grep -rn "Reservation is dissolution-eligible" solidity/` returns zero hits (only the removed assertion existed).
- Full reservation test suite passes:
  - `Bridge.ReservationStrandingLibrary.test.ts`
  - `Reservation.test.ts`
  - `ReservationProofs.test.ts`
  - `Bridge.ReservationCaps.test.ts`
  - `Bridge.ReservationOccupancy.test.ts`
  - **175 passing, 0 failing.**
- `prettier --check` clean. `solhint` clean for the touched file (preexisting warning at line 74 unrelated to this change).

## Why a new PR (not an amendment to #1111 or #1112)
The buggy code is in `Reservation.sol` on `reservations-upgrade` at `8f30da66`, the merged tip of PR D (`m1/reanchor-core`). PRs #1111 (`m1/vault-pause-flags`) and #1112 (`m1/bridge-integration-seams`) are stacked on top of it but neither touches `requestReservationReanchor`. There's no open PR whose scope is "fix this file" to amend.

PR #1111 does have its own gap (missing `redeemReservation` / `retryRedeemReservation` in `ReservationVault.sol`) — that is being addressed separately as a commit onto `m1/vault-pause-flags` rather than a new PR, per spec: `docs/spec/reservations/m1-tbtc-v2-readiness/03-followup-pr-spec.md`.

## Out of scope
- The `reanchorCooldownUntil` check three lines above (unrelated, still correct).
- The vault functions on #1111.
- `ReservationVault.sol` changes of any kind.

## Risk
Low. Removes one require statement. The removed assertion was the only test exercising this gate, and the rewritten test asserts the opposite outcome (success), so the test suite explicitly covers the new reachable state. The wallet-state gate below still prevents unauthorized re-anchors from healthy-Live wallets; only the timing window is opened.

## Spec Reference

The specs cited above live in the `keep-core` repo's `docs/spec/reservations/`
tree, not in this `tbtc-v2` checkout, so they are quoted here in full for
independent verification without a second-repo checkout.

**`m1-b-implementation.md` §4.4, "Keep writing `dissolutionEligibleAt`":**
> Acceptance sets `dissolutionEligibleAt = expiresAt + reservationDissolutionDelay`
> (`ReservationProofs.sol:537-539`). B deletes its only reader — re-anchor's
> `< dissolutionEligibleAt` gate — so an essentials-only rewrite would naturally
> drop the write as dead code. Do not. Without it, m2's dissolution has no
> eligibility date for any m1-era position...
>
> The general rule: **storage-complete means written, not merely declared.**
>
> The deeper reason this matters: in m1 B the custody term has no on-chain
> consumer at all. Every reader of `expiresAt` and `dissolutionEligibleAt` is
> cut or deleted... So the term is not enforced by anything in m1; it is a
> **commitment held in storage for m2 to honour**. The storage *is* the
> promise, which makes dropping the write a silent repudiation of it rather
> than a code-size optimisation.

**`m1-b-implementation.md` §6, "What m2 must then build" (inherited decision 1):**
> Whether to restore re-anchor's eligibility gate. B deletes
> `< dissolutionEligibleAt` (`Reservation.sol:785-788`) to make re-anchor
> unbounded, which is what makes dropping dissolution sound. Restoring
> dissolution does not automatically restore the gate, and leaving it out
> means a position can be rotated indefinitely past its eligibility date.

**`m1-tbtc-v2-readiness/03-followup-pr-spec.md`, "PR I: `m1/reanchor-dissolution-gate-fix`", Problem section (this PR's own spec):**
> `m1-b-implementation.md:190-192` states variant B's design deletes
> re-anchor's `< dissolutionEligibleAt` timing gate, making re-anchor
> unbounded in time... **Current behavior:** a reservation that has aged
> past `dissolutionEligibleAt` can never be re-anchored again — not even by
> a `privileged` (governance) caller — while its wallet stays healthy. Since
> m1 ships no dissolution or redemption path, that position has no exit
> until its custodying wallet itself terminates.

This PR implements that spec's "Change" section 1:1 (delete the gate, leave
the field declaration and its write in `settleAcceptance` untouched, rewrite
the one test exercising the removed revert). The follow-up spec's "Non-goals"
and "Acceptance criteria" sections are satisfied by this PR's Test section
above.
