### PR TITLE
fix(starknet): use relayer deposit id in success logs

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -663,7 +663,7 @@ Use StarkNetBitcoinDepositorConfig instead
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L67)
+[lib/starknet/starknet-depositor.ts:66](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L66)
 
 ___
 
@@ -1015,7 +1015,7 @@ Use StarkNetBitcoinDepositor instead
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:527](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L527)
+[lib/starknet/starknet-depositor.ts:501](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L501)
 
 ___
 

--- a/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
+++ b/typescript/api-reference/classes/StarkNetBitcoinDepositor.md
@@ -65,7 +65,7 @@ Error if provider is not provided
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L92)
+[lib/starknet/starknet-depositor.ts:91](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L91)
 
 ## Properties
 
@@ -75,7 +75,7 @@ Error if provider is not provided
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L81)
+[lib/starknet/starknet-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L80)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L80)
+[lib/starknet/starknet-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L79)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:83](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L83)
+[lib/starknet/starknet-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L82)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:79](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L79)
+[lib/starknet/starknet-depositor.ts:78](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L78)
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:82](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L82)
+[lib/starknet/starknet-depositor.ts:81](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L81)
 
 ## Methods
 
@@ -137,7 +137,7 @@ The StarkNetExtraDataEncoder instance.
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L195)
+[lib/starknet/starknet-depositor.ts:194](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L194)
 
 ___
 
@@ -161,7 +161,7 @@ Formatted error message
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:426](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L426)
+[lib/starknet/starknet-depositor.ts:400](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L400)
 
 ___
 
@@ -189,7 +189,7 @@ Error if the address is invalid
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L500)
+[lib/starknet/starknet-depositor.ts:474](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L474)
 
 ___
 
@@ -213,7 +213,7 @@ Always throws since StarkNet deposits are handled via L1.
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:155](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L155)
+[lib/starknet/starknet-depositor.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L154)
 
 ___
 
@@ -231,7 +231,7 @@ The chain name (e.g., "StarkNet")
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:138](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L138)
+[lib/starknet/starknet-depositor.ts:137](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L137)
 
 ___
 
@@ -253,7 +253,7 @@ The StarkNet address set as deposit owner, or undefined if not set.
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:166](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L166)
+[lib/starknet/starknet-depositor.ts:165](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L165)
 
 ___
 
@@ -271,7 +271,7 @@ The StarkNet provider instance
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:146](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L146)
+[lib/starknet/starknet-depositor.ts:145](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L145)
 
 ___
 
@@ -310,7 +310,7 @@ Error if deposit owner not set or relayer returns unexpected response
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:214](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L214)
+[lib/starknet/starknet-depositor.ts:213](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L213)
 
 ___
 
@@ -334,7 +334,7 @@ True if the error is retryable
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:398](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L398)
+[lib/starknet/starknet-depositor.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L372)
 
 ___
 
@@ -364,4 +364,4 @@ Error if the deposit owner is not a StarkNetAddress and not undefined/null.
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:176](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L176)
+[lib/starknet/starknet-depositor.ts:175](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L175)

