### PR TITLE
feat(sdk): expose redemption completion and timeout events

### DIFF
--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -1833,7 +1833,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:799](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L799)
+[src/lib/ethereum/bridge.ts:847](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L847)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -318,7 +318,7 @@ Represents an event emitted on deposit reveal to the on-chain bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:322](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L322)
+[src/lib/contracts/bridge.ts:346](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L346)
 
 ___
 
@@ -578,7 +578,7 @@ Represents an event emitted when new wallet is registered on the on-chain bridge
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L500)
+[src/lib/contracts/bridge.ts:535](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L535)
 
 ___
 
@@ -649,7 +649,7 @@ Represents an event emitted on redemption request.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:373](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L373)
+[src/lib/contracts/bridge.ts:397](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L397)
 
 ___
 
@@ -657,11 +657,15 @@ ___
 
 Ƭ **RedemptionTimedOutEvent**: [`ChainEvent`](interfaces/ChainEvent.md) & \{ `redeemerOutputScript`: [`Hex`](classes/Hex.md) ; `walletPublicKeyHash`: [`Hex`](classes/Hex.md)  }
 
-A request whose timeout was reported and processed on-chain.
+Represents an event emitted when a redemption request's timeout is
+reported and processed on-chain. Expiration of the redemption timeout
+alone does not emit this event; it fires only once the timeout report is
+accepted. `redeemerOutputScript` is reported without its CompactSize
+length prefix.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:391](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L391)
+[src/lib/contracts/bridge.ts:426](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L426)
 
 ___
 
@@ -669,11 +673,14 @@ ___
 
 Ƭ **RedemptionsCompletedEvent**: [`ChainEvent`](interfaces/ChainEvent.md) & \{ `redemptionTxHash`: [`BitcoinTxHash`](classes/BitcoinTxHash.md) ; `walletPublicKeyHash`: [`Hex`](classes/Hex.md)  }
 
-A Bitcoin redemption transaction whose SPV proof was accepted.
+Represents an event emitted when a redemption transaction's SPV proof is
+accepted on-chain. `redemptionTxHash` is reported in explorer/display byte
+order, i.e. reversed relative to the transaction's internal Bitcoin byte
+order.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:384](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L384)
+[src/lib/contracts/bridge.ts:413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L413)
 
 ___
 
@@ -1833,7 +1840,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:847](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L847)
+[src/lib/ethereum/bridge.ts:864](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L864)
 
 ___
 
@@ -2049,7 +2056,7 @@ This function does not validate the depositor's identifier as its
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L262)
+[src/lib/contracts/bridge.ts:286](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L286)
 
 ___
 

--- a/typescript/api-reference/README.md
+++ b/typescript/api-reference/README.md
@@ -135,6 +135,8 @@
 - [OptimisticMintingRequest](README.md#optimisticmintingrequest)
 - [OptimisticMintingRequestedEvent](README.md#optimisticmintingrequestedevent)
 - [RedemptionRequestedEvent](README.md#redemptionrequestedevent)
+- [RedemptionTimedOutEvent](README.md#redemptiontimedoutevent)
+- [RedemptionsCompletedEvent](README.md#redemptionscompletedevent)
 - [RelayerAbortedError](README.md#relayerabortederror)
 - [RetrierFn](README.md#retrierfn)
 - [StarkNetDepositorConfig](README.md#starknetdepositorconfig)
@@ -316,7 +318,7 @@ Represents an event emitted on deposit reveal to the on-chain bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:307](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L307)
+[src/lib/contracts/bridge.ts:322](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L322)
 
 ___
 
@@ -576,7 +578,7 @@ Represents an event emitted when new wallet is registered on the on-chain bridge
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:471](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L471)
+[src/lib/contracts/bridge.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L500)
 
 ___
 
@@ -647,7 +649,31 @@ Represents an event emitted on redemption request.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:358](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L358)
+[src/lib/contracts/bridge.ts:373](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L373)
+
+___
+
+### RedemptionTimedOutEvent
+
+Ƭ **RedemptionTimedOutEvent**: [`ChainEvent`](interfaces/ChainEvent.md) & \{ `redeemerOutputScript`: [`Hex`](classes/Hex.md) ; `walletPublicKeyHash`: [`Hex`](classes/Hex.md)  }
+
+A request whose timeout was reported and processed on-chain.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:391](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L391)
+
+___
+
+### RedemptionsCompletedEvent
+
+Ƭ **RedemptionsCompletedEvent**: [`ChainEvent`](interfaces/ChainEvent.md) & \{ `redemptionTxHash`: [`BitcoinTxHash`](classes/BitcoinTxHash.md) ; `walletPublicKeyHash`: [`Hex`](classes/Hex.md)  }
+
+A Bitcoin redemption transaction whose SPV proof was accepted.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:384](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L384)
 
 ___
 
@@ -1807,7 +1833,7 @@ Packed parameters.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:723](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L723)
+[src/lib/ethereum/bridge.ts:799](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L799)
 
 ___
 
@@ -2023,7 +2049,7 @@ This function does not validate the depositor's identifier as its
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:247](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L247)
+[src/lib/contracts/bridge.ts:262](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L262)
 
 ___
 

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -39,6 +39,9 @@ for reference.
 - [getEvents](EthereumBridge.md#getevents)
 - [getNewWalletRegisteredEvents](EthereumBridge.md#getnewwalletregisteredevents)
 - [getRedemptionRequestedEvents](EthereumBridge.md#getredemptionrequestedevents)
+- [getRedemptionTimedOutEvents](EthereumBridge.md#getredemptiontimedoutevents)
+- [getRedemptionTimeout](EthereumBridge.md#getredemptiontimeout)
+- [getRedemptionsCompletedEvents](EthereumBridge.md#getredemptionscompletedevents)
 - [getWalletCompressedPublicKey](EthereumBridge.md#getwalletcompressedpublickey)
 - [parseDepositRequest](EthereumBridge.md#parsedepositrequest)
 - [parseRedemptionRequest](EthereumBridge.md#parseredemptionrequest)
@@ -79,7 +82,7 @@ EthersContractHandle\&lt;BridgeTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:65](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L65)
+[src/lib/ethereum/bridge.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L67)
 
 ## Properties
 
@@ -149,7 +152,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:512](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L512)
+[src/lib/ethereum/bridge.ts:517](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L517)
 
 ___
 
@@ -178,7 +181,7 @@ Builds the UTXO hash based on the UTXO components. UTXO hash is computed as
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:652](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L652)
+[src/lib/ethereum/bridge.ts:657](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L657)
 
 ___
 
@@ -205,7 +208,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:447](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L447)
+[src/lib/ethereum/bridge.ts:452](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L452)
 
 ___
 
@@ -247,7 +250,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:92](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L92)
+[src/lib/ethereum/bridge.ts:94](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L94)
 
 ___
 
@@ -274,7 +277,7 @@ Bridge.getDepositRevealedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:100](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L100)
+[src/lib/ethereum/bridge.ts:102](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L102)
 
 ___
 
@@ -335,7 +338,7 @@ Bridge.getNewWalletRegisteredEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:564](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L564)
+[src/lib/ethereum/bridge.ts:569](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L569)
 
 ___
 
@@ -362,7 +365,93 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:669](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L669)
+[src/lib/ethereum/bridge.ts:745](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L745)
+
+___
+
+### getRedemptionTimedOutEvents
+
+▸ **getRedemptionTimedOutEvents**(`options?`, `...filterArgs`): `Promise`\<[`RedemptionTimedOutEvent`](../README.md#redemptiontimedoutevent)[]\>
+
+Reads reported redemption timeout events.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | [`Options`](../interfaces/GetChainEvents.Options.md) | Event query options. |
+| `...filterArgs` | `unknown`[] | Indexed event filters. |
+
+#### Returns
+
+`Promise`\<[`RedemptionTimedOutEvent`](../README.md#redemptiontimedoutevent)[]\>
+
+Timeout events with output scripts without their length prefix.
+
+#### Implementation of
+
+Bridge.getRedemptionTimedOutEvents
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:716](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L716)
+
+___
+
+### getRedemptionTimeout
+
+▸ **getRedemptionTimeout**(`blockNumber?`): `Promise`\<`number`\>
+
+Reads the redemption timeout at the specified block.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `blockNumber?` | `number` | Block to read, or the latest block when omitted. |
+
+#### Returns
+
+`Promise`\<`number`\>
+
+Timeout in seconds.
+
+#### Implementation of
+
+[Bridge](../interfaces/Bridge.md).[getRedemptionTimeout](../interfaces/Bridge.md#getredemptiontimeout)
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:675](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L675)
+
+___
+
+### getRedemptionsCompletedEvents
+
+▸ **getRedemptionsCompletedEvents**(`options?`, `...filterArgs`): `Promise`\<[`RedemptionsCompletedEvent`](../README.md#redemptionscompletedevent)[]\>
+
+Reads accepted redemption proof events.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `options?` | [`Options`](../interfaces/GetChainEvents.Options.md) | Event query options. |
+| `...filterArgs` | `unknown`[] | Indexed event filters. |
+
+#### Returns
+
+`Promise`\<[`RedemptionsCompletedEvent`](../README.md#redemptionscompletedevent)[]\>
+
+Completion events with Bitcoin hashes in display byte order.
+
+#### Implementation of
+
+Bridge.getRedemptionsCompletedEvents
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:690](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L690)
 
 ___
 
@@ -382,7 +471,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:533](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L533)
+[src/lib/ethereum/bridge.ts:538](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L538)
 
 ___
 
@@ -406,7 +495,7 @@ Parsed deposit request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:492](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L492)
+[src/lib/ethereum/bridge.ts:497](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L497)
 
 ___
 
@@ -431,7 +520,7 @@ Parsed redemption request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:233](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L233)
+[src/lib/ethereum/bridge.ts:238](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L238)
 
 ___
 
@@ -455,7 +544,7 @@ Parsed wallet data.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:623](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L623)
+[src/lib/ethereum/bridge.ts:628](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L628)
 
 ___
 
@@ -482,13 +571,13 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:137](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L137)
+[src/lib/ethereum/bridge.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L139)
 
 ___
 
 ### pendingRedemptionsByWalletPKH
 
-▸ **pendingRedemptionsByWalletPKH**(`walletPublicKeyHash`, `redeemerOutputScript`): `Promise`\<[`RedemptionRequest`](../interfaces/RedemptionRequest.md)\>
+▸ **pendingRedemptionsByWalletPKH**(`walletPublicKeyHash`, `redeemerOutputScript`, `blockNumber?`): `Promise`\<[`RedemptionRequest`](../interfaces/RedemptionRequest.md)\>
 
 #### Parameters
 
@@ -496,6 +585,7 @@ ___
 | :------ | :------ |
 | `walletPublicKeyHash` | [`Hex`](Hex.md) |
 | `redeemerOutputScript` | [`Hex`](Hex.md) |
+| `blockNumber?` | `number` |
 
 #### Returns
 
@@ -509,7 +599,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:152](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L152)
+[src/lib/ethereum/bridge.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L154)
 
 ___
 
@@ -538,7 +628,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:352](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L352)
+[src/lib/ethereum/bridge.ts:357](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L357)
 
 ___
 
@@ -567,7 +657,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:251](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L251)
+[src/lib/ethereum/bridge.ts:256](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L256)
 
 ___
 
@@ -596,7 +686,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:288](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L288)
+[src/lib/ethereum/bridge.ts:293](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L293)
 
 ___
 
@@ -625,7 +715,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:396](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L396)
+[src/lib/ethereum/bridge.ts:401](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L401)
 
 ___
 
@@ -652,7 +742,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:175](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L175)
+[src/lib/ethereum/bridge.ts:180](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L180)
 
 ___
 
@@ -672,7 +762,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:338](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L338)
+[src/lib/ethereum/bridge.ts:343](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L343)
 
 ___
 
@@ -692,7 +782,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:589](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L589)
+[src/lib/ethereum/bridge.ts:594](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L594)
 
 ___
 
@@ -718,7 +808,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:606](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L606)
+[src/lib/ethereum/bridge.ts:611](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L611)
 
 ___
 
@@ -743,7 +833,7 @@ Deposit key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:473](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L473)
+[src/lib/ethereum/bridge.ts:478](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L478)
 
 ___
 
@@ -768,4 +858,4 @@ The redemption key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:203](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L203)
+[src/lib/ethereum/bridge.ts:208](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L208)

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -38,6 +38,7 @@ for reference.
 - [getDepositRevealedEvents](EthereumBridge.md#getdepositrevealedevents)
 - [getEvents](EthereumBridge.md#getevents)
 - [getNewWalletRegisteredEvents](EthereumBridge.md#getnewwalletregisteredevents)
+- [getRedemptionEvents](EthereumBridge.md#getredemptionevents)
 - [getRedemptionRequestedEvents](EthereumBridge.md#getredemptionrequestedevents)
 - [getRedemptionTimedOutEvents](EthereumBridge.md#getredemptiontimedoutevents)
 - [getRedemptionTimeout](EthereumBridge.md#getredemptiontimeout)
@@ -82,7 +83,7 @@ EthersContractHandle\&lt;BridgeTypechain\&gt;.constructor
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:67](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L67)
+[src/lib/ethereum/bridge.ts:69](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L69)
 
 ## Properties
 
@@ -152,7 +153,7 @@ EthersContractHandle.\_totalRetryAttempts
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:517](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L517)
+[src/lib/ethereum/bridge.ts:519](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L519)
 
 ___
 
@@ -181,7 +182,7 @@ Builds the UTXO hash based on the UTXO components. UTXO hash is computed as
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:657](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L657)
+[src/lib/ethereum/bridge.ts:659](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L659)
 
 ___
 
@@ -208,7 +209,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:452](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L452)
+[src/lib/ethereum/bridge.ts:454](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L454)
 
 ___
 
@@ -250,7 +251,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:94](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L94)
+[src/lib/ethereum/bridge.ts:96](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L96)
 
 ___
 
@@ -277,7 +278,7 @@ Bridge.getDepositRevealedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:102](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L102)
+[src/lib/ethereum/bridge.ts:104](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L104)
 
 ___
 
@@ -338,7 +339,33 @@ Bridge.getNewWalletRegisteredEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:569](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L569)
+[src/lib/ethereum/bridge.ts:571](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L571)
+
+___
+
+### getRedemptionEvents
+
+▸ **getRedemptionEvents**(`eventName`, `options?`, `...filterArgs`): `Promise`\<`Event`[]\>
+
+Queries redemption lifecycle events with ABI-correct wallet topics.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | ``"RedemptionTimedOut"`` \| ``"RedemptionsCompleted"`` | Name of the lifecycle event. |
+| `options?` | [`Options`](../interfaces/GetChainEvents.Options.md) | Event query options. |
+| `...filterArgs` | `unknown`[] | Indexed event filters. |
+
+#### Returns
+
+`Promise`\<`Event`[]\>
+
+Matching events.
+
+#### Defined in
+
+[src/lib/ethereum/bridge.ts:750](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L750)
 
 ___
 
@@ -365,7 +392,7 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:745](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L745)
+[src/lib/ethereum/bridge.ts:793](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L793)
 
 ___
 
@@ -394,7 +421,7 @@ Bridge.getRedemptionTimedOutEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:716](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L716)
+[src/lib/ethereum/bridge.ts:718](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L718)
 
 ___
 
@@ -422,7 +449,7 @@ Timeout in seconds.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:675](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L675)
+[src/lib/ethereum/bridge.ts:677](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L677)
 
 ___
 
@@ -451,7 +478,7 @@ Bridge.getRedemptionsCompletedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:690](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L690)
+[src/lib/ethereum/bridge.ts:692](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L692)
 
 ___
 
@@ -471,7 +498,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:538](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L538)
+[src/lib/ethereum/bridge.ts:540](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L540)
 
 ___
 
@@ -495,7 +522,7 @@ Parsed deposit request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:497](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L497)
+[src/lib/ethereum/bridge.ts:499](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L499)
 
 ___
 
@@ -520,7 +547,7 @@ Parsed redemption request.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:238](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L238)
+[src/lib/ethereum/bridge.ts:240](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L240)
 
 ___
 
@@ -544,7 +571,7 @@ Parsed wallet data.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:628](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L628)
+[src/lib/ethereum/bridge.ts:630](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L630)
 
 ___
 
@@ -571,7 +598,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L139)
+[src/lib/ethereum/bridge.ts:141](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L141)
 
 ___
 
@@ -599,7 +626,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L154)
+[src/lib/ethereum/bridge.ts:156](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L156)
 
 ___
 
@@ -628,7 +655,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:357](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L357)
+[src/lib/ethereum/bridge.ts:359](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L359)
 
 ___
 
@@ -657,7 +684,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:256](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L256)
+[src/lib/ethereum/bridge.ts:258](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L258)
 
 ___
 
@@ -686,7 +713,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:293](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L293)
+[src/lib/ethereum/bridge.ts:295](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L295)
 
 ___
 
@@ -715,7 +742,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:401](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L401)
+[src/lib/ethereum/bridge.ts:403](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L403)
 
 ___
 
@@ -742,7 +769,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:180](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L180)
+[src/lib/ethereum/bridge.ts:182](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L182)
 
 ___
 
@@ -762,7 +789,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:343](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L343)
+[src/lib/ethereum/bridge.ts:345](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L345)
 
 ___
 
@@ -782,7 +809,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:594](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L594)
+[src/lib/ethereum/bridge.ts:596](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L596)
 
 ___
 
@@ -808,7 +835,7 @@ ___
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:611](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L611)
+[src/lib/ethereum/bridge.ts:613](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L613)
 
 ___
 
@@ -833,7 +860,7 @@ Deposit key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:478](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L478)
+[src/lib/ethereum/bridge.ts:480](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L480)
 
 ___
 
@@ -858,4 +885,4 @@ The redemption key.
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:208](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L208)
+[src/lib/ethereum/bridge.ts:210](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L210)

--- a/typescript/api-reference/classes/EthereumBridge.md
+++ b/typescript/api-reference/classes/EthereumBridge.md
@@ -353,7 +353,7 @@ Queries redemption lifecycle events with ABI-correct wallet topics.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `eventName` | ``"RedemptionTimedOut"`` \| ``"RedemptionsCompleted"`` | Name of the lifecycle event. |
+| `eventName` | ``"RedemptionRequested"`` \| ``"RedemptionTimedOut"`` \| ``"RedemptionsCompleted"`` | Name of the lifecycle event. |
 | `options?` | [`Options`](../interfaces/GetChainEvents.Options.md) | Event query options. |
 | `...filterArgs` | `unknown`[] | Indexed event filters. |
 
@@ -392,7 +392,7 @@ Bridge.getRedemptionRequestedEvents
 
 #### Defined in
 
-[src/lib/ethereum/bridge.ts:793](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L793)
+[src/lib/ethereum/bridge.ts:817](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/ethereum/bridge.ts#L817)
 
 ___
 

--- a/typescript/api-reference/classes/SolanaDepositorInterface.md
+++ b/typescript/api-reference/classes/SolanaDepositorInterface.md
@@ -2,6 +2,10 @@
 
 Implementation of the Solana Depositor Interface handle.
 
+**`See`**
+
+for reference.
+
 ## Implements
 
 - [`BitcoinDepositor`](../interfaces/BitcoinDepositor.md)
@@ -36,7 +40,7 @@ Implementation of the Solana Depositor Interface handle.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:43](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L43)
+[src/lib/solana/solana-depositor-interface.ts:44](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L44)
 
 ## Properties
 
@@ -46,7 +50,7 @@ Implementation of the Solana Depositor Interface handle.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L41)
+[src/lib/solana/solana-depositor-interface.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L42)
 
 ___
 
@@ -56,7 +60,7 @@ ___
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:40](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L40)
+[src/lib/solana/solana-depositor-interface.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L41)
 
 ## Methods
 
@@ -68,8 +72,7 @@ ___
 
 [`SolanaExtraDataEncoder`](SolanaExtraDataEncoder.md)
 
-Extra data encoder for this contract. The encoder is used to
-encode and decode the extra data included in the cross-chain deposit script.
+**`See`**
 
 #### Implementation of
 
@@ -77,7 +80,7 @@ encode and decode the extra data included in the cross-chain deposit script.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:55](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L55)
+[src/lib/solana/solana-depositor-interface.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L68)
 
 ___
 
@@ -85,14 +88,11 @@ ___
 
 ▸ **getDepositOwner**(): `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md)
 
-Gets the identifier that should be used as the owner of the deposits
-issued by this contract.
-
 #### Returns
 
 `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md)
 
-The identifier of the deposit owner or undefined if not set.
+**`See`**
 
 #### Implementation of
 
@@ -100,7 +100,7 @@ The identifier of the deposit owner or undefined if not set.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L47)
+[src/lib/solana/solana-depositor-interface.ts:52](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L52)
 
 ___
 
@@ -108,24 +108,24 @@ ___
 
 ▸ **initializeDeposit**(`depositTx`, `depositOutputIndex`, `deposit`, `vault?`): `Promise`\<`TransactionReceipt`\>
 
-Initializes a deposit by calling the external relayer service at
-`https://relayer.tbtcscan.com/api/reveal` to trigger the deposit transaction
-via an off-chain relayer process.
-
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `depositTx` | [`BitcoinRawTxVectors`](../interfaces/BitcoinRawTxVectors.md) | The Bitcoin raw transaction vectors. |
-| `depositOutputIndex` | `number` | The output index of the deposit in the funding transaction. |
-| `deposit` | [`DepositReceipt`](../interfaces/DepositReceipt.md) | The deposit receipt. |
-| `vault?` | [`ChainIdentifier`](../interfaces/ChainIdentifier.md) | Optional vault identifier. |
+| Name | Type |
+| :------ | :------ |
+| `depositTx` | [`BitcoinRawTxVectors`](../interfaces/BitcoinRawTxVectors.md) |
+| `depositOutputIndex` | `number` |
+| `deposit` | [`DepositReceipt`](../interfaces/DepositReceipt.md) |
+| `vault?` | [`ChainIdentifier`](../interfaces/ChainIdentifier.md) |
 
 #### Returns
 
 `Promise`\<`TransactionReceipt`\>
 
-The resulting transaction receipt containing the transaction hash.
+**`See`**
+
+This method calls the external service at `https://relayer.tbtcscan.com/api/reveal`
+to trigger the deposit transaction via a relayer off-chain process.
+It returns the resulting transaction hash as a Hex.
 
 #### Implementation of
 
@@ -133,7 +133,7 @@ The resulting transaction receipt containing the transaction hash.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:70](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L70)
+[src/lib/solana/solana-depositor-interface.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L80)
 
 ___
 
@@ -141,18 +141,17 @@ ___
 
 ▸ **setDepositOwner**(`depositOwner`): `void`
 
-Sets the identifier that should be used as the owner of the deposits
-issued by this contract.
-
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `depositOwner` | `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md) | Identifier of the deposit owner or undefined to clear. |
+| Name | Type |
+| :------ | :------ |
+| `depositOwner` | `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md) |
 
 #### Returns
 
 `void`
+
+**`See`**
 
 #### Implementation of
 
@@ -160,4 +159,4 @@ issued by this contract.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:51](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L51)
+[src/lib/solana/solana-depositor-interface.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L60)

--- a/typescript/api-reference/classes/SolanaDepositorInterface.md
+++ b/typescript/api-reference/classes/SolanaDepositorInterface.md
@@ -2,10 +2,6 @@
 
 Implementation of the Solana Depositor Interface handle.
 
-**`See`**
-
-for reference.
-
 ## Implements
 
 - [`BitcoinDepositor`](../interfaces/BitcoinDepositor.md)
@@ -40,7 +36,7 @@ for reference.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:44](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L44)
+[src/lib/solana/solana-depositor-interface.ts:43](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L43)
 
 ## Properties
 
@@ -50,7 +46,7 @@ for reference.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:42](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L42)
+[src/lib/solana/solana-depositor-interface.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L41)
 
 ___
 
@@ -60,7 +56,7 @@ ___
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:41](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L41)
+[src/lib/solana/solana-depositor-interface.ts:40](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L40)
 
 ## Methods
 
@@ -72,7 +68,8 @@ ___
 
 [`SolanaExtraDataEncoder`](SolanaExtraDataEncoder.md)
 