--- a/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
+++ b/typescript/api-reference/interfaces/StarkNetBitcoinDepositorConfig.md
@@ -18,7 +18,7 @@ Configuration for StarkNetBitcoinDepositor
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L59)
+[lib/starknet/starknet-depositor.ts:58](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L58)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:61](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L61)
+[lib/starknet/starknet-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L60)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[lib/starknet/starknet-depositor.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L60)
+[lib/starknet/starknet-depositor.ts:59](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/starknet/starknet-depositor.ts#L59)

--- a/typescript/src/lib/starknet/starknet-depositor.ts
+++ b/typescript/src/lib/starknet/starknet-depositor.ts
@@ -11,7 +11,6 @@ import { StarkNetProvider } from "./types"
 import { Hex } from "../utils"
 import { packRevealDepositParameters } from "../ethereum"
 import axios from "axios"
-import { ethers } from "ethers"
 import { TransactionReceipt } from "@ethersproject/providers"
 
 /**
@@ -287,31 +286,6 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
           hasReceipt: !!data.receipt,
         })
 
-        // Calculate deposit ID
-        let depositId: string | undefined
-        try {
-          // Get funding transaction hash - concatenate raw hex without 0x prefix
-          const fundingTxComponents =
-            depositTx.version.toString() +
-            depositTx.inputs.toString() +
-            depositTx.outputs.toString() +
-            depositTx.locktime.toString()
-
-          // Apply double SHA-256 (Bitcoin standard)
-          const fundingTxHash = ethers.utils.keccak256(
-            ethers.utils.keccak256("0x" + fundingTxComponents)
-          )
-
-          // Calculate deposit ID
-          const depositIdHash = ethers.utils.solidityKeccak256(
-            ["bytes32", "uint256"],
-            [fundingTxHash, depositOutputIndex]
-          )
-          depositId = ethers.BigNumber.from(depositIdHash).toString()
-        } catch (e) {
-          console.warn("Failed to calculate deposit ID:", e)
-        }
-
         // Validate response
         if (!data.success) {
           throw new Error(
@@ -330,9 +304,9 @@ export class StarkNetBitcoinDepositor implements BitcoinDepositor {
           )
         }
 
-        // Log deposit ID if available
-        if (depositId) {
-          console.log(`Deposit initialized with ID: ${depositId}`)
+        // Use the relayer's authoritative deposit ID when provided.
+        if (data.depositId) {
+          console.log(`Deposit initialized with ID: ${data.depositId}`)
         }
 
         return data.receipt as TransactionReceipt

--- a/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
+++ b/typescript/test/lib/starknet/starknet-depositor-payload.test.ts
@@ -28,7 +28,7 @@ describe("StarkNetDepositor Payload Format", () => {
   })
 
   afterEach(() => {
-    axiosStub.restore()
+    sinon.restore()
   })
 
   it("should include destinationChainDepositOwner in payload", async () => {
@@ -202,47 +202,58 @@ describe("StarkNetDepositor Payload Format", () => {
     expect(payload).to.have.property("l2Sender")
   })
 
-  it("should calculate deposit ID correctly", async () => {
-    // Mock console.log to capture deposit ID
-    const consoleLogStub = sinon.stub(console, "log")
+  for (const { title, depositId, expectedLogs } of [
+    {
+      title: "should log the deposit ID returned by the relayer",
+      depositId: "123456789",
+      expectedLogs: ["Deposit initialized with ID: 123456789"],
+    },
+    {
+      title: "should not invent a deposit ID when the relayer omits it",
+      depositId: undefined,
+      expectedLogs: [],
+    },
+  ]) {
+    it(title, async () => {
+      const consoleLogStub = sinon.stub(console, "log")
+      const receipt = {
+        transactionHash:
+          "0x366220f9853aa8ad83376bcb3fd9377da7b55f03fc3a3aa4aed7b57f7cc60745",
+        blockNumber: 8486402,
+      }
 
-    axiosStub.resolves({
-      data: {
-        success: true,
-        receipt: {
-          transactionHash:
-            "0x366220f9853aa8ad83376bcb3fd9377da7b55f03fc3a3aa4aed7b57f7cc60745",
-          blockNumber: 8486402,
-        },
-      },
+      axiosStub.resolves({
+        data: { success: true, depositId, receipt },
+      })
+
+      const depositTx: BitcoinRawTxVectors = {
+        version: Hex.from("02000000"),
+        inputs: Hex.from("01" + "a".repeat(64)),
+        outputs: Hex.from("02" + "e".repeat(64)),
+        locktime: Hex.from("00000000"),
+      }
+
+      const deposit: DepositReceipt = {
+        depositor: EthereumAddress.from("0x" + "0".repeat(40)),
+        walletPublicKeyHash: Hex.from(
+          "ef5a2946f294f1742a779c9ac034bc3fa5d417b8"
+        ),
+        refundPublicKeyHash: Hex.from(
+          "b4f19a044feea3aa4a7d3f494433a11d0f1c400e"
+        ),
+        blindingFactor: Hex.from("b3460f26eda61ad1"),
+        refundLocktime: Hex.from("a1faa569"),
+        extraData: Hex.from(testAddress),
+      }
+
+      const result = await depositor.initializeDeposit(depositTx, 0, deposit)
+
+      expect(result).to.equal(receipt)
+      const depositIdLogs = consoleLogStub
+        .getCalls()
+        .map((call) => call.args[0])
+        .filter((message) => message.startsWith("Deposit initialized with ID:"))
+      expect(depositIdLogs).to.deep.equal(expectedLogs)
     })
-
-    const depositTx: BitcoinRawTxVectors = {
-      version: Hex.from("02000000"),
-      inputs: Hex.from("01" + "a".repeat(64)),
-      outputs: Hex.from("02" + "e".repeat(64)),
-      locktime: Hex.from("00000000"),
-    }
-
-    const deposit: DepositReceipt = {
-      depositor: EthereumAddress.from("0x" + "0".repeat(40)),
-      walletPublicKeyHash: Hex.from("ef5a2946f294f1742a779c9ac034bc3fa5d417b8"),
-      refundPublicKeyHash: Hex.from("b4f19a044feea3aa4a7d3f494433a11d0f1c400e"),
-      blindingFactor: Hex.from("b3460f26eda61ad1"),
-      refundLocktime: Hex.from("a1faa569"),
-      extraData: Hex.from(testAddress),
-    }
-
-    await depositor.initializeDeposit(depositTx, 0, deposit)
-
-    // Verify deposit ID was logged
-    const depositIdLogCall = consoleLogStub
-      .getCalls()
-      .find((call) => call.args[0]?.includes("Deposit initialized with ID:"))
-
-    expect(depositIdLogCall).to.exist
-    expect(depositIdLogCall!.args[0]).to.include("Deposit initialized with ID:")
-
-    consoleLogStub.restore()
-  })
+  }
 })


### PR DESCRIPTION
StarkNet deposit initialization logs a locally calculated deposit ID even when the relayer returns a different ID or omits it. That calculation is used only for diagnostics, and its double-keccak derivation is unverified and incorrectly described as Bitcoin double-SHA256.

Remove the client-side calculation and its unused ethers import. Log the relayer's `data.depositId` after validating a successful response, and omit the ID log when the relayer provides none. The method continues to return the relayer receipt. Regenerate the API reference source links to match the updated file.

Replace the previous log-prefix-only test with regressions that assert the exact relayer ID and the omitted-ID case, including receipt preservation. Both regressions fail against the original implementation and pass with this fix.

Validation (Node 22, dependencies installed with the unchanged lockfile):

- Targeted StarkNet tests: 145 passing, 2 pending.
- `yarn test`: 684 passing, 63 pending.
- `yarn build`: passed.
- `yarn format` (ESLint and Prettier): passed.
- `yarn docs` followed by `git diff --exit-code`: passed; generated API references are up to date.
- `git diff --check`: passed.

Related to #1038.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deposit confirmations now use the deposit ID returned by the relayer, improving consistency with relayer processing.
  - Deposit confirmations no longer display a deposit ID when the relayer does not provide one.

- **Tests**
  - Added coverage for relayer-provided and missing deposit IDs.
  - Improved test cleanup and validation of deposit initialization results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->