-**`See`**
+Extra data encoder for this contract. The encoder is used to
+encode and decode the extra data included in the cross-chain deposit script.
 
 #### Implementation of
 
@@ -80,7 +77,7 @@ ___
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:68](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L68)
+[src/lib/solana/solana-depositor-interface.ts:55](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L55)
 
 ___
 
@@ -88,11 +85,14 @@ ___
 
 ▸ **getDepositOwner**(): `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md)
 
+Gets the identifier that should be used as the owner of the deposits
+issued by this contract.
+
 #### Returns
 
 `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md)
 
-**`See`**
+The identifier of the deposit owner or undefined if not set.
 
 #### Implementation of
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:52](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L52)
+[src/lib/solana/solana-depositor-interface.ts:47](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L47)
 
 ___
 
@@ -108,24 +108,24 @@ ___
 
 ▸ **initializeDeposit**(`depositTx`, `depositOutputIndex`, `deposit`, `vault?`): `Promise`\<`TransactionReceipt`\>
 
+Initializes a deposit by calling the external relayer service at
+`https://relayer.tbtcscan.com/api/reveal` to trigger the deposit transaction
+via an off-chain relayer process.
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `depositTx` | [`BitcoinRawTxVectors`](../interfaces/BitcoinRawTxVectors.md) |
-| `depositOutputIndex` | `number` |
-| `deposit` | [`DepositReceipt`](../interfaces/DepositReceipt.md) |
-| `vault?` | [`ChainIdentifier`](../interfaces/ChainIdentifier.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `depositTx` | [`BitcoinRawTxVectors`](../interfaces/BitcoinRawTxVectors.md) | The Bitcoin raw transaction vectors. |
+| `depositOutputIndex` | `number` | The output index of the deposit in the funding transaction. |
+| `deposit` | [`DepositReceipt`](../interfaces/DepositReceipt.md) | The deposit receipt. |
+| `vault?` | [`ChainIdentifier`](../interfaces/ChainIdentifier.md) | Optional vault identifier. |
 
 #### Returns
 
 `Promise`\<`TransactionReceipt`\>
 
-**`See`**
-
-This method calls the external service at `https://relayer.tbtcscan.com/api/reveal`
-to trigger the deposit transaction via a relayer off-chain process.
-It returns the resulting transaction hash as a Hex.
+The resulting transaction receipt containing the transaction hash.
 
 #### Implementation of
 
@@ -133,7 +133,7 @@ It returns the resulting transaction hash as a Hex.
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:80](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L80)
+[src/lib/solana/solana-depositor-interface.ts:70](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L70)
 
 ___
 
@@ -141,17 +141,18 @@ ___
 
 ▸ **setDepositOwner**(`depositOwner`): `void`
 
+Sets the identifier that should be used as the owner of the deposits
+issued by this contract.
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `depositOwner` | `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `depositOwner` | `undefined` \| [`ChainIdentifier`](../interfaces/ChainIdentifier.md) | Identifier of the deposit owner or undefined to clear. |
 
 #### Returns
 
 `void`
-
-**`See`**
 
 #### Implementation of
 
@@ -159,4 +160,4 @@ ___
 
 #### Defined in
 
-[src/lib/solana/solana-depositor-interface.ts:60](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L60)
+[src/lib/solana/solana-depositor-interface.ts:51](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/solana/solana-depositor-interface.ts#L51)

--- a/typescript/api-reference/enums/WalletState-1.md
+++ b/typescript/api-reference/enums/WalletState-1.md
@@ -22,7 +22,7 @@ any action in the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:395](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L395)
+[src/lib/contracts/bridge.ts:424](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L424)
 
 ___
 
@@ -36,7 +36,7 @@ and must defend against them.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:390](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L390)
+[src/lib/contracts/bridge.ts:419](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L419)
 
 ___
 
@@ -48,7 +48,7 @@ The wallet can sweep deposits and accept redemption requests.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:377](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L377)
+[src/lib/contracts/bridge.ts:406](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L406)
 
 ___
 
@@ -63,7 +63,7 @@ accepted.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:384](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L384)
+[src/lib/contracts/bridge.ts:413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L413)
 
 ___
 
@@ -78,7 +78,7 @@ any actions in the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:402](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L402)
+[src/lib/contracts/bridge.ts:431](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L431)
 
 ___
 
@@ -90,4 +90,4 @@ The wallet is unknown to the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:373](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L373)
+[src/lib/contracts/bridge.ts:402](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L402)

--- a/typescript/api-reference/enums/WalletState-1.md
+++ b/typescript/api-reference/enums/WalletState-1.md
@@ -22,7 +22,7 @@ any action in the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:424](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L424)
+[src/lib/contracts/bridge.ts:459](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L459)
 
 ___
 
@@ -36,7 +36,7 @@ and must defend against them.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:419](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L419)
+[src/lib/contracts/bridge.ts:454](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L454)
 
 ___
 
@@ -48,7 +48,7 @@ The wallet can sweep deposits and accept redemption requests.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:406](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L406)
+[src/lib/contracts/bridge.ts:441](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L441)
 
 ___
 
@@ -63,7 +63,7 @@ accepted.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:413](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L413)
+[src/lib/contracts/bridge.ts:448](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L448)
 
 ___
 
@@ -78,7 +78,7 @@ any actions in the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:431](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L431)
+[src/lib/contracts/bridge.ts:466](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L466)
 
 ___
 
@@ -90,4 +90,4 @@ The wallet is unknown to the Bridge.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:402](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L402)
+[src/lib/contracts/bridge.ts:437](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L437)

--- a/typescript/api-reference/interfaces/Bridge.md
+++ b/typescript/api-reference/interfaces/Bridge.md
@@ -13,6 +13,8 @@ Interface for communication with the Bridge on-chain contract.
 - [getDepositRevealedEvents](Bridge.md#getdepositrevealedevents)
 - [getNewWalletRegisteredEvents](Bridge.md#getnewwalletregisteredevents)
 - [getRedemptionRequestedEvents](Bridge.md#getredemptionrequestedevents)
+- [getRedemptionTimedOutEvents](Bridge.md#getredemptiontimedoutevents)
+- [getRedemptionsCompletedEvents](Bridge.md#getredemptionscompletedevents)
 
 ### Methods
 
@@ -20,6 +22,7 @@ Interface for communication with the Bridge on-chain contract.
 - [buildUtxoHash](Bridge.md#buildutxohash)
 - [deposits](Bridge.md#deposits)
 - [getChainIdentifier](Bridge.md#getchainidentifier)
+- [getRedemptionTimeout](Bridge.md#getredemptiontimeout)
 - [pendingRedemptions](Bridge.md#pendingredemptions)
 - [pendingRedemptionsByWalletPKH](Bridge.md#pendingredemptionsbywalletpkh)
 - [requestRedemption](Bridge.md#requestredemption)
@@ -61,7 +64,7 @@ GetEventsFunction
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:169](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L169)
+[src/lib/contracts/bridge.ts:171](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L171)
 
 ___
 
@@ -77,7 +80,31 @@ GetEventsFunction
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:195](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L195)
+[src/lib/contracts/bridge.ts:197](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L197)
+
+___
+
+### getRedemptionTimedOutEvents
+
+• **getRedemptionTimedOutEvents**: [`Function`](GetChainEvents.Function.md)\<[`RedemptionTimedOutEvent`](../README.md#redemptiontimedoutevent)\>
+
+Timeout reports accepted on-chain; expiration alone emits no event.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:203](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L203)
+
+___
+
+### getRedemptionsCompletedEvents
+
+• **getRedemptionsCompletedEvents**: [`Function`](GetChainEvents.Function.md)\<[`RedemptionsCompletedEvent`](../README.md#redemptionscompletedevent)\>
+
+Successful on-chain acceptance of a redemption transaction proof.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:200](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L200)
 
 ## Methods
 
@@ -97,7 +124,7 @@ Compressed (33 bytes long with 02 or 03 prefix) active wallet's
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:163](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L163)
+[src/lib/contracts/bridge.ts:165](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L165)
 
 ___
 
@@ -121,7 +148,7 @@ The hash of the UTXO.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:189](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L189)
+[src/lib/contracts/bridge.ts:191](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L191)
 
 ___
 
@@ -166,6 +193,30 @@ Gets the chain-specific identifier of this contract.
 
 ___
 
+### getRedemptionTimeout
+
+▸ **getRedemptionTimeout**(`blockNumber?`): `Promise`\<`number`\>
+
+Gets the configured redemption timeout in seconds.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `blockNumber?` | `number` | Optional block at which to read the configuration. |
+
+#### Returns
+
+`Promise`\<`number`\>
+
+The timeout in seconds.
+
+#### Defined in
+
+[src/lib/contracts/bridge.ts:210](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L210)
+
+___
+
 ### pendingRedemptions
 
 ▸ **pendingRedemptions**(`walletPublicKey`, `redeemerOutputScript`): `Promise`\<[`RedemptionRequest`](RedemptionRequest.md)\>
@@ -193,7 +244,7 @@ ___
 
 ### pendingRedemptionsByWalletPKH
 
-▸ **pendingRedemptionsByWalletPKH**(`walletPublicKeyHash`, `redeemerOutputScript`): `Promise`\<[`RedemptionRequest`](RedemptionRequest.md)\>
+▸ **pendingRedemptionsByWalletPKH**(`walletPublicKeyHash`, `redeemerOutputScript`, `blockNumber?`): `Promise`\<[`RedemptionRequest`](RedemptionRequest.md)\>
 
 Gets a pending redemption from the on-chain contract using the wallet's
 public key hash instead of the plain-text public key.
@@ -204,6 +255,7 @@ public key hash instead of the plain-text public key.
 | :------ | :------ | :------ |
 | `walletPublicKeyHash` | [`Hex`](../classes/Hex.md) | Bitcoin public key hash of the wallet the request is targeted to. Must be 20 bytes long. |
 | `redeemerOutputScript` | [`Hex`](../classes/Hex.md) | The redeemer output script the redeemed funds are supposed to be locked on. Must not be prepended with length. |
+| `blockNumber?` | `number` | Optional block at which to read the pending request. |
 
 #### Returns
 
@@ -213,7 +265,7 @@ Promise with the pending redemption.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:138](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L138)
+[src/lib/contracts/bridge.ts:139](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L139)
 
 ___
 
@@ -346,7 +398,7 @@ Promise with the pending redemption.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:152](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L152)
+[src/lib/contracts/bridge.ts:154](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L154)
 
 ___
 
@@ -385,7 +437,7 @@ Returns the attached WalletRegistry instance.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:174](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L174)
+[src/lib/contracts/bridge.ts:176](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L176)
 
 ___
 
@@ -409,4 +461,4 @@ Promise with the wallet details.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:182](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L182)
+[src/lib/contracts/bridge.ts:184](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L184)

--- a/typescript/api-reference/interfaces/Bridge.md
+++ b/typescript/api-reference/interfaces/Bridge.md
@@ -74,13 +74,18 @@ ___
 
 Get emitted RedemptionRequested events.
 
-**`See`**
+**`Param`**
 
-GetEventsFunction
+Optional wallet public key hash filter. The first
+       argument may be a single 20-byte wallet public key hash (as a
+       string or `Hex`), an array of them to match any of the listed
+       wallets, or `null`/omitted to match events from any wallet. An
+       empty array matches no events. No additional filter arguments
+       are supported.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:197](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L197)
+[src/lib/contracts/bridge.ts:202](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L202)
 
 ___
 
@@ -88,11 +93,22 @@ ___
 
 • **getRedemptionTimedOutEvents**: [`Function`](GetChainEvents.Function.md)\<[`RedemptionTimedOutEvent`](../README.md#redemptiontimedoutevent)\>
 
-Timeout reports accepted on-chain; expiration alone emits no event.
+Get emitted RedemptionTimedOut events. These are recorded only when a
+timeout report is accepted on-chain; expiration of the redemption
+timeout alone does not emit an event.
+
+**`Param`**
+
+Optional wallet public key hash filter. The first
+       argument may be a single 20-byte wallet public key hash (as a
+       string or `Hex`), an array of them to match any of the listed
+       wallets, or `null`/omitted to match events from any wallet. An
+       empty array matches no events. No additional filter arguments
+       are supported.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:203](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L203)
+[src/lib/contracts/bridge.ts:227](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L227)
 
 ___
 
@@ -100,11 +116,21 @@ ___
 
 • **getRedemptionsCompletedEvents**: [`Function`](GetChainEvents.Function.md)\<[`RedemptionsCompletedEvent`](../README.md#redemptionscompletedevent)\>
 
-Successful on-chain acceptance of a redemption transaction proof.
+Get emitted RedemptionsCompleted events (successful on-chain acceptance
+of a redemption transaction proof).
+
+**`Param`**
+
+Optional wallet public key hash filter. The first
+       argument may be a single 20-byte wallet public key hash (as a
+       string or `Hex`), an array of them to match any of the listed
+       wallets, or `null`/omitted to match events from any wallet. An
+       empty array matches no events. No additional filter arguments
+       are supported.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:200](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L200)
+[src/lib/contracts/bridge.ts:214](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L214)
 
 ## Methods
 
@@ -213,7 +239,7 @@ The timeout in seconds.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:210](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L210)
+[src/lib/contracts/bridge.ts:234](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L234)
 
 ___
 

--- a/typescript/api-reference/interfaces/DepositReceipt.md
+++ b/typescript/api-reference/interfaces/DepositReceipt.md
@@ -25,7 +25,7 @@ public key and refund public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:212](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L212)
+[src/lib/contracts/bridge.ts:227](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L227)
 
 ___
 
@@ -37,7 +37,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:206](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L206)
+[src/lib/contracts/bridge.ts:221](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L221)
 
 ___
 
@@ -49,7 +49,7 @@ Optional 32-byte extra data.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:237](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L237)
+[src/lib/contracts/bridge.ts:252](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L252)
 
 ___
 
@@ -61,7 +61,7 @@ A 4-byte little-endian refund locktime.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:232](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L232)
+[src/lib/contracts/bridge.ts:247](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L247)
 
 ___
 
@@ -76,7 +76,7 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:227](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L227)
+[src/lib/contracts/bridge.ts:242](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L242)
 
 ___
 
@@ -90,4 +90,4 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:219](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L219)
+[src/lib/contracts/bridge.ts:234](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L234)

--- a/typescript/api-reference/interfaces/DepositReceipt.md
+++ b/typescript/api-reference/interfaces/DepositReceipt.md
@@ -25,7 +25,7 @@ public key and refund public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:227](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L227)
+[src/lib/contracts/bridge.ts:251](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L251)
 
 ___
 
@@ -37,7 +37,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:221](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L221)
+[src/lib/contracts/bridge.ts:245](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L245)
 
 ___
 
@@ -49,7 +49,7 @@ Optional 32-byte extra data.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:252](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L252)
+[src/lib/contracts/bridge.ts:276](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L276)
 
 ___
 
@@ -61,7 +61,7 @@ A 4-byte little-endian refund locktime.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:247](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L247)
+[src/lib/contracts/bridge.ts:271](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L271)
 
 ___
 
@@ -76,7 +76,7 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:242](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L242)
+[src/lib/contracts/bridge.ts:266](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L266)
 
 ___
 
@@ -90,4 +90,4 @@ You can use `computeHash160` function to get the hash from a public key.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:234](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L234)
+[src/lib/contracts/bridge.ts:258](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L258)

--- a/typescript/api-reference/interfaces/DepositRequest.md
+++ b/typescript/api-reference/interfaces/DepositRequest.md
@@ -23,7 +23,7 @@ Deposit amount in satoshis.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:281](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L281)
+[src/lib/contracts/bridge.ts:296](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L296)
 
 ___
 
@@ -35,7 +35,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:276](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L276)
+[src/lib/contracts/bridge.ts:291](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L291)
 
 ___
 
@@ -47,7 +47,7 @@ UNIX timestamp the deposit was revealed at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:291](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L291)
+[src/lib/contracts/bridge.ts:306](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L306)
 
 ___
 
@@ -60,7 +60,7 @@ should have zero as value.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:296](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L296)
+[src/lib/contracts/bridge.ts:311](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L311)
 
 ___
 
@@ -73,7 +73,7 @@ Denominated in satoshi.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:301](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L301)
+[src/lib/contracts/bridge.ts:316](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L316)
 
 ___
 
@@ -85,4 +85,4 @@ Optional identifier of the vault the deposit should be routed in.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:286](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L286)
+[src/lib/contracts/bridge.ts:301](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L301)

--- a/typescript/api-reference/interfaces/DepositRequest.md
+++ b/typescript/api-reference/interfaces/DepositRequest.md
@@ -23,7 +23,7 @@ Deposit amount in satoshis.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:296](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L296)
+[src/lib/contracts/bridge.ts:320](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L320)
 
 ___
 
@@ -35,7 +35,7 @@ Depositor's chain identifier.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:291](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L291)
+[src/lib/contracts/bridge.ts:315](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L315)
 
 ___
 
@@ -47,7 +47,7 @@ UNIX timestamp the deposit was revealed at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:306](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L306)
+[src/lib/contracts/bridge.ts:330](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L330)
 
 ___
 
@@ -60,7 +60,7 @@ should have zero as value.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:311](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L311)
+[src/lib/contracts/bridge.ts:335](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L335)
 
 ___
 
@@ -73,7 +73,7 @@ Denominated in satoshi.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:316](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L316)
+[src/lib/contracts/bridge.ts:340](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L340)
 
 ___
 
@@ -85,4 +85,4 @@ Optional identifier of the vault the deposit should be routed in.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:301](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L301)
+[src/lib/contracts/bridge.ts:325](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L325)

--- a/typescript/api-reference/interfaces/RedemptionRequest.md
+++ b/typescript/api-reference/interfaces/RedemptionRequest.md
@@ -23,7 +23,7 @@ On-chain identifier of the redeemer.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:335](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L335)
+[src/lib/contracts/bridge.ts:359](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L359)
 
 ___
 
@@ -36,7 +36,7 @@ prepended with length.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:341](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L341)
+[src/lib/contracts/bridge.ts:365](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L365)
 
 ___
 
@@ -50,7 +50,7 @@ by the sum of the fee share and the treasury fee for this particular output.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:348](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L348)
+[src/lib/contracts/bridge.ts:372](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L372)
 
 ___
 
@@ -62,7 +62,7 @@ UNIX timestamp the request was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:367](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L367)
+[src/lib/contracts/bridge.ts:391](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L391)
 
 ___
 
@@ -77,7 +77,7 @@ on-chain contract at the time the redemption request was made.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:356](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L356)
+[src/lib/contracts/bridge.ts:380](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L380)
 
 ___
 
@@ -90,4 +90,4 @@ redemption's `requestedAmount` to pay the transaction network fee.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:362](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L362)
+[src/lib/contracts/bridge.ts:386](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L386)

--- a/typescript/api-reference/interfaces/RedemptionRequest.md
+++ b/typescript/api-reference/interfaces/RedemptionRequest.md
@@ -23,7 +23,7 @@ On-chain identifier of the redeemer.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:320](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L320)
+[src/lib/contracts/bridge.ts:335](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L335)
 
 ___
 
@@ -36,7 +36,7 @@ prepended with length.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:326](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L326)
+[src/lib/contracts/bridge.ts:341](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L341)
 
 ___
 
@@ -50,7 +50,7 @@ by the sum of the fee share and the treasury fee for this particular output.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:333](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L333)
+[src/lib/contracts/bridge.ts:348](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L348)
 
 ___
 
@@ -62,7 +62,7 @@ UNIX timestamp the request was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:352](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L352)
+[src/lib/contracts/bridge.ts:367](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L367)
 
 ___
 
@@ -77,7 +77,7 @@ on-chain contract at the time the redemption request was made.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:341](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L341)
+[src/lib/contracts/bridge.ts:356](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L356)
 
 ___
 
@@ -90,4 +90,4 @@ redemption's `requestedAmount` to pay the transaction network fee.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:347](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L347)
+[src/lib/contracts/bridge.ts:362](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L362)

--- a/typescript/api-reference/interfaces/Wallet.md
+++ b/typescript/api-reference/interfaces/Wallet.md
@@ -27,7 +27,7 @@ UNIX timestamp indicating the moment the wallet's closing period started.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:453](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L453)
+[src/lib/contracts/bridge.ts:482](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L482)
 
 ___
 
@@ -39,7 +39,7 @@ UNIX timestamp the wallet was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:444](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L444)
+[src/lib/contracts/bridge.ts:473](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L473)
 
 ___
 
@@ -51,7 +51,7 @@ Identifier of a ECDSA Wallet registered in the ECDSA Wallet Registry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:426](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L426)
+[src/lib/contracts/bridge.ts:455](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L455)
 
 ___
 
@@ -63,7 +63,7 @@ Latest wallet's main UTXO hash.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:436](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L436)
+[src/lib/contracts/bridge.ts:465](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L465)
 
 ___
 
@@ -76,7 +76,7 @@ funds.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:449](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L449)
+[src/lib/contracts/bridge.ts:478](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L478)
 
 ___
 
@@ -88,7 +88,7 @@ Moving funds target wallet commitment submitted by the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:465](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L465)
+[src/lib/contracts/bridge.ts:494](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L494)
 
 ___
 
@@ -100,7 +100,7 @@ Total count of pending moved funds sweep requests targeting this wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:457](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L457)
+[src/lib/contracts/bridge.ts:486](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L486)
 
 ___
 
@@ -112,7 +112,7 @@ The total redeemable value of pending redemption requests targeting that wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:440](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L440)
+[src/lib/contracts/bridge.ts:469](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L469)
 
 ___
 
@@ -124,7 +124,7 @@ Current state of the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:461](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L461)
+[src/lib/contracts/bridge.ts:490](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L490)
 
 ___
 
@@ -138,4 +138,4 @@ WalletRegistry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:432](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L432)
+[src/lib/contracts/bridge.ts:461](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L461)

--- a/typescript/api-reference/interfaces/Wallet.md
+++ b/typescript/api-reference/interfaces/Wallet.md
@@ -27,7 +27,7 @@ UNIX timestamp indicating the moment the wallet's closing period started.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:482](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L482)
+[src/lib/contracts/bridge.ts:517](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L517)
 
 ___
 
@@ -39,7 +39,7 @@ UNIX timestamp the wallet was created at.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:473](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L473)
+[src/lib/contracts/bridge.ts:508](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L508)
 
 ___
 
@@ -51,7 +51,7 @@ Identifier of a ECDSA Wallet registered in the ECDSA Wallet Registry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:455](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L455)
+[src/lib/contracts/bridge.ts:490](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L490)
 
 ___
 
@@ -63,7 +63,7 @@ Latest wallet's main UTXO hash.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:465](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L465)
+[src/lib/contracts/bridge.ts:500](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L500)
 
 ___
 
@@ -76,7 +76,7 @@ funds.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:478](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L478)
+[src/lib/contracts/bridge.ts:513](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L513)
 
 ___
 
@@ -88,7 +88,7 @@ Moving funds target wallet commitment submitted by the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:494](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L494)
+[src/lib/contracts/bridge.ts:529](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L529)
 
 ___
 
@@ -100,7 +100,7 @@ Total count of pending moved funds sweep requests targeting this wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:486](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L486)
+[src/lib/contracts/bridge.ts:521](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L521)
 
 ___
 
@@ -112,7 +112,7 @@ The total redeemable value of pending redemption requests targeting that wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:469](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L469)
+[src/lib/contracts/bridge.ts:504](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L504)
 
 ___
 
@@ -124,7 +124,7 @@ Current state of the wallet.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:490](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L490)
+[src/lib/contracts/bridge.ts:525](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L525)
 
 ___
 
@@ -138,4 +138,4 @@ WalletRegistry.
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:461](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L461)
+[src/lib/contracts/bridge.ts:496](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L496)

--- a/typescript/api-reference/modules/WalletState.md
+++ b/typescript/api-reference/modules/WalletState.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:408](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L408)
+[src/lib/contracts/bridge.ts:437](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L437)

--- a/typescript/api-reference/modules/WalletState.md
+++ b/typescript/api-reference/modules/WalletState.md
@@ -24,4 +24,4 @@
 
 #### Defined in
 
-[src/lib/contracts/bridge.ts:437](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L437)
+[src/lib/contracts/bridge.ts:472](https://github.com/threshold-network/tbtc-v2/blob/main/typescript/src/lib/contracts/bridge.ts#L472)

--- a/typescript/src/lib/contracts/bridge.ts
+++ b/typescript/src/lib/contracts/bridge.ts
@@ -133,11 +133,13 @@ export interface Bridge {
    *        request is targeted to. Must be 20 bytes long.
    * @param redeemerOutputScript The redeemer output script the redeemed funds
    *        are supposed to be locked on. Must not be prepended with length.
+   * @param blockNumber Optional block at which to read the pending request.
    * @returns Promise with the pending redemption.
    */
   pendingRedemptionsByWalletPKH(
     walletPublicKeyHash: Hex,
-    redeemerOutputScript: Hex
+    redeemerOutputScript: Hex,
+    blockNumber?: number
   ): Promise<RedemptionRequest>
 
   /**
@@ -193,6 +195,19 @@ export interface Bridge {
    * @see GetEventsFunction
    */
   getRedemptionRequestedEvents: GetChainEvents.Function<RedemptionRequestedEvent>
+
+  /** Successful on-chain acceptance of a redemption transaction proof. */
+  getRedemptionsCompletedEvents: GetChainEvents.Function<RedemptionsCompletedEvent>
+
+  /** Timeout reports accepted on-chain; expiration alone emits no event. */
+  getRedemptionTimedOutEvents: GetChainEvents.Function<RedemptionTimedOutEvent>
+
+  /**
+   * Gets the configured redemption timeout in seconds.
+   * @param blockNumber Optional block at which to read the configuration.
+   * @returns The timeout in seconds.
+   */
+  getRedemptionTimeout(blockNumber?: number): Promise<number>
 }
 
 /**
@@ -364,6 +379,20 @@ export type RedemptionRequestedEvent = Omit<
    */
   walletPublicKeyHash: Hex
 } & ChainEvent
+
+/** A Bitcoin redemption transaction whose SPV proof was accepted. */
+export type RedemptionsCompletedEvent = ChainEvent & {
+  walletPublicKeyHash: Hex
+  /** Bitcoin transaction hash in explorer/display byte order. */
+  redemptionTxHash: BitcoinTxHash
+}
+
+/** A request whose timeout was reported and processed on-chain. */
+export type RedemptionTimedOutEvent = ChainEvent & {
+  walletPublicKeyHash: Hex
+  /** Output script without its CompactSize length prefix. */
+  redeemerOutputScript: Hex
+}
 
 /* eslint-disable no-unused-vars */
 export enum WalletState {

--- a/typescript/src/lib/contracts/bridge.ts
+++ b/typescript/src/lib/contracts/bridge.ts
@@ -192,14 +192,38 @@ export interface Bridge {
 
   /**
    * Get emitted RedemptionRequested events.
-   * @see GetEventsFunction
+   * @param filterArgs Optional wallet public key hash filter. The first
+   *        argument may be a single 20-byte wallet public key hash (as a
+   *        string or `Hex`), an array of them to match any of the listed
+   *        wallets, or `null`/omitted to match events from any wallet. An
+   *        empty array matches no events. No additional filter arguments
+   *        are supported.
    */
   getRedemptionRequestedEvents: GetChainEvents.Function<RedemptionRequestedEvent>
 
-  /** Successful on-chain acceptance of a redemption transaction proof. */
+  /**
+   * Get emitted RedemptionsCompleted events (successful on-chain acceptance
+   * of a redemption transaction proof).
+   * @param filterArgs Optional wallet public key hash filter. The first
+   *        argument may be a single 20-byte wallet public key hash (as a
+   *        string or `Hex`), an array of them to match any of the listed
+   *        wallets, or `null`/omitted to match events from any wallet. An
+   *        empty array matches no events. No additional filter arguments
+   *        are supported.
+   */
   getRedemptionsCompletedEvents: GetChainEvents.Function<RedemptionsCompletedEvent>
 
-  /** Timeout reports accepted on-chain; expiration alone emits no event. */
+  /**
+   * Get emitted RedemptionTimedOut events. These are recorded only when a
+   * timeout report is accepted on-chain; expiration of the redemption
+   * timeout alone does not emit an event.
+   * @param filterArgs Optional wallet public key hash filter. The first
+   *        argument may be a single 20-byte wallet public key hash (as a
+   *        string or `Hex`), an array of them to match any of the listed
+   *        wallets, or `null`/omitted to match events from any wallet. An
+   *        empty array matches no events. No additional filter arguments
+   *        are supported.
+   */
   getRedemptionTimedOutEvents: GetChainEvents.Function<RedemptionTimedOutEvent>
 
   /**
@@ -380,14 +404,25 @@ export type RedemptionRequestedEvent = Omit<
   walletPublicKeyHash: Hex
 } & ChainEvent
 
-/** A Bitcoin redemption transaction whose SPV proof was accepted. */
+/**
+ * Represents an event emitted when a redemption transaction's SPV proof is
+ * accepted on-chain. `redemptionTxHash` is reported in explorer/display byte
+ * order, i.e. reversed relative to the transaction's internal Bitcoin byte
+ * order.
+ */
 export type RedemptionsCompletedEvent = ChainEvent & {
   walletPublicKeyHash: Hex
   /** Bitcoin transaction hash in explorer/display byte order. */
   redemptionTxHash: BitcoinTxHash
 }
 
-/** A request whose timeout was reported and processed on-chain. */
+/**
+ * Represents an event emitted when a redemption request's timeout is
+ * reported and processed on-chain. Expiration of the redemption timeout
+ * alone does not emit this event; it fires only once the timeout report is
+ * accepted. `redeemerOutputScript` is reported without its CompactSize
+ * length prefix.
+ */
 export type RedemptionTimedOutEvent = ChainEvent & {
   walletPublicKeyHash: Hex
   /** Output script without its CompactSize length prefix. */

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -26,6 +26,7 @@ import {
   Event as EthersEvent,
 } from "@ethersproject/contracts"
 import { BigNumber } from "@ethersproject/bignumber"
+import { defaultAbiCoder } from "@ethersproject/abi"
 import { AddressZero } from "@ethersproject/constants"
 import { keccak256 as solidityKeccak256 } from "@ethersproject/solidity"
 import { backoffRetrier, Hex } from "../utils"
@@ -42,6 +43,7 @@ import {
   EthersContractConfig,
   EthersContractDeployment,
   EthersContractHandle,
+  EthersEventUtils,
   EthersTransactionUtils,
 } from "./adapter"
 import { EthereumAddress } from "./address"
@@ -691,7 +693,7 @@ export class EthereumBridge
     options?: GetChainEvents.Options,
     ...filterArgs: Array<unknown>
   ): Promise<RedemptionsCompletedEvent[]> {
-    const events = await this.getEvents(
+    const events = await this.getRedemptionEvents(
       "RedemptionsCompleted",
       options,
       ...filterArgs
@@ -717,7 +719,7 @@ export class EthereumBridge
     options?: GetChainEvents.Options,
     ...filterArgs: Array<unknown>
   ): Promise<RedemptionTimedOutEvent[]> {
-    const events = await this.getEvents(
+    const events = await this.getRedemptionEvents(
       "RedemptionTimedOut",
       options,
       ...filterArgs
@@ -735,6 +737,52 @@ export class EthereumBridge
             .slice(BitcoinCompactSizeUint.read(prefixedScript).byteLength * 2)
         ),
       }
+    })
+  }
+
+  /**
+   * Queries redemption lifecycle events with ABI-correct wallet topics.
+   * @param eventName Name of the lifecycle event.
+   * @param options Event query options.
+   * @param filterArgs Indexed event filters.
+   * @returns Matching events.
+   */
+  private async getRedemptionEvents(
+    eventName: "RedemptionsCompleted" | "RedemptionTimedOut",
+    options?: GetChainEvents.Options,
+    ...filterArgs: Array<unknown>
+  ): Promise<EthersEvent[]> {
+    const filter = {
+      address: this._instance.address,
+      topics: this._instance.interface.encodeFilterTopics(
+        eventName,
+        filterArgs
+      ),
+    }
+    const walletFilter = filterArgs[0]
+    if (walletFilter != null) {
+      // Ethers v5 left-pads indexed bytes20 filters, but Solidity emits them
+      // right-padded. Both events index the wallet PKH as their first argument.
+      // Use the ABI coder for exact-length validation and canonical padding,
+      // including each alternative in an OR filter. Null/omitted stays wildcard.
+      const walletTopic = (wallet: unknown): string =>
+        defaultAbiCoder.encode(["bytes20"], [wallet])
+      filter.topics[1] = Array.isArray(walletFilter)
+        ? walletFilter.map(walletTopic)
+        : walletTopic(walletFilter)
+    }
+
+    return backoffRetrier<EthersEvent[]>(
+      options?.retries ?? this._totalRetryAttempts
+    )(async () => {
+      return EthersEventUtils.getEvents(
+        this._instance,
+        filter,
+        options?.fromBlock ?? this._deployedAtBlockNumber,
+        options?.toBlock,
+        options?.batchedQueryBlockInterval,
+        options?.logger
+      )
     })
   }
 

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -748,25 +748,49 @@ export class EthereumBridge
    * @returns Matching events.
    */
   private async getRedemptionEvents(
-    eventName: "RedemptionsCompleted" | "RedemptionTimedOut",
+    eventName:
+      | "RedemptionsCompleted"
+      | "RedemptionTimedOut"
+      | "RedemptionRequested",
     options?: GetChainEvents.Options,
     ...filterArgs: Array<unknown>
   ): Promise<EthersEvent[]> {
-    const filter = {
-      address: this._instance.address,
-      topics: this._instance.interface.encodeFilterTopics(
-        eventName,
-        filterArgs
-      ),
+    if (filterArgs.length > 1) {
+      // encodeFilterTopics is positional over the full ABI parameter list
+      // (indexed and non-indexed), unlike the typechain filter helpers used
+      // elsewhere in this file, which are positional over indexed params
+      // only. RedemptionRequested's second indexed param (redeemer) is not
+      // at ABI slot 1 (that is the non-indexed redeemerOutputScript), so a
+      // second positional filter argument cannot be forwarded correctly.
+      // Fail loudly instead of silently filtering on the wrong field.
+      throw new Error(
+        "getRedemptionEvents only supports filtering by the wallet public key hash"
+      )
     }
     const walletFilter = filterArgs[0]
+    if (Array.isArray(walletFilter) && walletFilter.length === 0) {
+      return Promise.resolve([])
+    }
+    const filter = {
+      address: this._instance.address,
+      topics: this._instance.interface.encodeFilterTopics(eventName, []),
+    }
     if (walletFilter != null) {
       // Ethers v5 left-pads indexed bytes20 filters, but Solidity emits them
-      // right-padded. Both events index the wallet PKH as their first argument.
-      // Use the ABI coder for exact-length validation and canonical padding,
-      // including each alternative in an OR filter. Null/omitted stays wildcard.
+      // right-padded. All three redemption lifecycle events index the wallet
+      // PKH as their first argument. Use the ABI coder for exact-length
+      // validation and canonical right padding, including each alternative
+      // in an OR filter. Null/omitted stays wildcard. The wallet filter is
+      // encoded manually rather than through encodeFilterTopics because that
+      // call cannot hexlify an SDK Hex instance, only raw BytesLike values.
+      const normalizeWallet = (wallet: unknown): string => {
+        if (wallet instanceof Hex) {
+          return wallet.toPrefixedString()
+        }
+        return wallet as string
+      }
       const walletTopic = (wallet: unknown): string =>
-        defaultAbiCoder.encode(["bytes20"], [wallet])
+        defaultAbiCoder.encode(["bytes20"], [normalizeWallet(wallet)])
       filter.topics[1] = Array.isArray(walletFilter)
         ? walletFilter.map(walletTopic)
         : walletTopic(walletFilter)
@@ -794,14 +818,7 @@ export class EthereumBridge
     options?: GetChainEvents.Options,
     ...filterArgs: Array<unknown>
   ): Promise<RedemptionRequestedEvent[]> {
-    // FIXME: Filtering by indexed walletPubKeyHash field may not work
-    //        until https://github.com/ethers-io/ethers.js/pull/4244 is
-    //        included in the @ethersproject/contracts/@ethersproject/abi
-    //        v5 packages. Ethers v6 contains the referenced fix, but this SDK
-    //        targets v5 types.
-    //        Short-term, we can workaround the problem as presented in:
-    //        https://github.com/threshold-network/token-dashboard/blob/main/src/threshold-ts/tbtc/index.ts#L1041C1-L1093C1
-    const events: EthersEvent[] = await this.getEvents(
+    const events: EthersEvent[] = await this.getRedemptionEvents(
       "RedemptionRequested",
       options,
       ...filterArgs

--- a/typescript/src/lib/ethereum/bridge.ts
+++ b/typescript/src/lib/ethereum/bridge.ts
@@ -14,6 +14,8 @@ import {
   WalletState,
   RedemptionRequest,
   RedemptionRequestedEvent,
+  RedemptionsCompletedEvent,
+  RedemptionTimedOutEvent,
   DepositRevealedEvent,
   DepositReceipt,
   DepositRequest,
@@ -151,7 +153,8 @@ export class EthereumBridge
    */
   async pendingRedemptionsByWalletPKH(
     walletPublicKeyHash: Hex,
-    redeemerOutputScript: Hex
+    redeemerOutputScript: Hex,
+    blockNumber?: number
   ): Promise<RedemptionRequest> {
     const redemptionKey = EthereumBridge.buildRedemptionKey(
       walletPublicKeyHash,
@@ -162,7 +165,9 @@ export class EthereumBridge
       await backoffRetrier<RedemptionRequestTypechain>(
         this._totalRetryAttempts
       )(async () => {
-        return await this._instance.pendingRedemptions(redemptionKey)
+        return await this._instance.pendingRedemptions(redemptionKey, {
+          blockTag: blockNumber ?? "latest",
+        })
       })
 
     return this.parseRedemptionRequest(request, redeemerOutputScript)
@@ -662,9 +667,80 @@ export class EthereumBridge
     )
   }
 
+  /**
+   * Reads the redemption timeout at the specified block.
+   * @param blockNumber Block to read, or the latest block when omitted.
+   * @returns Timeout in seconds.
+   */
+  async getRedemptionTimeout(blockNumber?: number): Promise<number> {
+    return backoffRetrier<number>(this._totalRetryAttempts)(async () => {
+      const parameters = await this._instance.redemptionParameters({
+        blockTag: blockNumber ?? "latest",
+      })
+      return BigNumber.from(parameters.redemptionTimeout).toNumber()
+    })
+  }
+
+  /**
+   * Reads accepted redemption proof events.
+   * @param options Event query options.
+   * @param filterArgs Indexed event filters.
+   * @returns Completion events with Bitcoin hashes in display byte order.
+   */
+  async getRedemptionsCompletedEvents(
+    options?: GetChainEvents.Options,
+    ...filterArgs: Array<unknown>
+  ): Promise<RedemptionsCompletedEvent[]> {
+    const events = await this.getEvents(
+      "RedemptionsCompleted",
+      options,
+      ...filterArgs
+    )
+    return events.map((event) => ({
+      blockNumber: event.blockNumber,
+      blockHash: Hex.from(event.blockHash),
+      transactionHash: Hex.from(event.transactionHash),
+      walletPublicKeyHash: Hex.from(event.args!.walletPubKeyHash),
+      redemptionTxHash: BitcoinTxHash.from(
+        event.args!.redemptionTxHash
+      ).reverse(),
+    }))
+  }
+
+  /**
+   * Reads reported redemption timeout events.
+   * @param options Event query options.
+   * @param filterArgs Indexed event filters.
+   * @returns Timeout events with output scripts without their length prefix.
+   */
+  async getRedemptionTimedOutEvents(
+    options?: GetChainEvents.Options,
+    ...filterArgs: Array<unknown>
+  ): Promise<RedemptionTimedOutEvent[]> {
+    const events = await this.getEvents(
+      "RedemptionTimedOut",
+      options,
+      ...filterArgs
+    )
+    return events.map((event) => {
+      const prefixedScript = Hex.from(event.args!.redeemerOutputScript)
+      return {
+        blockNumber: event.blockNumber,
+        blockHash: Hex.from(event.blockHash),
+        transactionHash: Hex.from(event.transactionHash),
+        walletPublicKeyHash: Hex.from(event.args!.walletPubKeyHash),
+        redeemerOutputScript: Hex.from(
+          prefixedScript
+            .toString()
+            .slice(BitcoinCompactSizeUint.read(prefixedScript).byteLength * 2)
+        ),
+      }
+    })
+  }
+
   // eslint-disable-next-line valid-jsdoc
   /**
-   * @see {Bridge#getDepositRevealedEvents}
+   * @see {Bridge#getRedemptionRequestedEvents}
    */
   async getRedemptionRequestedEvents(
     options?: GetChainEvents.Options,

--- a/typescript/test/lib/ethereum/redemption-monitoring.test.ts
+++ b/typescript/test/lib/ethereum/redemption-monitoring.test.ts
@@ -11,10 +11,15 @@ const blockHash = `0x${"22".repeat(32)}`
 const transactionHash = `0x${"44".repeat(32)}`
 const script = `0014${"33".repeat(20)}`
 const redemptionTxHash = `0x01${"00".repeat(30)}ab`
+const redeemer = `0x${"55".repeat(20)}`
 
 const eventInterface = new utils.Interface([
   "event RedemptionsCompleted(bytes20 indexed walletPubKeyHash, bytes32 redemptionTxHash)",
   "event RedemptionTimedOut(bytes20 indexed walletPubKeyHash, bytes redeemerOutputScript)",
+])
+
+const redemptionRequestedInterface = new utils.Interface([
+  "event RedemptionRequested(bytes20 indexed walletPubKeyHash, bytes redeemerOutputScript, address indexed redeemer, uint64 requestedAmount, uint64 treasuryFee, uint64 txMaxFee)",
 ])
 
 type RedemptionEventName = "RedemptionsCompleted" | "RedemptionTimedOut"
@@ -71,9 +76,13 @@ function eventQuery(eventName: RedemptionEventName) {
         log.blockNumber <= toBlock &&
         (filter.topics ?? []).every((topic, index) => {
           if (topic === null) return true
-          return Array.isArray(topic)
-            ? topic.includes(log.topics[index])
-            : topic === log.topics[index]
+          if (Array.isArray(topic)) {
+            // Real JSON-RPC/Geth semantics: an empty topic array is
+            // unconstrained and matches everything. Production code must
+            // short-circuit before ever querying with an empty wallet list.
+            return topic.length === 0 || topic.includes(log.topics[index])
+          }
+          return topic === log.topics[index]
         })
       )
     })
@@ -87,6 +96,81 @@ function eventQuery(eventName: RedemptionEventName) {
       ? instance.getRedemptionsCompletedEvents.bind(instance)
       : instance.getRedemptionTimedOutEvents.bind(instance)
   return { provider, filters, query }
+}
+
+function redemptionRequestedEventLog(
+  walletPublicKeyHash: string,
+  redeemerAddress: string,
+  requestedAmount: number,
+  treasuryFee: number,
+  txMaxFee: number,
+  logIndex: number
+): providers.Log {
+  const encoded = redemptionRequestedInterface.encodeEventLog(
+    redemptionRequestedInterface.getEvent("RedemptionRequested"),
+    [
+      walletPublicKeyHash,
+      `0x16${script}`,
+      redeemerAddress,
+      requestedAmount,
+      treasuryFee,
+      txMaxFee,
+    ]
+  )
+  // Event encoding follows the ABI's right padding for indexed bytes20.
+  expect(encoded.topics[1]).to.equal(walletTopic(walletPublicKeyHash))
+  return {
+    ...encoded,
+    address: bridgeAddress,
+    blockNumber: 123,
+    blockHash,
+    transactionHash,
+    transactionIndex: 0,
+    logIndex,
+    removed: false,
+  }
+}
+
+function redemptionRequestedQuery() {
+  const provider = new providers.StaticJsonRpcProvider(undefined, {
+    name: "mainnet",
+    chainId: 1,
+  })
+  const filters: providers.Filter[] = []
+  const logs = [
+    redemptionRequestedEventLog(wallet, redeemer, 100000, 100, 1000, 0),
+    redemptionRequestedEventLog(otherWallet, redeemer, 200000, 200, 2000, 1),
+  ]
+  provider.getLogs = async (requestedFilter) => {
+    const filter: providers.Filter = await requestedFilter
+    filters.push(filter)
+    return logs.filter((log) => {
+      const fromBlock =
+        typeof filter.fromBlock === "number" ? filter.fromBlock : 0
+      const toBlock =
+        typeof filter.toBlock === "number" ? filter.toBlock : Infinity
+      return (
+        log.blockNumber >= fromBlock &&
+        log.blockNumber <= toBlock &&
+        (filter.topics ?? []).every((topic, index) => {
+          if (topic === null) return true
+          if (Array.isArray(topic)) {
+            return topic.length === 0 || topic.includes(log.topics[index])
+          }
+          return topic === log.topics[index]
+        })
+      )
+    })
+  }
+  const instance = new EthereumBridge({
+    signerOrProvider: provider,
+    address: bridgeAddress,
+  })
+  return {
+    provider,
+    filters,
+    query: instance.getRedemptionRequestedEvents.bind(instance),
+  }
 }
 
 function bridge(): EthereumBridge {
@@ -114,6 +198,18 @@ describe("redemption monitoring bridge methods", () => {
         {
           name: "an OR list of wallets",
           args: [[wallet, otherWallet]],
+          topics: [[walletTopic(wallet), walletTopic(otherWallet)]],
+          wallets: [wallet, otherWallet],
+        },
+        {
+          name: "a single Hex wallet",
+          args: [Hex.from(wallet)],
+          topics: [walletTopic(wallet)],
+          wallets: [wallet],
+        },
+        {
+          name: "an OR list of Hex wallets",
+          args: [[Hex.from(wallet), Hex.from(otherWallet)]],
           topics: [[walletTopic(wallet), walletTopic(otherWallet)]],
           wallets: [wallet, otherWallet],
         },
@@ -186,6 +282,16 @@ describe("redemption monitoring bridge methods", () => {
           expect(filters).to.have.length(0)
         })
       }
+
+      it("returns no events without querying the provider for an empty wallet filter", async () => {
+        const { filters, query } = eventQuery(eventName)
+        const events = await query(
+          { fromBlock: 100, toBlock: 200, retries: 0 },
+          []
+        )
+        expect(filters).to.have.length(0)
+        expect(events).to.deep.equal([])
+      })
 
       it("preserves wallet topics and block options in fallback batches", async () => {
         const { provider, query } = eventQuery(eventName)
@@ -274,6 +380,133 @@ describe("redemption monitoring bridge methods", () => {
     })
   }
 
+  describe("RedemptionRequested", () => {
+    for (const testCase of [
+      {
+        name: "a single wallet",
+        args: [wallet],
+        topics: [walletTopic(wallet)],
+        wallets: [wallet],
+      },
+      {
+        name: "an OR list of wallets",
+        args: [[wallet, otherWallet]],
+        topics: [[walletTopic(wallet), walletTopic(otherWallet)]],
+        wallets: [wallet, otherWallet],
+      },
+      {
+        name: "an omitted wallet filter",
+        args: [],
+        topics: [],
+        wallets: [wallet, otherWallet],
+      },
+      {
+        name: "a null wallet wildcard",
+        args: [null],
+        topics: [],
+        wallets: [wallet, otherWallet],
+      },
+      {
+        name: "a nonmatching wallet",
+        args: [unknownWallet],
+        topics: [walletTopic(unknownWallet)],
+        wallets: [],
+      },
+      {
+        name: "a single Hex wallet",
+        args: [Hex.from(wallet)],
+        topics: [walletTopic(wallet)],
+        wallets: [wallet],
+      },
+      {
+        name: "an OR list of Hex wallets",
+        args: [[Hex.from(wallet), Hex.from(otherWallet)]],
+        topics: [[walletTopic(wallet), walletTopic(otherWallet)]],
+        wallets: [wallet, otherWallet],
+      },
+    ]) {
+      it(`queries the ABI-correct right-padded wallet topic for ${testCase.name}`, async () => {
+        const { filters, query } = redemptionRequestedQuery()
+        const events = await query(
+          { fromBlock: 100, toBlock: 200, retries: 0 },
+          ...testCase.args
+        )
+        expect(filters).to.have.length(1)
+        expect(filters[0].address).to.equal(bridgeAddress)
+        expect(filters[0].fromBlock).to.equal(100)
+        expect(filters[0].toBlock).to.equal(200)
+        expect(filters[0].topics).to.deep.equal([
+          redemptionRequestedInterface.getEventTopic("RedemptionRequested"),
+          ...testCase.topics,
+        ])
+        expect(
+          events.map((event) => event.walletPublicKeyHash.toPrefixedString())
+        ).to.deep.equal(testCase.wallets)
+        for (const event of events) {
+          expect(event.blockNumber).to.equal(123)
+          expect(event.blockHash.toPrefixedString()).to.equal(blockHash)
+          expect(event.transactionHash.toPrefixedString()).to.equal(
+            transactionHash
+          )
+          expect(event.redeemer.identifierHex).to.equal(
+            redeemer.substring(2).toLowerCase()
+          )
+          expect(event.redeemerOutputScript.toString()).to.equal(script)
+          const expectedAmounts =
+            event.walletPublicKeyHash.toPrefixedString() === wallet
+              ? [100000, 100, 1000]
+              : [200000, 200, 2000]
+          expect(event.requestedAmount.toNumber()).to.equal(expectedAmounts[0])
+          expect(event.treasuryFee.toNumber()).to.equal(expectedAmounts[1])
+          expect(event.txMaxFee.toNumber()).to.equal(expectedAmounts[2])
+        }
+      })
+    }
+
+    for (const byteLength of [19, 21]) {
+      it(`rejects a ${byteLength}-byte wallet filter before querying`, async () => {
+        const { filters, query } = redemptionRequestedQuery()
+        let caught: unknown
+        try {
+          await query(
+            { fromBlock: 100, toBlock: 200, retries: 0 },
+            `0x${"11".repeat(byteLength)}`
+          )
+        } catch (error) {
+          caught = error
+        }
+        expect(caught).to.be.instanceOf(Error)
+        expect(filters).to.have.length(0)
+      })
+    }
+
+    it("rejects a second positional filter argument before querying", async () => {
+      const { filters, query } = redemptionRequestedQuery()
+      let caught: unknown
+      try {
+        await query(
+          { fromBlock: 100, toBlock: 200, retries: 0 },
+          wallet,
+          redeemer
+        )
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).to.be.instanceOf(Error)
+      expect(filters).to.have.length(0)
+    })
+
+    it("returns no events without querying the provider for an empty wallet filter", async () => {
+      const { filters, query } = redemptionRequestedQuery()
+      const events = await query(
+        { fromBlock: 100, toBlock: 200, retries: 0 },
+        []
+      )
+      expect(filters).to.have.length(0)
+      expect(events).to.deep.equal([])
+    })
+  })
+
   it("reads the timeout and pending request at the requested block, including zero", async () => {
     const instance = bridge()
     const observedBlocks: unknown[] = []
@@ -306,12 +539,23 @@ describe("redemption monitoring bridge methods", () => {
     })
     expect(await instance.getRedemptionTimeout(0)).to.equal(172800)
     await instance.getRedemptionTimeout()
+    const pendingDefaultBlock = await instance.pendingRedemptionsByWalletPKH(
+      Hex.from(wallet),
+      Hex.from(script)
+    )
+    const pendingZeroBlock = await instance.pendingRedemptionsByWalletPKH(
+      Hex.from(wallet),
+      Hex.from(script),
+      0
+    )
     const pending = await instance.pendingRedemptionsByWalletPKH(
       Hex.from(wallet),
       Hex.from(script),
       200
     )
+    expect(pendingDefaultBlock.requestedAt).to.equal(1234)
+    expect(pendingZeroBlock.requestedAt).to.equal(1234)
     expect(pending.requestedAt).to.equal(1234)
-    expect(observedBlocks).to.deep.equal([0, "latest", 200])
+    expect(observedBlocks).to.deep.equal([0, "latest", "latest", 0, 200])
   })
 })

--- a/typescript/test/lib/ethereum/redemption-monitoring.test.ts
+++ b/typescript/test/lib/ethereum/redemption-monitoring.test.ts
@@ -1,13 +1,93 @@
 import { expect } from "chai"
-import { BigNumber, providers } from "ethers"
-import type { Event } from "@ethersproject/contracts"
+import { BigNumber, providers, utils } from "ethers"
 import { EthereumBridge } from "../../../src/lib/ethereum/bridge"
 import { Hex } from "../../../src/lib/utils"
 
 const wallet = `0x${"11".repeat(20)}`
+const otherWallet = `0x${"66".repeat(20)}`
+const unknownWallet = `0x${"77".repeat(20)}`
+const bridgeAddress = `0x${"88".repeat(20)}`
 const blockHash = `0x${"22".repeat(32)}`
 const transactionHash = `0x${"44".repeat(32)}`
 const script = `0014${"33".repeat(20)}`
+const redemptionTxHash = `0x01${"00".repeat(30)}ab`
+
+const eventInterface = new utils.Interface([
+  "event RedemptionsCompleted(bytes20 indexed walletPubKeyHash, bytes32 redemptionTxHash)",
+  "event RedemptionTimedOut(bytes20 indexed walletPubKeyHash, bytes redeemerOutputScript)",
+])
+
+type RedemptionEventName = "RedemptionsCompleted" | "RedemptionTimedOut"
+
+function walletTopic(value: string): string {
+  return utils.defaultAbiCoder.encode(["bytes20"], [value])
+}
+
+function eventLog(
+  eventName: RedemptionEventName,
+  walletPublicKeyHash: string,
+  logIndex: number
+): providers.Log {
+  const encoded = eventInterface.encodeEventLog(
+    eventInterface.getEvent(eventName),
+    [
+      walletPublicKeyHash,
+      eventName === "RedemptionsCompleted" ? redemptionTxHash : `0x16${script}`,
+    ]
+  )
+  // Event encoding follows the ABI's right padding for indexed bytes20.
+  expect(encoded.topics[1]).to.equal(walletTopic(walletPublicKeyHash))
+  return {
+    ...encoded,
+    address: bridgeAddress,
+    blockNumber: 123,
+    blockHash,
+    transactionHash,
+    transactionIndex: 0,
+    logIndex,
+    removed: false,
+  }
+}
+
+function eventQuery(eventName: RedemptionEventName) {
+  const provider = new providers.StaticJsonRpcProvider(undefined, {
+    name: "mainnet",
+    chainId: 1,
+  })
+  const filters: providers.Filter[] = []
+  const logs = [wallet, otherWallet].map((value, index) =>
+    eventLog(eventName, value, index)
+  )
+  provider.getLogs = async (requestedFilter) => {
+    const filter: providers.Filter = await requestedFilter
+    filters.push(filter)
+    return logs.filter((log) => {
+      const fromBlock =
+        typeof filter.fromBlock === "number" ? filter.fromBlock : 0
+      const toBlock =
+        typeof filter.toBlock === "number" ? filter.toBlock : Infinity
+      return (
+        log.blockNumber >= fromBlock &&
+        log.blockNumber <= toBlock &&
+        (filter.topics ?? []).every((topic, index) => {
+          if (topic === null) return true
+          return Array.isArray(topic)
+            ? topic.includes(log.topics[index])
+            : topic === log.topics[index]
+        })
+      )
+    })
+  }
+  const instance = new EthereumBridge({
+    signerOrProvider: provider,
+    address: bridgeAddress,
+  })
+  const query =
+    eventName === "RedemptionsCompleted"
+      ? instance.getRedemptionsCompletedEvents.bind(instance)
+      : instance.getRedemptionTimedOutEvents.bind(instance)
+  return { provider, filters, query }
+}
 
 function bridge(): EthereumBridge {
   return new EthereumBridge({
@@ -19,59 +99,180 @@ function bridge(): EthereumBridge {
 }
 
 describe("redemption monitoring bridge methods", () => {
-  it("decodes proof completion and forwards the event window and filters", async () => {
-    const instance = bridge()
-    const options = { fromBlock: 100, toBlock: 200 }
-    instance.getEvents = async (name, requestedOptions, ...filters) => {
-      expect(name).to.equal("RedemptionsCompleted")
-      expect(requestedOptions).to.equal(options)
-      expect(filters).to.deep.equal([wallet])
-      return [
+  for (const eventName of [
+    "RedemptionsCompleted",
+    "RedemptionTimedOut",
+  ] as const) {
+    describe(eventName, () => {
+      for (const testCase of [
         {
-          blockNumber: 123,
-          blockHash,
-          transactionHash,
-          args: {
-            walletPubKeyHash: wallet,
-            redemptionTxHash: `0x01${"00".repeat(30)}ab`,
-          },
-        } as unknown as Event,
-      ]
-    }
-    const [event] = await instance.getRedemptionsCompletedEvents(
-      options,
-      wallet
-    )
-    expect(event.blockNumber).to.equal(123)
-    expect(event.blockHash.toPrefixedString()).to.equal(blockHash)
-    expect(event.transactionHash.toPrefixedString()).to.equal(transactionHash)
-    expect(event.walletPublicKeyHash.toPrefixedString()).to.equal(wallet)
-    expect(event.redemptionTxHash.toString()).to.equal(`ab${"00".repeat(30)}01`)
-  })
+          name: "a single wallet",
+          args: [wallet],
+          topics: [walletTopic(wallet)],
+          wallets: [wallet],
+        },
+        {
+          name: "an OR list of wallets",
+          args: [[wallet, otherWallet]],
+          topics: [[walletTopic(wallet), walletTopic(otherWallet)]],
+          wallets: [wallet, otherWallet],
+        },
+        {
+          name: "an omitted wallet filter",
+          args: [],
+          topics: [],
+          wallets: [wallet, otherWallet],
+        },
+        {
+          name: "a null wallet wildcard",
+          args: [null],
+          topics: [],
+          wallets: [wallet, otherWallet],
+        },
+        {
+          name: "a nonmatching wallet",
+          args: [unknownWallet],
+          topics: [walletTopic(unknownWallet)],
+          wallets: [],
+        },
+      ]) {
+        it(`queries canonical emitted topics for ${testCase.name}`, async () => {
+          const { filters, query } = eventQuery(eventName)
+          const events = await query(
+            { fromBlock: 100, toBlock: 200, retries: 0 },
+            ...testCase.args
+          )
+          expect(filters).to.have.length(1)
+          expect(filters[0].address).to.equal(bridgeAddress)
+          expect(filters[0].fromBlock).to.equal(100)
+          expect(filters[0].toBlock).to.equal(200)
+          expect(filters[0].topics).to.deep.equal([
+            eventInterface.getEventTopic(eventName),
+            ...testCase.topics,
+          ])
+          expect(
+            events.map((event) => event.walletPublicKeyHash.toPrefixedString())
+          ).to.deep.equal(testCase.wallets)
+          for (const event of events) {
+            expect(event.blockNumber).to.equal(123)
+            expect(event.blockHash.toPrefixedString()).to.equal(blockHash)
+            expect(event.transactionHash.toPrefixedString()).to.equal(
+              transactionHash
+            )
+            if ("redemptionTxHash" in event) {
+              expect(event.redemptionTxHash.toString()).to.equal(
+                `ab${"00".repeat(30)}01`
+              )
+            } else {
+              expect(event.redeemerOutputScript.toString()).to.equal(script)
+            }
+          }
+        })
+      }
 
-  it("removes the CompactSize prefix from a timeout event's output script", async () => {
-    const instance = bridge()
-    const options = { fromBlock: 10, toBlock: 20 }
-    instance.getEvents = async (name, requestedOptions) => {
-      expect(name).to.equal("RedemptionTimedOut")
-      expect(requestedOptions).to.equal(options)
-      return [
-        {
-          blockNumber: 15,
-          blockHash,
-          transactionHash,
-          args: {
-            walletPubKeyHash: wallet,
-            redeemerOutputScript: `0x16${script}`,
+      for (const byteLength of [19, 21]) {
+        it(`rejects a ${byteLength}-byte wallet filter before querying`, async () => {
+          const { filters, query } = eventQuery(eventName)
+          let caught: unknown
+          try {
+            await query(
+              { fromBlock: 100, toBlock: 200, retries: 0 },
+              `0x${"11".repeat(byteLength)}`
+            )
+          } catch (error) {
+            caught = error
+          }
+          expect(caught).to.be.instanceOf(Error)
+          expect(filters).to.have.length(0)
+        })
+      }
+
+      it("preserves wallet topics and block options in fallback batches", async () => {
+        const { provider, query } = eventQuery(eventName)
+        const getLogs = provider.getLogs.bind(provider)
+        const requests: providers.Filter[] = []
+        provider.getLogs = async (filter) => {
+          requests.push(await filter)
+          if (requests.length === 1) {
+            throw new Error("query range too large")
+          }
+          return getLogs(filter)
+        }
+        const messages: string[] = []
+        const events = await query(
+          {
+            fromBlock: 100,
+            toBlock: 200,
+            batchedQueryBlockInterval: 40,
+            retries: 0,
+            logger: (message) => messages.push(message),
           },
-        } as unknown as Event,
-      ]
-    }
-    const [event] = await instance.getRedemptionTimedOutEvents(options)
-    expect(event.redeemerOutputScript.toString()).to.equal(script)
-    expect(event.walletPublicKeyHash.toPrefixedString()).to.equal(wallet)
-    expect(event.transactionHash.toPrefixedString()).to.equal(transactionHash)
-  })
+          wallet
+        )
+        expect(
+          requests.map(({ fromBlock, toBlock }) => [fromBlock, toBlock])
+        ).to.deep.equal([
+          [100, 200],
+          [100, 140],
+          [141, 181],
+          [182, 200],
+        ])
+        for (const request of requests) {
+          expect(request.topics).to.deep.equal([
+            eventInterface.getEventTopic(eventName),
+            walletTopic(wallet),
+          ])
+        }
+        expect(messages).not.to.be.empty
+        expect(events).to.have.length(1)
+        expect(events[0].walletPublicKeyHash.toPrefixedString()).to.equal(
+          wallet
+        )
+      })
+
+      it("retries failed provider queries with the same wallet topics", async () => {
+        const { provider, query } = eventQuery(eventName)
+        const getLogs = provider.getLogs.bind(provider)
+        const requests: providers.Filter[] = []
+        provider.getLogs = async (filter) => {
+          requests.push(await filter)
+          if (requests.length <= 2) {
+            throw new Error("RPC temporarily unavailable")
+          }
+          return getLogs(filter)
+        }
+        const events = await query(
+          { fromBlock: 100, toBlock: 200, retries: 1 },
+          wallet
+        )
+        expect(requests).to.have.length(3)
+        for (const request of requests) {
+          expect(request.fromBlock).to.equal(100)
+          expect(request.toBlock).to.equal(200)
+          expect(request.topics).to.deep.equal([
+            eventInterface.getEventTopic(eventName),
+            walletTopic(wallet),
+          ])
+        }
+        expect(events).to.have.length(1)
+      })
+
+      it("propagates provider query failures so monitoring can retry the window", async () => {
+        const { provider, query } = eventQuery(eventName)
+        const failure = new Error("RPC unavailable")
+        provider.getLogs = async () => {
+          throw failure
+        }
+        let caught: unknown
+        try {
+          await query({ fromBlock: 100, toBlock: 200, retries: 0 })
+        } catch (error) {
+          caught = error
+        }
+        expect(caught).to.equal(failure)
+      })
+    })
+  }
 
   it("reads the timeout and pending request at the requested block, including zero", async () => {
     const instance = bridge()
@@ -112,25 +313,5 @@ describe("redemption monitoring bridge methods", () => {
     )
     expect(pending.requestedAt).to.equal(1234)
     expect(observedBlocks).to.deep.equal([0, "latest", 200])
-  })
-
-  it("propagates event query failures so monitoring can retry the window", async () => {
-    const instance = bridge()
-    const failure = new Error("RPC unavailable")
-    instance.getEvents = async () => {
-      throw failure
-    }
-    for (const query of [
-      () => instance.getRedemptionsCompletedEvents(),
-      () => instance.getRedemptionTimedOutEvents(),
-    ]) {
-      let caught: unknown
-      try {
-        await query()
-      } catch (error) {
-        caught = error
-      }
-      expect(caught).to.equal(failure)
-    }
   })
 })

--- a/typescript/test/lib/ethereum/redemption-monitoring.test.ts
+++ b/typescript/test/lib/ethereum/redemption-monitoring.test.ts
@@ -1,0 +1,136 @@
+import { expect } from "chai"
+import { BigNumber, providers } from "ethers"
+import type { Event } from "@ethersproject/contracts"
+import { EthereumBridge } from "../../../src/lib/ethereum/bridge"
+import { Hex } from "../../../src/lib/utils"
+
+const wallet = `0x${"11".repeat(20)}`
+const blockHash = `0x${"22".repeat(32)}`
+const transactionHash = `0x${"44".repeat(32)}`
+const script = `0014${"33".repeat(20)}`
+
+function bridge(): EthereumBridge {
+  return new EthereumBridge({
+    signerOrProvider: new providers.StaticJsonRpcProvider(undefined, {
+      name: "mainnet",
+      chainId: 1,
+    }),
+  })
+}
+
+describe("redemption monitoring bridge methods", () => {
+  it("decodes proof completion and forwards the event window and filters", async () => {
+    const instance = bridge()
+    const options = { fromBlock: 100, toBlock: 200 }
+    instance.getEvents = async (name, requestedOptions, ...filters) => {
+      expect(name).to.equal("RedemptionsCompleted")
+      expect(requestedOptions).to.equal(options)
+      expect(filters).to.deep.equal([wallet])
+      return [
+        {
+          blockNumber: 123,
+          blockHash,
+          transactionHash,
+          args: {
+            walletPubKeyHash: wallet,
+            redemptionTxHash: `0x01${"00".repeat(30)}ab`,
+          },
+        } as unknown as Event,
+      ]
+    }
+    const [event] = await instance.getRedemptionsCompletedEvents(
+      options,
+      wallet
+    )
+    expect(event.blockNumber).to.equal(123)
+    expect(event.blockHash.toPrefixedString()).to.equal(blockHash)
+    expect(event.transactionHash.toPrefixedString()).to.equal(transactionHash)
+    expect(event.walletPublicKeyHash.toPrefixedString()).to.equal(wallet)
+    expect(event.redemptionTxHash.toString()).to.equal(`ab${"00".repeat(30)}01`)
+  })
+
+  it("removes the CompactSize prefix from a timeout event's output script", async () => {
+    const instance = bridge()
+    const options = { fromBlock: 10, toBlock: 20 }
+    instance.getEvents = async (name, requestedOptions) => {
+      expect(name).to.equal("RedemptionTimedOut")
+      expect(requestedOptions).to.equal(options)
+      return [
+        {
+          blockNumber: 15,
+          blockHash,
+          transactionHash,
+          args: {
+            walletPubKeyHash: wallet,
+            redeemerOutputScript: `0x16${script}`,
+          },
+        } as unknown as Event,
+      ]
+    }
+    const [event] = await instance.getRedemptionTimedOutEvents(options)
+    expect(event.redeemerOutputScript.toString()).to.equal(script)
+    expect(event.walletPublicKeyHash.toPrefixedString()).to.equal(wallet)
+    expect(event.transactionHash.toPrefixedString()).to.equal(transactionHash)
+  })
+
+  it("reads the timeout and pending request at the requested block, including zero", async () => {
+    const instance = bridge()
+    const observedBlocks: unknown[] = []
+    Object.defineProperty(instance, "_instance", {
+      value: {
+        redemptionParameters: async (overrides: { blockTag: unknown }) => {
+          observedBlocks.push(overrides.blockTag)
+          return { redemptionTimeout: 172800 }
+        },
+        pendingRedemptions: async (
+          key: string,
+          overrides: { blockTag: unknown }
+        ) => {
+          expect(key).to.equal(
+            EthereumBridge.buildRedemptionKey(
+              Hex.from(wallet),
+              Hex.from(script)
+            )
+          )
+          observedBlocks.push(overrides.blockTag)
+          return {
+            redeemer: `0x${"55".repeat(20)}`,
+            requestedAmount: BigNumber.from(100000),
+            treasuryFee: BigNumber.from(100),
+            txMaxFee: BigNumber.from(1000),
+            requestedAt: 1234,
+          }
+        },
+      },
+    })
+    expect(await instance.getRedemptionTimeout(0)).to.equal(172800)
+    await instance.getRedemptionTimeout()
+    const pending = await instance.pendingRedemptionsByWalletPKH(
+      Hex.from(wallet),
+      Hex.from(script),
+      200
+    )
+    expect(pending.requestedAt).to.equal(1234)
+    expect(observedBlocks).to.deep.equal([0, "latest", 200])
+  })
+
+  it("propagates event query failures so monitoring can retry the window", async () => {
+    const instance = bridge()
+    const failure = new Error("RPC unavailable")
+    instance.getEvents = async () => {
+      throw failure
+    }
+    for (const query of [
+      () => instance.getRedemptionsCompletedEvents(),
+      () => instance.getRedemptionTimedOutEvents(),
+    ]) {
+      let caught: unknown
+      try {
+        await query()
+      } catch (error) {
+        caught = error
+      }
+      expect(caught).to.equal(failure)
+    }
+  })
+})

--- a/typescript/test/utils/mock-bridge.ts
+++ b/typescript/test/utils/mock-bridge.ts
@@ -7,6 +7,8 @@ import {
   Wallet,
   RedemptionRequest,
   RedemptionRequestedEvent,
+  RedemptionsCompletedEvent,
+  RedemptionTimedOutEvent,
   DepositReceipt,
   DepositRevealedEvent,
   DepositRequest,
@@ -402,6 +404,18 @@ export class MockBridge implements Bridge {
     options?: GetChainEvents.Options,
     ...filterArgs: Array<any>
   ): Promise<RedemptionRequestedEvent[]> {
+    throw new Error("not implemented")
+  }
+
+  getRedemptionsCompletedEvents(): Promise<RedemptionsCompletedEvent[]> {
+    throw new Error("not implemented")
+  }
+
+  getRedemptionTimedOutEvents(): Promise<RedemptionTimedOutEvent[]> {
+    throw new Error("not implemented")
+  }
+
+  getRedemptionTimeout(): Promise<number> {
     throw new Error("not implemented")
   }
 


### PR DESCRIPTION
Bridge consumers currently cannot query accepted redemption proofs, reported timeouts, or the configured redemption timeout through the SDK. This adds typed `RedemptionsCompleted` and `RedemptionTimedOut` event readers, `getRedemptionTimeout`, and optional historical-block reads for pending redemption requests.

Bitcoin transaction hashes use display byte order, and timeout-event output scripts omit the CompactSize prefix, matching the existing request-event API. Timeout reports are distinct from expiration: the contract emits the event only after a timeout report is accepted. Historical reads allow monitors to evaluate state at a consistent checkpoint. The generated API reference is updated for these changes and refreshed to include public exports already present on `dev`. Two existing lint violations are corrected so the full SDK formatting check passes.

Wallet filters on both new event readers encode indexed `bytes20` topics with the ABI-required right padding. Single-wallet filters and OR lists match emitted events; omitted or null filters remain wildcards. Queries retain the configured block window, batching fallback, and retries.

Refs threshold-network/keep-core#3664. This SDK PR targets `dev`. The monitoring service currently pins SDK 2.5, while this source tree is 4.0-dev; the companion monitoring PR #1126 uses a narrow local contract adapter to avoid requiring an unpublished major SDK release.

Compatibility: existing calls with two arguments still work. Custom `Bridge` implementations must implement the three new methods; the SDK test mock is updated.

Validation:
- Immutable Yarn 4.12.0 dependency installation and SDK build pass.
- 21 focused event-query and historical-read tests pass on Node 22. They exercise the real ethers contract query through a local provider stub and cover generated topics, matching/nonmatching wallets, OR lists, wildcards, invalid lengths, decoding, fallback batching, retries, and RPC failures.
- Full `yarn format` (ESLint and Prettier) passes; `git diff --check` passes.
- 30 focused Sui and Starknet depositor tests pass, with one existing pending test.
- Generated API reference is refreshed with the locked TypeDoc dependencies, including the previously missing Solana and Starknet class pages.
- No live chain RPC or transaction submission was performed.

