### PR TITLE
feat(monitoring): report redemption proof and timeout lifecycle

### DIFF
--- a/monitoring/README.adoc
+++ b/monitoring/README.adoc
@@ -200,6 +200,8 @@ The behavior can be configured using the following env variables:
 
 |*LARGE_REDEMPTION_THRESHOLD_SAT* |Satoshi threshold used to determine which redemptions are large. Default: _1000000000_ |No
 
+|*REDEMPTION_TIMEOUT_WARNING_SECONDS* |Positive integer lead time for pending redemption deadline warnings. Default: _21600_ (6 hours); capped at the Bridge timeout. |No
+
 |*DATA_DIR_PATH* |Directory used to persist processing data. Default: _./data_ |No
 
 |*SENTRY_DSN* |DSN of the Sentry receiver. If not set, events are not dispatched to Sentry |No
@@ -208,6 +210,54 @@ The behavior can be configured using the following env variables:
 |===
 
 === Deployment
+
+==== Redemption lifecycle rollout
+
+The redemption lifecycle monitor adds proof-accepted notifications, pending
+request deadline warnings, expired-without-proof alerts, and accepted timeout
+report alerts. Configure both `DISCORD_WEBHOOK_URL` (informational events) and
+`SENTRY_DSN` (warnings and critical events) to deliver all four. A deployment with
+only one receiver intentionally ignores the event types supported by the other.
+
+Deadlines use Ethereum block timestamps and the Bridge's configured timeout,
+not an assumed block duration. Pending state and timeout parameters are read
+at the window's end block; the timeout is also read at the start block to
+handle changes made through governance. The RPC must support historical state
+for every replayed checkpoint. Unavailable state or logs fail the run and keep
+the checkpoint for retry. Log queries are split into batches of at most 5,000
+blocks. Tune the monitoring schedule and RPC limits against the request volume.
+
+The monitor queries requests whose warning or expiry crosses the current
+checkpoint window. On first installation, or when enabling this monitor on an
+existing checkpoint, it does not inventory requests that crossed their threshold
+before that window. Before relying on coverage:
+
+. Stop the scheduled job and back up `DATA_DIR_PATH/db.json` before changing its
+  checkpoint. Preserve the handled-event history for deduplication.
+. Select a historical block before the earliest warning/deadline requiring
+  backfill, at or after the Bridge deployment. Rewind `checkpointBlock` to that
+  block on a copy of the data directory and run with staging receivers. Every
+  monitor shares this checkpoint, so review the resulting notification volume.
+. Verify that proof acceptance reaches Discord and near-timeout, expiration,
+  and timeout-report events reach Sentry, including failed delivery followed by
+  retry. Run `yarn test` for deterministic boundary, reorg-overlap, and RPC
+  failure checks; these tests do not contact live receivers.
+. Apply the reviewed checkpoint to the stopped production job and resume it.
+  Catch-up advances in the Manager's bounded windows. Check pending requests
+  older than the chosen backfill range separately before declaring coverage.
+  The handled-event cache is bounded, so a sufficiently large replay can resend
+  notifications that have aged out of it.
+
+The service retains its published SDK 2.5 dependency. A narrow read-only contract
+adapter supplies lifecycle reads until the service can upgrade to an SDK release
+that exposes them; no unpublished SDK build or new runtime dependency is needed.
+Wallet proposal broadcasts are off-chain and require the wallet node telemetry
+described in `keep-core/docs/redemption-proposal-monitoring.adoc`. Complete those
+receiver and maintainer-alert rollout checks before closing keep-core issue #3664.
+
+To roll back, restore the previous monitoring image while preserving the data
+directory and its backup. Account for lifecycle notifications already delivered
+when replaying the checkpoint after re-enabling this monitor.
 
 ==== Docker image
 

--- a/monitoring/README.adoc
+++ b/monitoring/README.adoc
@@ -86,67 +86,51 @@ checkpoint block is 100, the loop will look as follows:
 - Run 2: Start block 150 - 12 = 138, end block 155
 - Run 3: Start block 155 - 12 = 143, end block 200
 
-This way we are achieving a sliding block window that covers the entire
-chain. Worth noting, the checkpoint block is updated only if the given run
-completes with success. A run is considered successful when no single error was
-thrown by any of the components. If the run is not successful, the checkpoint
-block is not updated and the next run will cover the exact failed range again.
-The Manager saves both bounds in `pendingBlockRange` in `db.json` before
-checking or delivering events, so retries retain the same historical state even
-after the job restarts or a pending redemption is completed in a newer block:
+Scanning and notification delivery have separate persistence. Before delivery,
+the Manager saves the scanned event payloads in `pendingSystemEvents` in
+`db.json`, grouped by receiver ID. Once every monitor has completed and those
+payloads are saved, the scan checkpoint advances even if a receiver rejects a
+notification. New critical notifications can therefore reach Sentry while
+Discord retries an older informational notification.
 
-- Run 1: Start block 100 - 12 = 88, end block 150 - failed
-- Run 2: Start block 100 - 12 = 88, end block 150 - failed
-- Run 3: Start block 100 - 12 = 88, end block 150 - success
-- Run 4: Start block 150 - 12 = 138, end block 250 - success
+A run still reports failure when any receiver rejects delivery. Its pending
+notifications are retried alongside new events on subsequent runs, including
+after process restarts. Payloads remain queued even if later chain state changes,
+such as a proof being accepted after an expiration alert was first generated.
+Temporarily removing a receiver preserves its queue until that receiver ID is
+configured again. Events explicitly ignored by a receiver are removed from its
+queue; events ignored by every receiver are valid in partial deployments.
 
-The pending range is cleared only after handled events and the successful
-checkpoint have been saved. Existing data directories without this field are
-supported. Preserve a pending range during delivery recovery; complete its retry
-before manually rewinding the checkpoint.
+The Manager also persists `pendingBlockRange` before scanning. A monitor or
+initial queue-storage failure keeps that range for historical retry. Delivery
+failures alone do not retain it: after durable event capture, the checkpoint is
+saved and the range is cleared. Existing data directories without these fields
+are supported. An outstanding range from an earlier version is scanned once
+and its events queued before scanning advances.
 
-This way the monitoring tool guarantees to not miss any system events.
-However, such a solution can produce duplicated system events. To prevent
-that, the *Manager* component contains a deduplication logic that leverages
-the *Persistence* component to filter out already handled system events.
+Handled events are saved for deduplication before acknowledged notifications
+are removed from the queue. A process exit or storage failure after external
+acceptance can still cause a notification to be delivered again. The handled
+history is bounded; pending notifications are never truncated. A prolonged
+receiver outage can therefore increase the size of `db.json`.
 
-=== Sentry delivery failures
+=== Receiver delivery failures
 
-The Sentry receiver is intentionally fail-closed. A run fails if Sentry does not
-accept a warning or critical system event, or if the event is not flushed before
-the receiver returns. When that happens, the checkpoint block is not advanced
-and the next run will rescan the same block range.
+The Sentry receiver reports failure if Sentry rejects a warning or critical
+event, or if the event is not flushed before the receiver returns. Discord
+failures are also reported. Either receiver's failed notifications remain in
+its own queue while healthy receivers continue receiving new events.
 
-This behavior prevents silent alert loss but means a Sentry outage, disabled
-Sentry project, invalid DSN, or rate limit can halt monitoring progress until
-delivery recovers. Operators should:
+On a delivery failure, check the reported receiver's credentials, service limits,
+and network reachability. Resume the scheduled job after recovery to drain its
+pending notifications. Preserve `pendingSystemEvents` and handled history during
+recovery; rewinding the scan checkpoint is unnecessary for queued notifications.
 
-- confirm the Sentry DSN and project are enabled,
-- check Sentry rate limits and network reachability from the monitoring
-  environment,
-- rerun or wait for the monitoring loop after Sentry recovers, and
-- expect catch-up to proceed in capped block-range increments if the checkpoint
-  is stale.
-
-=== Dispatch coverage failures
-
-The monitoring manager is fail-closed on dispatch coverage. A run fails if a
-system event produced by a monitor is not accepted (handled or deduplicated) by
-any receiver that attempted delivery. When that happens, the checkpoint block is
-not advanced and the next run will rescan the same block range.
-
-Events explicitly ignored by all registered receivers do not trigger a coverage
-failure. This is expected in partial-receiver deployments -- for example, if
-only the Sentry receiver is configured, informational events will not produce
-coverage errors because Sentry only accepts warning and critical events.
-
-If monitoring halts with a coverage failure, check that:
-
-- all active receivers are healthy (dispatch errors will appear earlier in the
-  same run's log),
-- the receiver configuration covers every event type emitted by active
-  monitors, and
-- no new monitor event types were recently added without a matching receiver.
+A run also reports pending notifications whose receiver is no longer configured.
+Restore that receiver with the same ID to deliver its queue. This does not prevent
+scanning or delivery to other receivers. With only Sentry configured, newly
+scanned informational events are intentionally ignored because Sentry supports
+only warnings and critical events.
 
 == Build and deployment
 
@@ -247,8 +231,9 @@ before that window. Before relying on coverage:
 . Stop the scheduled job and back up `DATA_DIR_PATH/db.json` before changing its
   checkpoint. Preserve the handled-event history for deduplication.
 . If `pendingBlockRange` is non-null, resume the unchanged job to finish that
-  retry before stopping and rewinding. Otherwise a manual checkpoint change
-  would not replace the outstanding range.
+  scan and capture its events before stopping and rewinding. Otherwise a manual
+  checkpoint change would not replace the outstanding range. Preserve
+  `pendingSystemEvents`; delivery retries do not require a checkpoint rewind.
 . Select a historical block before the earliest warning/deadline requiring
   backfill, at or after the Bridge deployment. Rewind `checkpointBlock` to that
   block on a copy of the data directory and run with staging receivers. Every
@@ -270,9 +255,11 @@ Wallet proposal broadcasts are off-chain and require the wallet node telemetry
 described in `keep-core/docs/redemption-proposal-monitoring.adoc`. Complete those
 receiver and maintainer-alert rollout checks before closing keep-core issue #3664.
 
-To roll back, restore the previous monitoring image while preserving the data
-directory and its backup. Account for lifecycle notifications already delivered
-when replaying the checkpoint after re-enabling this monitor.
+Before rolling back to an image without delivery-queue support, finish delivering
+`pendingSystemEvents`; that image cannot retry queued payloads whose scan
+checkpoint has advanced. Preserve the data directory and its backup. Account for
+lifecycle notifications already delivered when replaying the checkpoint after
+re-enabling this monitor.
 
 ==== Docker image
 

--- a/monitoring/README.adoc
+++ b/monitoring/README.adoc
@@ -90,12 +90,20 @@ This way we are achieving a sliding block window that covers the entire
 chain. Worth noting, the checkpoint block is updated only if the given run
 completes with success. A run is considered successful when no single error was
 thrown by any of the components. If the run is not successful, the checkpoint
-block is not updated and the next run will cover the failed range again:
+block is not updated and the next run will cover the exact failed range again.
+The Manager saves both bounds in `pendingBlockRange` in `db.json` before
+checking or delivering events, so retries retain the same historical state even
+after the job restarts or a pending redemption is completed in a newer block:
 
 - Run 1: Start block 100 - 12 = 88, end block 150 - failed
-- Run 2: Start block 100 - 12 = 88, end block 170 - failed
-- Run 3: Start block 100 - 12 = 88, end block 200 - success
-- Run 4: Start block 200 - 12 = 188, end block 250 - success
+- Run 2: Start block 100 - 12 = 88, end block 150 - failed
+- Run 3: Start block 100 - 12 = 88, end block 150 - success
+- Run 4: Start block 150 - 12 = 138, end block 250 - success
+
+The pending range is cleared only after handled events and the successful
+checkpoint have been saved. Existing data directories without this field are
+supported. Preserve a pending range during delivery recovery; complete its retry
+before manually rewinding the checkpoint.
 
 This way the monitoring tool guarantees to not miss any system events.
 However, such a solution can produce duplicated system events. To prevent
@@ -222,7 +230,11 @@ only one receiver intentionally ignores the event types supported by the other.
 Deadlines use Ethereum block timestamps and the Bridge's configured timeout,
 not an assumed block duration. Pending state and timeout parameters are read
 at the window's end block; the timeout is also read at the start block to
-handle changes made through governance. The RPC must support historical state
+handle changes made through governance. If the start precedes Bridge deployment,
+the first deployed state in the window supplies the initial timeout and timestamp.
+Windows entirely before deployment have no pending requests to check. Empty
+contract responses are treated as pre-deployment only when historical `eth_getCode`
+confirms no code at that block. The RPC must support historical state
 for every replayed checkpoint. Unavailable state or logs fail the run and keep
 the checkpoint for retry. Log queries are split into batches of at most 5,000
 blocks. Tune the monitoring schedule and RPC limits against the request volume.
@@ -234,6 +246,9 @@ before that window. Before relying on coverage:
 
 . Stop the scheduled job and back up `DATA_DIR_PATH/db.json` before changing its
   checkpoint. Preserve the handled-event history for deduplication.
+. If `pendingBlockRange` is non-null, resume the unchanged job to finish that
+  retry before stopping and rewinding. Otherwise a manual checkpoint change
+  would not replace the outstanding range.
 . Select a historical block before the earliest warning/deadline requiring
   backfill, at or after the Bridge deployment. Rewind `checkpointBlock` to that
   block on a copy of the data directory and run with staging receivers. Every

--- a/monitoring/docs/monitoring-and-telemetry.adoc
+++ b/monitoring/docs/monitoring-and-telemetry.adoc
@@ -189,6 +189,42 @@ should get team’s attention. The default action is investigating the cause
 of the extended processing time as this alert may be an early sign of
 a malfunctioning wallet or may indicate a problem with the maintainer bot.
 
+==== Redemption proof accepted
+
+An *informational system event* sent to Discord when the Bridge emits
+`RedemptionsCompleted`, confirming acceptance of an SPV proof. It includes the
+wallet public key hash, Bitcoin redemption transaction hash in display byte
+order, and Ethereum proof transaction. Proof submission attempts and off-chain
+proposal broadcasts do not trigger this notification.
+
+==== Redemption nearing timeout
+
+A *warning system event* sent to Sentry when a pending request enters the
+configured warning period (6 hours by default). The deadline is the request's
+block timestamp plus the current Bridge timeout. Confirm Bitcoin transaction
+status and SPV maintainer progress before the deadline. If a catch-up window
+ends after expiration, the monitor emits the critical expiration alert instead.
+
+==== Redemption expired without proof
+
+A *critical system event* sent to Sentry when a request remains pending strictly
+after its contract deadline. Expiration does not emit an on-chain event; the
+monitor derives it from checkpointed pending state. This alert does not assert
+that a timeout report was submitted or that the Bitcoin payment failed. Check
+the payment, proof acceptance, and maintainer state immediately.
+
+==== Redemption timeout reported
+
+A *critical system event* sent to Sentry when the Bridge emits
+`RedemptionTimedOut`. This confirms that a timeout report was accepted, separately
+from the earlier derived expiration alert. It includes the wallet, output script,
+and Ethereum reporting transaction. Inspect the affected wallet and request.
+
+Lifecycle deadline alerts use stable request identifiers and deadlines so the
+Manager can deduplicate overlapping/retried windows. Follow the initial backfill
+and receiver validation procedure in link:../README.adoc[the rollout guide]; a
+new checkpoint does not automatically inventory every already-expired request.
+
 ==== Optimistic minting cancelled
 
 A *warning system event* indicating that an optimistic minting request was

--- a/monitoring/src/context.ts
+++ b/monitoring/src/context.ts
@@ -7,6 +7,7 @@ const {
   ELECTRUM_URL,
   LARGE_DEPOSIT_THRESHOLD_SAT,
   LARGE_REDEMPTION_THRESHOLD_SAT,
+  REDEMPTION_TIMEOUT_WARNING_SECONDS,
   DATA_DIR_PATH,
   SENTRY_DSN,
   DISCORD_WEBHOOK_URL,
@@ -66,6 +67,9 @@ export const context = {
   electrumUrl: resolveElectrumUrl(),
   largeDepositThresholdSat: LARGE_DEPOSIT_THRESHOLD_SAT ?? 1000000000, // 10 BTC by default
   largeRedemptionThresholdSat: LARGE_REDEMPTION_THRESHOLD_SAT ?? 1000000000, // 10 BTC by default
+  redemptionTimeoutWarningSeconds: Number(
+    REDEMPTION_TIMEOUT_WARNING_SECONDS ?? 6 * 60 * 60
+  ),
   dataDirPath: DATA_DIR_PATH ?? "./data",
   sentryDsn: SENTRY_DSN,
   discordWebhookUrl: DISCORD_WEBHOOK_URL,

--- a/monitoring/src/file-persistence.ts
+++ b/monitoring/src/file-persistence.ts
@@ -4,6 +4,7 @@ import { context } from "./context"
 
 import type { SupplyMonitorPersistence } from "./supply-monitor"
 import type {
+  BlockRange,
   Persistence as SystemEventPersistence,
   ReceiverId as SystemEventReceiverId,
   SystemEvent,
@@ -15,6 +16,8 @@ export class SystemEventFilePersistence implements SystemEventPersistence {
   private readonly checkpointBlockPath = "/checkpointBlock"
 
   private readonly handledSystemEventsPath = "/handledSystemEvents"
+
+  private readonly pendingBlockRangePath = "/pendingBlockRange"
 
   private db: JsonDB
 
@@ -34,6 +37,19 @@ export class SystemEventFilePersistence implements SystemEventPersistence {
 
   async updateCheckpointBlock(block: number): Promise<void> {
     await this.db.push(this.checkpointBlockPath, block)
+  }
+
+  async pendingBlockRange(): Promise<BlockRange | null> {
+    // Existing data directories have no pending range until their first run.
+    if (!(await this.db.exists(this.pendingBlockRangePath))) {
+      return null
+    }
+
+    return this.db.getObject<BlockRange | null>(this.pendingBlockRangePath)
+  }
+
+  async updatePendingBlockRange(range: BlockRange | null): Promise<void> {
+    await this.db.push(this.pendingBlockRangePath, range)
   }
 
   async handledSystemEvents(): Promise<

--- a/monitoring/src/file-persistence.ts
+++ b/monitoring/src/file-persistence.ts
@@ -19,6 +19,8 @@ export class SystemEventFilePersistence implements SystemEventPersistence {
 
   private readonly pendingBlockRangePath = "/pendingBlockRange"
 
+  private readonly pendingSystemEventsPath = "/pendingSystemEvents"
+
   private db: JsonDB
 
   constructor() {
@@ -50,6 +52,24 @@ export class SystemEventFilePersistence implements SystemEventPersistence {
 
   async updatePendingBlockRange(range: BlockRange | null): Promise<void> {
     await this.db.push(this.pendingBlockRangePath, range)
+  }
+
+  async pendingSystemEvents(): Promise<
+    Record<SystemEventReceiverId, SystemEvent[]>
+  > {
+    if (!(await this.db.exists(this.pendingSystemEventsPath))) {
+      return {}
+    }
+    return this.db.getObject<Record<SystemEventReceiverId, SystemEvent[]>>(
+      this.pendingSystemEventsPath
+    )
+  }
+
+  async updatePendingSystemEvents(
+    systemEvents: Record<SystemEventReceiverId, SystemEvent[]>
+  ): Promise<void> {
+    // Pending notifications must not be truncated like the handled-event cache.
+    await this.db.push(this.pendingSystemEventsPath, systemEvents)
   }
 
   async handledSystemEvents(): Promise<

--- a/monitoring/src/index.ts
+++ b/monitoring/src/index.ts
@@ -18,6 +18,8 @@ import { MintingMonitor } from "./minting-monitor"
 import { WalletMonitor } from "./wallet-monitor"
 import { SupplyMonitor } from "./supply-monitor"
 import { RedemptionMonitor } from "./redemption-monitor"
+import { RedemptionChain } from "./redemption-chain"
+import { RedemptionLifecycleMonitor } from "./redemption-lifecycle-monitor"
 
 import type {
   Monitor as SystemEventMonitor,
@@ -54,6 +56,13 @@ async function setupMonitoring(sdk: TBTC): Promise<SystemEventManager> {
     ),
     new WalletMonitor(tbtcContracts.bridge),
     new RedemptionMonitor(tbtcContracts.bridge),
+    new RedemptionLifecycleMonitor(
+      new RedemptionChain(
+        tbtcContracts.bridge,
+        new providers.JsonRpcProvider(context.ethereumUrl)
+      ),
+      context.redemptionTimeoutWarningSeconds
+    ),
   ]
 
   const receivers: SystemEventReceiver[] = ((): SystemEventReceiver[] => {

--- a/monitoring/src/redemption-chain.ts
+++ b/monitoring/src/redemption-chain.ts
@@ -1,0 +1,198 @@
+import { BigNumber, utils } from "ethers"
+import {
+  BitcoinCompactSizeUint,
+  BitcoinTxHash,
+  EthereumBridge,
+  Hex,
+} from "@keep-network/tbtc-v2.ts"
+
+import type { providers } from "ethers"
+import type {
+  Bridge,
+  ChainEvent,
+  RedemptionRequestedEvent,
+} from "@keep-network/tbtc-v2.ts"
+
+export interface RedemptionsCompletedEvent extends ChainEvent {
+  walletPublicKeyHash: Hex
+  redemptionTxHash: BitcoinTxHash
+}
+
+export interface RedemptionTimedOutEvent extends ChainEvent {
+  walletPublicKeyHash: Hex
+  redeemerOutputScript: Hex
+}
+
+export interface RedemptionLifecycleSource {
+  requested(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<RedemptionRequestedEvent[]>
+  completed(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<RedemptionsCompletedEvent[]>
+  timedOut(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<RedemptionTimedOutEvent[]>
+  timeout(block: number): Promise<number>
+  pendingRequestedAt(
+    request: RedemptionRequestedEvent,
+    block: number
+  ): Promise<number>
+  blockTimestamp(block: number): Promise<number>
+}
+
+// The monitoring package pins SDK 2.5. Keep this small read-only adapter until
+// its SDK can be upgraded to a release exposing these lifecycle methods.
+// Signatures match solidity/contracts/bridge/Bridge.sol.
+export const redemptionMonitoringABI = new utils.Interface([
+  "event RedemptionsCompleted(bytes20 indexed walletPubKeyHash, bytes32 redemptionTxHash)",
+  "event RedemptionTimedOut(bytes20 indexed walletPubKeyHash, bytes redeemerOutputScript)",
+  "function redemptionParameters() view returns (uint64 redemptionDustThreshold, uint64 redemptionTreasuryFeeDivisor, uint64 redemptionTxMaxFee, uint64 redemptionTxMaxTotalFee, uint32 redemptionTimeout, uint96 redemptionTimeoutSlashingAmount, uint32 redemptionTimeoutNotifierRewardMultiplier)",
+  "function pendingRedemptions(uint256 redemptionKey) view returns (tuple(address redeemer, uint64 requestedAmount, uint64 treasuryFee, uint64 txMaxFee, uint32 requestedAt))",
+])
+
+const maxLogQueryBlocks = 5000
+
+export class RedemptionChain implements RedemptionLifecycleSource {
+  private readonly address: string
+
+  constructor(
+    private readonly bridge: Pick<
+      Bridge,
+      "getChainIdentifier" | "getRedemptionRequestedEvents"
+    >,
+    private readonly provider: Pick<
+      providers.Provider,
+      "getLogs" | "call" | "getBlock"
+    >
+  ) {
+    this.address = `0x${bridge.getChainIdentifier().identifierHex}`
+  }
+
+  async requested(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<RedemptionRequestedEvent[]> {
+    return RedemptionChain.inBatches(fromBlock, toBlock, (from, to) =>
+      this.bridge.getRedemptionRequestedEvents({ fromBlock: from, toBlock: to })
+    )
+  }
+
+  async completed(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<RedemptionsCompletedEvent[]> {
+    const logs = await this.logs("RedemptionsCompleted", fromBlock, toBlock)
+    return logs.map((log) => ({
+      ...RedemptionChain.metadata(log),
+      walletPublicKeyHash: Hex.from(
+        redemptionMonitoringABI.parseLog(log).args.walletPubKeyHash
+      ),
+      redemptionTxHash: BitcoinTxHash.from(
+        redemptionMonitoringABI.parseLog(log).args.redemptionTxHash
+      ).reverse(),
+    }))
+  }
+
+  async timedOut(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<RedemptionTimedOutEvent[]> {
+    const logs = await this.logs("RedemptionTimedOut", fromBlock, toBlock)
+    return logs.map((log) => {
+      const { walletPubKeyHash, redeemerOutputScript } =
+        redemptionMonitoringABI.parseLog(log).args
+      const script = Hex.from(redeemerOutputScript)
+      const prefix = BitcoinCompactSizeUint.read(script)
+      return {
+        ...RedemptionChain.metadata(log),
+        walletPublicKeyHash: Hex.from(walletPubKeyHash),
+        redeemerOutputScript: Hex.from(
+          script.toString().slice(prefix.byteLength * 2)
+        ),
+      }
+    })
+  }
+
+  async timeout(block: number): Promise<number> {
+    const result = await this.read("redemptionParameters", [], block)
+    return BigNumber.from(result.redemptionTimeout).toNumber()
+  }
+
+  async pendingRequestedAt(
+    request: RedemptionRequestedEvent,
+    block: number
+  ): Promise<number> {
+    const key = EthereumBridge.buildRedemptionKey(
+      request.walletPublicKeyHash,
+      request.redeemerOutputScript
+    )
+    const result = await this.read("pendingRedemptions", [key], block)
+    return BigNumber.from(result[0].requestedAt).toNumber()
+  }
+
+  async blockTimestamp(block: number): Promise<number> {
+    const header = await this.provider.getBlock(block)
+    if (!header) throw new Error(`missing Ethereum block ${block}`)
+    return header.timestamp
+  }
+
+  private async read(
+    method: string,
+    args: unknown[],
+    block: number
+  ): Promise<utils.Result> {
+    const encoded = await this.provider.call(
+      {
+        to: this.address,
+        data: redemptionMonitoringABI.encodeFunctionData(method, args),
+      },
+      block
+    )
+    return redemptionMonitoringABI.decodeFunctionResult(method, encoded)
+  }
+
+  private logs(
+    event: string,
+    fromBlock: number,
+    toBlock: number
+  ): Promise<providers.Log[]> {
+    return RedemptionChain.inBatches(fromBlock, toBlock, (from, to) =>
+      this.provider.getLogs({
+        address: this.address,
+        topics: [redemptionMonitoringABI.getEventTopic(event)],
+        fromBlock: from,
+        toBlock: to,
+      })
+    )
+  }
+
+  private static metadata(log: providers.Log): ChainEvent {
+    return {
+      blockNumber: log.blockNumber,
+      blockHash: Hex.from(log.blockHash),
+      transactionHash: Hex.from(log.transactionHash),
+    }
+  }
+
+  private static async inBatches<T>(
+    fromBlock: number,
+    toBlock: number,
+    query: (from: number, to: number) => Promise<T[]>
+  ): Promise<T[]> {
+    const result: T[] = []
+    for (let from = fromBlock; from <= toBlock; from += maxLogQueryBlocks) {
+      // Sequential batches cap RPC pressure during catch-up and timeout changes.
+      // eslint-disable-next-line no-await-in-loop
+      const batch = await query(
+        from,
+        Math.min(from + maxLogQueryBlocks - 1, toBlock)
+      )
+      result.push(...batch)
+    }
+    return result
+  }
+}

--- a/monitoring/src/redemption-chain.ts
+++ b/monitoring/src/redemption-chain.ts
@@ -36,7 +36,8 @@ export interface RedemptionLifecycleSource {
     fromBlock: number,
     toBlock: number
   ): Promise<RedemptionTimedOutEvent[]>
-  timeout(block: number): Promise<number>
+  // Undefined means the Bridge had no code at this historical block.
+  timeout(block: number): Promise<number | undefined>
   pendingRequestedAt(
     request: RedemptionRequestedEvent,
     block: number
@@ -66,7 +67,7 @@ export class RedemptionChain implements RedemptionLifecycleSource {
     >,
     private readonly provider: Pick<
       providers.Provider,
-      "getLogs" | "call" | "getBlock"
+      "getLogs" | "call" | "getBlock" | "getCode"
     >
   ) {
     this.address = `0x${bridge.getChainIdentifier().identifierHex}`
@@ -117,8 +118,21 @@ export class RedemptionChain implements RedemptionLifecycleSource {
     })
   }
 
-  async timeout(block: number): Promise<number> {
-    const result = await this.read("redemptionParameters", [], block)
+  async timeout(block: number): Promise<number | undefined> {
+    const encoded = await this.call("redemptionParameters", [], block)
+    // eth_call returns empty data before deployment. Confirm the missing code
+    // rather than interpreting archive-node errors or invalid deployed responses
+    // as an empty monitoring window.
+    if (
+      encoded === "0x" &&
+      (await this.provider.getCode(this.address, block)) === "0x"
+    ) {
+      return undefined
+    }
+    const result = redemptionMonitoringABI.decodeFunctionResult(
+      "redemptionParameters",
+      encoded
+    )
     return BigNumber.from(result.redemptionTimeout).toNumber()
   }
 
@@ -145,14 +159,22 @@ export class RedemptionChain implements RedemptionLifecycleSource {
     args: unknown[],
     block: number
   ): Promise<utils.Result> {
-    const encoded = await this.provider.call(
+    const encoded = await this.call(method, args, block)
+    return redemptionMonitoringABI.decodeFunctionResult(method, encoded)
+  }
+
+  private call(
+    method: string,
+    args: unknown[],
+    block: number
+  ): Promise<string> {
+    return this.provider.call(
       {
         to: this.address,
         data: redemptionMonitoringABI.encodeFunctionData(method, args),
       },
       block
     )
-    return redemptionMonitoringABI.decodeFunctionResult(method, encoded)
   }
 
   private logs(

--- a/monitoring/src/redemption-lifecycle-monitor.ts
+++ b/monitoring/src/redemption-lifecycle-monitor.ts
@@ -1,0 +1,169 @@
+import { SystemEventType } from "./system-event"
+import { createBtcTxUrl, createEthTxUrl } from "./block-explorer"
+import { satsToRoundedBTC } from "./deposit-monitor"
+
+import type { RedemptionRequestedEvent } from "@keep-network/tbtc-v2.ts"
+import type { Monitor, SystemEvent } from "./system-event"
+import type { RedemptionLifecycleSource } from "./redemption-chain"
+
+export class RedemptionLifecycleMonitor implements Monitor {
+  constructor(
+    private readonly chain: RedemptionLifecycleSource,
+    private readonly warningSeconds: number = 6 * 60 * 60
+  ) {
+    if (!Number.isSafeInteger(warningSeconds) || warningSeconds <= 0) {
+      throw new Error(
+        "redemption timeout warning must be a positive integer in seconds"
+      )
+    }
+  }
+
+  async check(fromBlock: number, toBlock: number): Promise<SystemEvent[]> {
+    const [completed, timedOut, pending] = await Promise.all([
+      this.chain.completed(fromBlock, toBlock),
+      this.chain.timedOut(fromBlock, toBlock),
+      this.checkPending(fromBlock, toBlock),
+    ])
+    return [
+      ...completed.map(
+        (event): SystemEvent => ({
+          title: "Redemption proof accepted",
+          type: SystemEventType.Informational,
+          data: {
+            walletPublicKeyHash: event.walletPublicKeyHash.toString(),
+            redemptionTxHash: event.redemptionTxHash.toString(),
+            redemptionTxHashURL: createBtcTxUrl(event.redemptionTxHash),
+            ethProofTxHash: event.transactionHash.toPrefixedString(),
+            ethProofTxHashURL: createEthTxUrl(event.transactionHash),
+          },
+          block: event.blockNumber,
+        })
+      ),
+      ...timedOut.map(
+        (event): SystemEvent => ({
+          title: "Redemption timeout reported",
+          type: SystemEventType.Critical,
+          data: {
+            walletPublicKeyHash: event.walletPublicKeyHash.toString(),
+            redeemerOutputScript: event.redeemerOutputScript.toString(),
+            ethTimeoutTxHash: event.transactionHash.toPrefixedString(),
+            ethTimeoutTxHashURL: createEthTxUrl(event.transactionHash),
+          },
+          block: event.blockNumber,
+        })
+      ),
+      ...pending,
+    ]
+  }
+
+  private async checkPending(
+    fromBlock: number,
+    toBlock: number
+  ): Promise<SystemEvent[]> {
+    // Cache timestamps only for this run so a later run can observe a reorg.
+    const timestamps = new Map<number, Promise<number>>()
+    const timestamp = (block: number): Promise<number> => {
+      const existing = timestamps.get(block)
+      if (existing) return existing
+      const pending = this.chain.blockTimestamp(block)
+      timestamps.set(block, pending)
+      return pending
+    }
+    const [fromTime, toTime, previousTimeout, timeout] = await Promise.all([
+      timestamp(fromBlock),
+      timestamp(toBlock),
+      this.chain.timeout(fromBlock),
+      this.chain.timeout(toBlock),
+    ])
+    if (timeout <= 0 || previousTimeout <= 0)
+      throw new Error("invalid Bridge redemption timeout")
+
+    // Query requests whose warning or expiry can cross this checkpoint window.
+    // Include the old timeout so reductions through governance cannot hide a
+    // newly expired request. State reads use the same end block as the events.
+    const earliest = Math.max(
+      0,
+      fromTime - Math.max(previousTimeout, timeout) - 1
+    )
+    const latest = Math.max(
+      0,
+      toTime - timeout + Math.min(this.warningSeconds, timeout)
+    )
+    const firstAtOrAfter = async (target: number): Promise<number> => {
+      let low = 0
+      let high = toBlock + 1
+      while (low < high) {
+        const mid = Math.floor((low + high) / 2)
+        // eslint-disable-next-line no-await-in-loop
+        if ((await timestamp(mid)) < target) low = mid + 1
+        else high = mid
+      }
+      return low
+    }
+    const [start, end] = await Promise.all([
+      firstAtOrAfter(earliest),
+      firstAtOrAfter(latest + 1),
+    ])
+    const requests =
+      start < end ? await this.chain.requested(start, end - 1) : []
+    const events: SystemEvent[] = []
+    // Sequential request reads bound concurrency when a window contains many requests.
+    // eslint-disable-next-line no-restricted-syntax
+    for (const request of requests) {
+      // eslint-disable-next-line no-await-in-loop
+      const requestedAt = await timestamp(request.blockNumber)
+      const deadline = requestedAt + timeout
+      const previousDeadline = requestedAt + previousTimeout
+      const crossed = (threshold: number, previous: number) =>
+        threshold <= toTime &&
+        (threshold >= fromTime ||
+          (timeout !== previousTimeout && previous >= fromTime))
+
+      // The contract permits a timeout report strictly AFTER the deadline.
+      const expired =
+        deadline < toTime && crossed(deadline + 1, previousDeadline + 1)
+      const nearTimeout =
+        deadline >= toTime &&
+        crossed(
+          deadline - Math.min(this.warningSeconds, timeout),
+          previousDeadline - Math.min(this.warningSeconds, previousTimeout)
+        )
+      if (expired || nearTimeout) {
+        // A wallet/script pair can be reused: match its current requestedAt to
+        // this event, rather than alerting on an older completed request.
+        // eslint-disable-next-line no-await-in-loop
+        const pendingAt = await this.chain.pendingRequestedAt(request, toBlock)
+        if (pendingAt !== 0 && pendingAt === requestedAt) {
+          events.push(
+            RedemptionLifecycleMonitor.deadlineEvent(request, deadline, expired)
+          )
+        }
+      }
+    }
+    return events
+  }
+
+  private static deadlineEvent(
+    request: RedemptionRequestedEvent,
+    deadline: number,
+    expired: boolean
+  ): SystemEvent {
+    return {
+      title: expired
+        ? "Redemption expired without proof"
+        : "Redemption nearing timeout",
+      type: expired ? SystemEventType.Critical : SystemEventType.Warning,
+      // Keep the payload stable across overlapping/retried windows. Do not add
+      // the current block, wall clock, or remaining time to the deduplication key.
+      data: {
+        walletPublicKeyHash: request.walletPublicKeyHash.toString(),
+        redeemerOutputScript: request.redeemerOutputScript.toString(),
+        requestedAmountBTC: satsToRoundedBTC(request.requestedAmount),
+        ethRequestTxHash: request.transactionHash.toPrefixedString(),
+        ethRequestTxHashURL: createEthTxUrl(request.transactionHash),
+        deadlineTimestamp: `${deadline}`,
+      },
+      block: request.blockNumber,
+    }
+  }
+}

--- a/monitoring/src/redemption-lifecycle-monitor.ts
+++ b/monitoring/src/redemption-lifecycle-monitor.ts
@@ -69,14 +69,32 @@ export class RedemptionLifecycleMonitor implements Monitor {
       timestamps.set(block, pending)
       return pending
     }
-    const [fromTime, toTime, previousTimeout, timeout] = await Promise.all([
-      timestamp(fromBlock),
-      timestamp(toBlock),
-      this.chain.timeout(fromBlock),
-      this.chain.timeout(toBlock),
-    ])
-    if (timeout <= 0 || previousTimeout <= 0)
+    const timeout = await this.chain.timeout(toBlock)
+    // A backfill or reorg allowance can precede deployment entirely.
+    if (timeout === undefined) return []
+    if (timeout <= 0) throw new Error("invalid Bridge redemption timeout")
+    let initializedFromBlock = fromBlock
+    let previousTimeout = await this.chain.timeout(fromBlock)
+    if (previousTimeout === undefined) {
+      // Find the first deployed state inside the window, so the old timeout is
+      // historical even if governance changed it before the end of a backfill.
+      let low = fromBlock + 1
+      let high = toBlock
+      while (low < high) {
+        const mid = Math.floor((low + high) / 2)
+        // eslint-disable-next-line no-await-in-loop
+        if ((await this.chain.timeout(mid)) === undefined) low = mid + 1
+        else high = mid
+      }
+      initializedFromBlock = low
+      previousTimeout = await this.chain.timeout(initializedFromBlock)
+    }
+    if (previousTimeout === undefined || previousTimeout <= 0)
       throw new Error("invalid Bridge redemption timeout")
+    const [fromTime, toTime] = await Promise.all([
+      timestamp(initializedFromBlock),
+      timestamp(toBlock),
+    ])
 
     // Query requests whose warning or expiry can cross this checkpoint window.
     // Include the old timeout so reductions through governance cannot hide a

--- a/monitoring/src/system-event.ts
+++ b/monitoring/src/system-event.ts
@@ -104,10 +104,19 @@ class Deduplicator implements Receiver {
   }
 }
 
+export interface BlockRange {
+  fromBlock: number
+  toBlock: number
+}
+
 export interface Persistence {
   checkpointBlock: () => Promise<number>
 
   updateCheckpointBlock: (block: number) => Promise<void>
+
+  pendingBlockRange: () => Promise<BlockRange | null>
+
+  updatePendingBlockRange: (range: BlockRange | null) => Promise<void>
 
   handledSystemEvents: () => Promise<Record<ReceiverId, SystemEvent[]>>
 
@@ -149,20 +158,31 @@ export class Manager {
 
   async trigger(): Promise<ManagerReport> {
     try {
-      const checkpointBlock = await this.persistence.checkpointBlock()
-      const latestBlock = await blocks.latestBlock()
+      let range = await this.persistence.pendingBlockRange()
+      if (!range) {
+        const checkpointBlock = await this.persistence.checkpointBlock()
+        const latestBlock = await blocks.latestBlock()
 
-      const validCheckpoint =
-        checkpointBlock > 0 && checkpointBlock < latestBlock
+        const validCheckpoint =
+          checkpointBlock > 0 && checkpointBlock < latestBlock
 
-      let fromBlock = validCheckpoint ? checkpointBlock : latestBlock
+        let fromBlock = validCheckpoint ? checkpointBlock : latestBlock
 
-      // Adjust the fromBlock using the reorgDepthBlocks factor to cover
-      // potential chain reorgs.
-      fromBlock =
-        fromBlock - reorgDepthBlocks > 0 ? fromBlock - reorgDepthBlocks : 0
+        // Adjust the fromBlock using the reorgDepthBlocks factor to cover
+        // potential chain reorgs.
+        fromBlock =
+          fromBlock - reorgDepthBlocks > 0 ? fromBlock - reorgDepthBlocks : 0
 
-      const toBlock = Math.min(latestBlock, fromBlock + maxBlockRange)
+        range = {
+          fromBlock,
+          toBlock: Math.min(latestBlock, fromBlock + maxBlockRange),
+        }
+      }
+      // Persist before checking or dispatching: a later end block could
+      // erase a failed state-derived notification, even after a restart.
+      // Persist retries too, in case a failed save left only an in-memory range.
+      await this.persistence.updatePendingBlockRange(range)
+      const { fromBlock, toBlock } = range
 
       const { systemEventsAcks, errors } = await this.check(fromBlock, toBlock)
 
@@ -196,6 +216,16 @@ export class Manager {
           await this.persistence.updateCheckpointBlock(toBlock)
         } catch (error) {
           errors.push(`cannot update checkpoint block: ${error}`)
+        }
+      }
+
+      if (errors.length === 0) {
+        try {
+          // Clear only after acknowledgments and the checkpoint are durable.
+          // A failure here safely replays the same range with deduplication.
+          await this.persistence.updatePendingBlockRange(null)
+        } catch (error) {
+          errors.push(`cannot clear pending block range: ${error}`)
         }
       }
 

--- a/monitoring/src/system-event.ts
+++ b/monitoring/src/system-event.ts
@@ -118,6 +118,12 @@ export interface Persistence {
 
   updatePendingBlockRange: (range: BlockRange | null) => Promise<void>
 
+  pendingSystemEvents: () => Promise<Record<ReceiverId, SystemEvent[]>>
+
+  updatePendingSystemEvents: (
+    systemEvents: Record<ReceiverId, SystemEvent[]>
+  ) => Promise<void>
+
   handledSystemEvents: () => Promise<Record<ReceiverId, SystemEvent[]>>
 
   storeHandledSystemEvents: (
@@ -178,54 +184,21 @@ export class Manager {
           toBlock: Math.min(latestBlock, fromBlock + maxBlockRange),
         }
       }
-      // Persist before checking or dispatching: a later end block could
-      // erase a failed state-derived notification, even after a restart.
+      // Keep historical bounds until the scan results are durably captured.
       // Persist retries too, in case a failed save left only an in-memory range.
       await this.persistence.updatePendingBlockRange(range)
       const { fromBlock, toBlock } = range
 
-      const { systemEventsAcks, errors } = await this.check(fromBlock, toBlock)
+      const { scanSucceeded, errors } = await this.check(fromBlock, toBlock)
 
-      const handledSystemEventsAcks = systemEventsAcks.filter(
-        (ack) => ack.status === "handled"
-      )
-
-      if (handledSystemEventsAcks.length !== 0) {
-        try {
-          const groupByReceiver = (
-            group: Record<ReceiverId, SystemEvent[]>,
-            ack: SystemEventAck
-          ) => {
-            const { receiverId, systemEvent } = ack
-            // eslint-disable-next-line no-param-reassign
-            group[receiverId] = group[receiverId] ?? []
-            group[receiverId].push(systemEvent)
-            return group
-          }
-
-          await this.persistence.storeHandledSystemEvents(
-            handledSystemEventsAcks.reduce(groupByReceiver, {})
-          )
-        } catch (error) {
-          errors.push(`cannot store handled system events: ${error}`)
-        }
-      }
-
-      if (errors.length === 0) {
+      // Once every monitor's events are durably queued, receiver failures must
+      // not hold the scan checkpoint behind newer events for healthy receivers.
+      if (scanSucceeded) {
         try {
           await this.persistence.updateCheckpointBlock(toBlock)
-        } catch (error) {
-          errors.push(`cannot update checkpoint block: ${error}`)
-        }
-      }
-
-      if (errors.length === 0) {
-        try {
-          // Clear only after acknowledgments and the checkpoint are durable.
-          // A failure here safely replays the same range with deduplication.
           await this.persistence.updatePendingBlockRange(null)
         } catch (error) {
-          errors.push(`cannot clear pending block range: ${error}`)
+          errors.push(`cannot complete scanned block range: ${error}`)
         }
       }
 
@@ -248,6 +221,7 @@ export class Manager {
     toBlock: number
   ): Promise<{
     systemEventsAcks: SystemEventAck[]
+    scanSucceeded: boolean
     errors: string[]
   }> {
     const systemEvents: SystemEvent[] = []
@@ -264,61 +238,88 @@ export class Manager {
         errors.push(`cannot check system events monitor: ${result.reason}`)
       }
     })
+    const scanSucceeded = errors.length === 0
 
-    const handledSystemEvents = await this.persistence.handledSystemEvents()
+    const [handledSystemEvents, pendingSystemEvents] = await Promise.all([
+      this.persistence.handledSystemEvents(),
+      this.persistence.pendingSystemEvents(),
+    ])
+    const queued: Record<ReceiverId, SystemEvent[]> = { ...pendingSystemEvents }
+    this.receivers.forEach((receiver) => {
+      const id = receiver.id()
+      const uniqueEvents = new Map(
+        [...(queued[id] ?? []), ...systemEvents].map((event) => [
+          Deduplicator.systemEventKey(event),
+          event,
+        ])
+      )
+      queued[id] = [...uniqueEvents.values()]
+    })
 
+    // Capture payloads per receiver before any delivery or checkpoint update.
+    // In particular, an expiration must survive a later proof or process exit.
+    // Entries for temporarily unconfigured receivers remain in this outbox.
+    await this.persistence.updatePendingSystemEvents(queued)
+
+    const deliveries = this.receivers.flatMap((receiver) => {
+      const id = receiver.id()
+      const deduplicator = Deduplicator.wrap(
+        receiver,
+        handledSystemEvents[id] ?? []
+      )
+      return (queued[id] ?? []).map((systemEvent) => ({
+        receiverId: id,
+        systemEvent,
+        receive: () => deduplicator.receive(systemEvent),
+      }))
+    })
     const dispatches = await Promise.allSettled(
-      this.receivers
-        .map((r) => Deduplicator.wrap(r, handledSystemEvents[r.id()] ?? []))
-        .flatMap((r) => systemEvents.map((se) => r.receive(se)))
+      deliveries.map((delivery) => delivery.receive())
     )
 
     const systemEventsAcks: SystemEventAck[] = []
-
-    dispatches.forEach((result) => {
+    const remaining: Record<ReceiverId, SystemEvent[]> = { ...queued }
+    this.receivers.forEach((receiver) => {
+      delete remaining[receiver.id()]
+    })
+    dispatches.forEach((result, index) => {
+      const { receiverId, systemEvent } = deliveries[index]
       if (result.status === "fulfilled") {
         systemEventsAcks.push(result.value)
       } else {
-        errors.push(`cannot dispatch system event: ${result.reason}`)
+        remaining[receiverId] = remaining[receiverId] ?? []
+        remaining[receiverId].push(systemEvent)
+        errors.push(
+          `cannot dispatch system event to ${receiverId}: ${result.reason}`
+        )
+      }
+    })
+    Object.keys(remaining).forEach((id) => {
+      if (
+        remaining[id].length > 0 &&
+        !this.receivers.some((r) => r.id() === id)
+      ) {
+        errors.push(`pending system events have no configured receiver: ${id}`)
       }
     })
 
-    const dispatchedSystemEventKeys = new Set(
-      systemEventsAcks
-        .filter((ack) => ack.status === "handled" || ack.status === "duplicate")
-        .map((ack) => Deduplicator.systemEventKey(ack.systemEvent))
-    )
-
-    // Index ack statuses by event key to detect partial-deployment cases.
-    const ackStatusesByKey = new Map<string, Set<SystemEventAck["status"]>>()
+    const handled: Record<ReceiverId, SystemEvent[]> = {}
     systemEventsAcks.forEach((ack) => {
-      const key = Deduplicator.systemEventKey(ack.systemEvent)
-      const statuses =
-        ackStatusesByKey.get(key) ?? new Set<SystemEventAck["status"]>()
-      statuses.add(ack.status)
-      ackStatusesByKey.set(key, statuses)
+      if (ack.status !== "handled") return
+      handled[ack.receiverId] = handled[ack.receiverId] ?? []
+      handled[ack.receiverId].push(ack.systemEvent)
     })
-
-    systemEvents.forEach((systemEvent) => {
-      const key = Deduplicator.systemEventKey(systemEvent)
-      if (dispatchedSystemEventKeys.has(key)) return
-      const statuses = ackStatusesByKey.get(key) ?? new Set()
-      // Skip if every receiver ignored this event (no receiver is configured
-      // for this event type -- valid in partial-receiver deployments) or if all
-      // dispatches were rejected and already recorded as errors above.
-      if (
-        statuses.size === 0 ||
-        (statuses.size === 1 && statuses.has("ignored"))
-      )
-        return
-      errors.push(
-        `system event was not handled by any receiver: ${systemEvent.title}`
-      )
-    })
-
-    return {
-      systemEventsAcks,
-      errors,
+    try {
+      if (Object.keys(handled).length > 0) {
+        await this.persistence.storeHandledSystemEvents(handled)
+      }
+      // Remove acknowledged/ignored events only after handled history is saved.
+      // If either write fails, the durable pre-dispatch outbox permits replay.
+      await this.persistence.updatePendingSystemEvents(remaining)
+    } catch (error) {
+      errors.push(`cannot store system event delivery results: ${error}`)
     }
+
+    return { systemEventsAcks, scanSucceeded, errors }
   }
 }

--- a/monitoring/test/receiver-isolation.test.ts
+++ b/monitoring/test/receiver-isolation.test.ts
@@ -1,0 +1,374 @@
+import assert from "assert"
+import { promises as fs } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+
+import { blocks } from "../src/blocks"
+import { context } from "../src/context"
+import { SystemEventFilePersistence } from "../src/file-persistence"
+import { Manager, SystemEventType } from "../src/system-event"
+
+import { test } from "./test-runner"
+
+import type { Monitor, Receiver, SystemEvent } from "../src/system-event"
+
+async function withDataDirectory(run: () => Promise<void>): Promise<void> {
+  const originalDataDir = context.dataDirPath
+  const originalLatest = blocks.latestBlock
+  const directory = await fs.mkdtemp(join(tmpdir(), "receiver-isolation-"))
+  context.dataDirPath = directory
+  try {
+    await run()
+  } finally {
+    context.dataDirPath = originalDataDir
+    blocks.latestBlock = originalLatest
+    await Promise.all(
+      (
+        await fs.readdir(directory)
+      ).map((name) => fs.unlink(join(directory, name)))
+    )
+    await fs.rmdir(directory)
+  }
+}
+
+test("a receiver outage preserves retries while newer critical events reach a healthy receiver", async () => {
+  await withDataDirectory(async () => {
+    const informational: SystemEvent = {
+      title: "Redemption proof accepted",
+      type: SystemEventType.Informational,
+      data: { transactionHash: "proof" },
+      block: 100,
+    }
+    const critical: SystemEvent = {
+      title: "Redemption timeout reported",
+      type: SystemEventType.Critical,
+      data: { transactionHash: "timeout" },
+      block: 125,
+    }
+    const checkedRanges: [number, number][] = []
+    const monitor: Monitor = {
+      check: async (fromBlock, toBlock) => {
+        checkedRanges.push([fromBlock, toBlock])
+        return [informational, critical].filter(
+          (event) => event.block >= fromBlock && event.block <= toBlock
+        )
+      },
+    }
+    let latestBlock = 100
+    blocks.latestBlock = async () => latestBlock
+    let discordUnavailable = true
+    const discordDeliveries: SystemEvent[] = []
+    const sentryDeliveries: SystemEvent[] = []
+    const discord: Receiver = {
+      id: () => "discord",
+      receive: async (event) => {
+        if (event.type !== SystemEventType.Informational) {
+          return {
+            receiverId: "discord",
+            systemEvent: event,
+            status: "ignored",
+          }
+        }
+        if (discordUnavailable) throw new Error("Discord unavailable")
+        discordDeliveries.push(event)
+        return { receiverId: "discord", systemEvent: event, status: "handled" }
+      },
+    }
+    const sentry: Receiver = {
+      id: () => "sentry",
+      receive: async (event) => {
+        if (event.type !== SystemEventType.Critical) {
+          return { receiverId: "sentry", systemEvent: event, status: "ignored" }
+        }
+        sentryDeliveries.push(event)
+        return { receiverId: "sentry", systemEvent: event, status: "handled" }
+      },
+    }
+    const createManager = () =>
+      new Manager(
+        [monitor],
+        [discord, sentry],
+        new SystemEventFilePersistence()
+      )
+    await new SystemEventFilePersistence().updateCheckpointBlock(99)
+
+    const first = await createManager().trigger()
+    assert.strictEqual(first.status, "failure")
+    assert.ok(
+      first.errors.some((error) => error.includes("Discord unavailable"))
+    )
+    assert.deepStrictEqual(discordDeliveries, [])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      100
+    )
+    assert.strictEqual(
+      await new SystemEventFilePersistence().pendingBlockRange(),
+      null
+    )
+    assert.deepStrictEqual(
+      (await new SystemEventFilePersistence().pendingSystemEvents()).discord,
+      [informational]
+    )
+
+    latestBlock = 130
+    // Each trigger reloads the durable state, as a restarted scheduled job does.
+    const second = await createManager().trigger()
+    assert.strictEqual(second.status, "failure")
+    assert.deepStrictEqual(sentryDeliveries, [critical])
+    assert.deepStrictEqual(checkedRanges, [
+      [87, 100],
+      [88, 130],
+    ])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      130
+    )
+    assert.deepStrictEqual(discordDeliveries, [])
+    assert.deepStrictEqual(
+      (await new SystemEventFilePersistence().pendingSystemEvents()).discord,
+      [informational]
+    )
+
+    // The original notification is now outside the reorganization overlap.
+    latestBlock = 160
+    discordUnavailable = false
+    assert.strictEqual((await createManager().trigger()).status, "success")
+    assert.deepStrictEqual(discordDeliveries, [informational])
+    assert.deepStrictEqual(sentryDeliveries, [critical])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      160
+    )
+    assert.deepStrictEqual(
+      Object.values(
+        await new SystemEventFilePersistence().pendingSystemEvents()
+      ).flat(),
+      []
+    )
+
+    latestBlock = 170
+    assert.strictEqual((await createManager().trigger()).status, "success")
+    assert.deepStrictEqual(discordDeliveries, [informational])
+    assert.deepStrictEqual(sentryDeliveries, [critical])
+  })
+})
+
+test("a temporarily unconfigured receiver keeps its durable notifications while scanning advances", async () => {
+  await withDataDirectory(async () => {
+    const event: SystemEvent = {
+      title: "Redemption proof accepted",
+      type: SystemEventType.Informational,
+      data: { transactionHash: "proof" },
+      block: 100,
+    }
+    const monitor: Monitor = {
+      check: async (fromBlock, toBlock) =>
+        event.block >= fromBlock && event.block <= toBlock ? [event] : [],
+    }
+    let latestBlock = 100
+    blocks.latestBlock = async () => latestBlock
+    let unavailable = true
+    const deliveries: SystemEvent[] = []
+    const receiver: Receiver = {
+      id: () => "discord",
+      receive: async (systemEvent) => {
+        if (unavailable) throw new Error("Discord unavailable")
+        deliveries.push(systemEvent)
+        return { receiverId: "discord", systemEvent, status: "handled" }
+      },
+    }
+    const trigger = (receivers: Receiver[]) =>
+      new Manager(
+        [monitor],
+        receivers,
+        new SystemEventFilePersistence()
+      ).trigger()
+    await new SystemEventFilePersistence().updateCheckpointBlock(99)
+    assert.strictEqual((await trigger([receiver])).status, "failure")
+
+    latestBlock = 130
+    await trigger([])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      130
+    )
+    assert.deepStrictEqual(
+      (await new SystemEventFilePersistence().pendingSystemEvents()).discord,
+      [event]
+    )
+
+    latestBlock = 160
+    unavailable = false
+    assert.strictEqual((await trigger([receiver])).status, "success")
+    assert.deepStrictEqual(deliveries, [event])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      160
+    )
+    assert.deepStrictEqual(
+      Object.values(
+        await new SystemEventFilePersistence().pendingSystemEvents()
+      ).flat(),
+      []
+    )
+  })
+})
+
+test("a failed outbox capture retains the scan window without delivering notifications", async () => {
+  await withDataDirectory(async () => {
+    const event: SystemEvent = {
+      title: "Redemption expired without proof",
+      type: SystemEventType.Critical,
+      data: { transactionHash: "request" },
+      block: 99,
+    }
+    const monitor: Monitor = {
+      check: async (fromBlock, toBlock) =>
+        event.block >= fromBlock && toBlock === 100 ? [event] : [],
+    }
+    let latestBlock = 100
+    blocks.latestBlock = async () => latestBlock
+    const deliveries: SystemEvent[] = []
+    const receiver: Receiver = {
+      id: () => "sentry",
+      receive: async (systemEvent) => {
+        deliveries.push(systemEvent)
+        return { receiverId: "sentry", systemEvent, status: "handled" }
+      },
+    }
+    const persistence = new SystemEventFilePersistence()
+    await persistence.updateCheckpointBlock(99)
+    persistence.updatePendingSystemEvents = async () => {
+      throw new Error("outbox capture failed")
+    }
+
+    const failed = await new Manager(
+      [monitor],
+      [receiver],
+      persistence
+    ).trigger()
+    assert.strictEqual(failed.status, "failure")
+    assert.ok(
+      failed.errors.some((error) => error.includes("outbox capture failed"))
+    )
+    assert.deepStrictEqual(deliveries, [])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      99
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().pendingBlockRange(),
+      { fromBlock: 87, toBlock: 100 }
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().pendingSystemEvents(),
+      {}
+    )
+
+    latestBlock = 130
+    const recovered = await new Manager(
+      [monitor],
+      [receiver],
+      new SystemEventFilePersistence()
+    ).trigger()
+    assert.strictEqual(recovered.status, "success")
+    assert.strictEqual(recovered.fromBlock, 87)
+    assert.strictEqual(recovered.toBlock, 100)
+    assert.deepStrictEqual(deliveries, [event])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      100
+    )
+    assert.strictEqual(
+      await new SystemEventFilePersistence().pendingBlockRange(),
+      null
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().pendingSystemEvents(),
+      {}
+    )
+  })
+})
+
+test("a failed handled-history save retains captured notifications for at-least-once replay", async () => {
+  await withDataDirectory(async () => {
+    const event: SystemEvent = {
+      title: "Redemption expired without proof",
+      type: SystemEventType.Critical,
+      data: { transactionHash: "request" },
+      block: 99,
+    }
+    const monitor: Monitor = {
+      // A proof accepted after block 100 removes this notification from new scans.
+      check: async (fromBlock, toBlock) =>
+        event.block >= fromBlock && toBlock === 100 ? [event] : [],
+    }
+    let latestBlock = 100
+    blocks.latestBlock = async () => latestBlock
+    const deliveries: SystemEvent[] = []
+    const receiver: Receiver = {
+      id: () => "sentry",
+      receive: async (systemEvent) => {
+        deliveries.push(systemEvent)
+        return { receiverId: "sentry", systemEvent, status: "handled" }
+      },
+    }
+    const persistence = new SystemEventFilePersistence()
+    await persistence.updateCheckpointBlock(99)
+    persistence.storeHandledSystemEvents = async () => {
+      throw new Error("handled-history save failed")
+    }
+
+    const failed = await new Manager(
+      [monitor],
+      [receiver],
+      persistence
+    ).trigger()
+    assert.strictEqual(failed.status, "failure")
+    assert.ok(
+      failed.errors.some((error) =>
+        error.includes("handled-history save failed")
+      )
+    )
+    assert.deepStrictEqual(deliveries, [event])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      100
+    )
+    assert.strictEqual(
+      await new SystemEventFilePersistence().pendingBlockRange(),
+      null
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().pendingSystemEvents(),
+      { sentry: [event] }
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().handledSystemEvents(),
+      {}
+    )
+
+    latestBlock = 130
+    const recovered = await new Manager(
+      [monitor],
+      [receiver],
+      new SystemEventFilePersistence()
+    ).trigger()
+    assert.strictEqual(recovered.status, "success")
+    assert.strictEqual(recovered.toBlock, 130)
+    assert.deepStrictEqual(deliveries, [event, event])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      130
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().pendingSystemEvents(),
+      {}
+    )
+    assert.deepStrictEqual(
+      await new SystemEventFilePersistence().handledSystemEvents(),
+      { sentry: [event] }
+    )
+  })
+})

--- a/monitoring/test/redemption-chain.test.ts
+++ b/monitoring/test/redemption-chain.test.ts
@@ -6,6 +6,7 @@ import {
   RedemptionChain,
   redemptionMonitoringABI as abi,
 } from "../src/redemption-chain"
+import { RedemptionLifecycleMonitor } from "../src/redemption-lifecycle-monitor"
 
 import { test } from "./test-runner"
 import { redemptionRequest } from "./redemption-fixtures"
@@ -38,7 +39,10 @@ function log(name: string, args: unknown[], block: number): providers.Log {
   }
 }
 
-function provider(): Pick<providers.Provider, "getLogs" | "call" | "getBlock"> {
+function provider(): Pick<
+  providers.Provider,
+  "getLogs" | "call" | "getBlock" | "getCode"
+> {
   return {
     getLogs: async () => [],
     call: async () => {
@@ -46,6 +50,9 @@ function provider(): Pick<providers.Provider, "getLogs" | "call" | "getBlock"> {
     },
     getBlock: async () => {
       throw new Error("unexpected block read")
+    },
+    getCode: async () => {
+      throw new Error("unexpected code read")
     },
   }
 }
@@ -147,4 +154,105 @@ test("lifecycle adapter propagates log and historical state failures", async () 
   const chain = new RedemptionChain(bridge, rpc)
   await assert.rejects(() => chain.completed(1, 2), /logs unavailable/)
   await assert.rejects(() => chain.timeout(2), /unexpected eth_call/)
+})
+
+test("historical timeout is absent only when an empty response has no contract code", async () => {
+  const rpc = provider()
+  rpc.call = async () => "0x"
+  rpc.getCode = async (queriedAddress, block) => {
+    assert.strictEqual(queriedAddress, address)
+    assert.strictEqual(block, 99)
+    return "0x"
+  }
+  const chain = new RedemptionChain(bridge, rpc)
+  assert.strictEqual(await chain.timeout(99), undefined)
+
+  rpc.getCode = async () => "0x6000"
+  await assert.rejects(() => chain.timeout(99), /call revert exception/)
+  rpc.getCode = async () => {
+    throw new Error("historical code unavailable")
+  }
+  await assert.rejects(() => chain.timeout(99), /historical code unavailable/)
+  rpc.call = async () => {
+    throw new Error("historical call unavailable")
+  }
+  await assert.rejects(() => chain.timeout(99), /historical call unavailable/)
+})
+
+function deploymentProvider(deploymentBlock: number) {
+  const rpc = provider()
+  const timeoutReads: number[] = []
+  rpc.call = async (transaction, block) => {
+    const atBlock = Number(block)
+    const parsed = abi.parseTransaction({
+      data: String(await transaction.data),
+    })
+    if (parsed.name === "redemptionParameters") {
+      timeoutReads.push(atBlock)
+      if (atBlock < deploymentBlock) return "0x"
+      return abi.encodeFunctionResult(
+        parsed.name,
+        [1000, 2000, 3000, 4000, 100, 5000, 100]
+      )
+    }
+    assert.strictEqual(parsed.name, "pendingRedemptions")
+    assert.ok(atBlock >= deploymentBlock)
+    return abi.encodeFunctionResult(parsed.name, [
+      [address, 10000000, 1000, 10000, (deploymentBlock + 1) * 10],
+    ])
+  }
+  rpc.getCode = async (_, block) => {
+    assert.ok(Number(block) < deploymentBlock)
+    return "0x"
+  }
+  rpc.getBlock = async (block) =>
+    ({ timestamp: Number(block) * 10 } as providers.Block)
+  return { rpc, timeoutReads }
+}
+
+test("deployment backfill includes reorg overlap without reading nonexistent timeout state", async () => {
+  const deploymentBlock = 100
+  const request = redemptionRequest(deploymentBlock + 1)
+  const { rpc, timeoutReads } = deploymentProvider(deploymentBlock)
+  const chain = new RedemptionChain(
+    {
+      ...bridge,
+      getRedemptionRequestedEvents: async (options) => {
+        const from = Number(options?.fromBlock)
+        const to = Number(options?.toBlock)
+        return from <= request.blockNumber && to >= request.blockNumber
+          ? [request]
+          : []
+      },
+    },
+    rpc
+  )
+  const [event] = await new RedemptionLifecycleMonitor(chain, 20).check(
+    deploymentBlock - 12,
+    112
+  )
+  assert.strictEqual(event.title, "Redemption expired without proof")
+  assert.strictEqual(event.data.deadlineTimestamp, "1110")
+  assert.ok(timeoutReads.includes(deploymentBlock))
+})
+
+test("a lifecycle window entirely before Bridge deployment is empty", async () => {
+  const { rpc, timeoutReads } = deploymentProvider(100)
+  rpc.getBlock = async () => {
+    throw new Error("unexpected timestamp scan before deployment")
+  }
+  const chain = new RedemptionChain(
+    {
+      ...bridge,
+      getRedemptionRequestedEvents: async () => {
+        throw new Error("unexpected request scan before deployment")
+      },
+    },
+    rpc
+  )
+  assert.deepStrictEqual(
+    await new RedemptionLifecycleMonitor(chain).check(0, 99),
+    []
+  )
+  assert.deepStrictEqual(timeoutReads, [99])
 })

--- a/monitoring/test/redemption-chain.test.ts
+++ b/monitoring/test/redemption-chain.test.ts
@@ -1,0 +1,150 @@
+import assert from "assert"
+
+import { EthereumAddress, EthereumBridge } from "@keep-network/tbtc-v2.ts"
+
+import {
+  RedemptionChain,
+  redemptionMonitoringABI as abi,
+} from "../src/redemption-chain"
+
+import { test } from "./test-runner"
+import { redemptionRequest } from "./redemption-fixtures"
+
+import type { providers } from "ethers"
+import type { Bridge } from "@keep-network/tbtc-v2.ts"
+
+const address = `0x${"aa".repeat(20)}`
+const wallet = `0x${"11".repeat(20)}`
+const script = `0014${"33".repeat(20)}`
+const bridge: Pick<
+  Bridge,
+  "getChainIdentifier" | "getRedemptionRequestedEvents"
+> = {
+  getChainIdentifier: () => EthereumAddress.from(address),
+  getRedemptionRequestedEvents: async () => [],
+}
+
+function log(name: string, args: unknown[], block: number): providers.Log {
+  const encoded = abi.encodeEventLog(abi.getEvent(name), args)
+  return {
+    ...encoded,
+    blockNumber: block,
+    blockHash: `0x${"22".repeat(32)}`,
+    transactionHash: `0x${"44".repeat(32)}`,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+    address,
+  }
+}
+
+function provider(): Pick<providers.Provider, "getLogs" | "call" | "getBlock"> {
+  return {
+    getLogs: async () => [],
+    call: async () => {
+      throw new Error("unexpected eth_call")
+    },
+    getBlock: async () => {
+      throw new Error("unexpected block read")
+    },
+  }
+}
+
+test("lifecycle adapter decodes real ABI logs and queries all indexed wallets", async () => {
+  const rpc = provider()
+  rpc.getLogs = async (filter) => {
+    assert.strictEqual(filter.address, address)
+    assert.strictEqual(filter.fromBlock, 100)
+    assert.strictEqual(filter.toBlock, 200)
+    assert.strictEqual(filter.topics?.length, 1)
+    if (filter.topics?.[0] === abi.getEventTopic("RedemptionsCompleted")) {
+      return [
+        log("RedemptionsCompleted", [wallet, `0x01${"00".repeat(30)}ab`], 123),
+      ]
+    }
+    return [log("RedemptionTimedOut", [wallet, `0x16${script}`], 124)]
+  }
+  const chain = new RedemptionChain(bridge, rpc)
+  const [proof] = await chain.completed(100, 200)
+  assert.strictEqual(
+    proof.redemptionTxHash.toString(),
+    `ab${"00".repeat(30)}01`
+  )
+  assert.strictEqual(proof.walletPublicKeyHash.toPrefixedString(), wallet)
+  assert.strictEqual(proof.blockNumber, 123)
+  const [report] = await chain.timedOut(100, 200)
+  assert.strictEqual(report.redeemerOutputScript.toString(), script)
+  assert.strictEqual(report.blockNumber, 124)
+})
+
+test("lifecycle adapter reads the configured timeout and current request at an exact historical block", async () => {
+  const rpc = provider()
+  const request = redemptionRequest()
+  const observedBlocks: unknown[] = []
+  rpc.call = async (transaction, block) => {
+    assert.strictEqual(transaction.to, address)
+    observedBlocks.push(block)
+    const data = await transaction.data
+    const parsed = abi.parseTransaction({ data: String(data) })
+    if (parsed.name === "redemptionParameters") {
+      return abi.encodeFunctionResult(
+        parsed.name,
+        [1000, 2000, 3000, 4000, 172800, 5000, 100]
+      )
+    }
+    assert.strictEqual(
+      parsed.args.redemptionKey.toHexString(),
+      EthereumBridge.buildRedemptionKey(
+        request.walletPublicKeyHash,
+        request.redeemerOutputScript
+      )
+    )
+    return abi.encodeFunctionResult(parsed.name, [
+      [address, 10000000, 1000, 10000, 1234],
+    ])
+  }
+  const chain = new RedemptionChain(bridge, rpc)
+  assert.strictEqual(await chain.timeout(0), 172800)
+  assert.strictEqual(await chain.pendingRequestedAt(request, 200), 1234)
+  assert.deepStrictEqual(observedBlocks, [0, 200])
+})
+
+test("lifecycle log reads and SDK request reads are bounded and preserve inclusive endpoints", async () => {
+  const ranges: unknown[] = []
+  const rpc = provider()
+  rpc.getLogs = async (filter) => {
+    ranges.push([filter.fromBlock, filter.toBlock])
+    return []
+  }
+  const requestBridge = {
+    ...bridge,
+    getRedemptionRequestedEvents: async (options?: {
+      fromBlock?: number
+      toBlock?: number | string
+    }) => {
+      ranges.push([options?.fromBlock, options?.toBlock])
+      return []
+    },
+  }
+  const chain = new RedemptionChain(requestBridge, rpc)
+  await chain.completed(100, 10100)
+  await chain.requested(100, 10100)
+  assert.deepStrictEqual(ranges, [
+    [100, 5099],
+    [5100, 10099],
+    [10100, 10100],
+    [100, 5099],
+    [5100, 10099],
+    [10100, 10100],
+  ])
+})
+
+test("lifecycle adapter propagates log and historical state failures", async () => {
+  const rpc = provider()
+  rpc.getLogs = async () => {
+    throw new Error("logs unavailable")
+  }
+  const chain = new RedemptionChain(bridge, rpc)
+  await assert.rejects(() => chain.completed(1, 2), /logs unavailable/)
+  await assert.rejects(() => chain.timeout(2), /unexpected eth_call/)
+})

--- a/monitoring/test/redemption-fixtures.ts
+++ b/monitoring/test/redemption-fixtures.ts
@@ -1,0 +1,21 @@
+import { BigNumber } from "ethers"
+import { EthereumAddress, Hex } from "@keep-network/tbtc-v2.ts"
+
+import type { RedemptionRequestedEvent } from "@keep-network/tbtc-v2.ts"
+
+export function redemptionRequest(
+  blockNumber = 10,
+  txByte = "44"
+): RedemptionRequestedEvent {
+  return {
+    blockNumber,
+    blockHash: Hex.from("22".repeat(32)),
+    transactionHash: Hex.from(txByte.repeat(32)),
+    walletPublicKeyHash: Hex.from("11".repeat(20)),
+    redeemerOutputScript: Hex.from(`0014${"33".repeat(20)}`),
+    redeemer: EthereumAddress.from(`0x${"55".repeat(20)}`),
+    requestedAmount: BigNumber.from(10000000),
+    treasuryFee: BigNumber.from(1000),
+    txMaxFee: BigNumber.from(10000),
+  }
+}

--- a/monitoring/test/redemption-lifecycle-monitor.test.ts
+++ b/monitoring/test/redemption-lifecycle-monitor.test.ts
@@ -1,0 +1,283 @@
+import assert from "assert"
+
+import { BitcoinTxHash } from "@keep-network/tbtc-v2.ts"
+
+import { RedemptionLifecycleMonitor } from "../src/redemption-lifecycle-monitor"
+import { Manager, SystemEventType } from "../src/system-event"
+import { blocks } from "../src/blocks"
+
+import { redemptionRequest } from "./redemption-fixtures"
+import { test } from "./test-runner"
+
+import type { RedemptionRequestedEvent } from "@keep-network/tbtc-v2.ts"
+import type {
+  RedemptionLifecycleSource,
+  RedemptionsCompletedEvent,
+  RedemptionTimedOutEvent,
+} from "../src/redemption-chain"
+import type { Persistence, Receiver, SystemEvent } from "../src/system-event"
+
+class Chain implements RedemptionLifecycleSource {
+  requests = [redemptionRequest()]
+
+  completions: RedemptionsCompletedEvent[] = []
+
+  reports: RedemptionTimedOutEvent[] = []
+
+  // Test cases replace the clock and contract configuration independently.
+  // eslint-disable-next-line class-methods-use-this
+  timestampAt = (block: number) => block * 10
+
+  // eslint-disable-next-line class-methods-use-this
+  timeoutAt: (block: number) => number = () => 1000
+
+  pendingAt = (request: RedemptionRequestedEvent) =>
+    this.timestampAt(request.blockNumber)
+
+  stateReads: number[] = []
+
+  timestampReads: number[] = []
+
+  requestQueries: [number, number][] = []
+
+  async requested(from: number, to: number) {
+    this.requestQueries.push([from, to])
+    return this.requests.filter(
+      (event) => event.blockNumber >= from && event.blockNumber <= to
+    )
+  }
+
+  async completed(from: number, to: number) {
+    return this.completions.filter(
+      (event) => event.blockNumber >= from && event.blockNumber <= to
+    )
+  }
+
+  async timedOut(from: number, to: number) {
+    return this.reports.filter(
+      (event) => event.blockNumber >= from && event.blockNumber <= to
+    )
+  }
+
+  async timeout(block: number) {
+    return this.timeoutAt(block)
+  }
+
+  async blockTimestamp(block: number) {
+    this.timestampReads.push(block)
+    return this.timestampAt(block)
+  }
+
+  async pendingRequestedAt(request: RedemptionRequestedEvent, block: number) {
+    this.stateReads.push(block)
+    return this.pendingAt(request)
+  }
+}
+
+test("redemption deadline warning and strict expiry boundaries", async () => {
+  const chain = new Chain()
+  const monitor = new RedemptionLifecycleMonitor(chain, 200)
+  assert.deepStrictEqual(await monitor.check(80, 89), [])
+  const [near] = await monitor.check(80, 90)
+  assert.strictEqual(near.title, "Redemption nearing timeout")
+  assert.strictEqual(near.type, SystemEventType.Warning)
+  assert.strictEqual(near.data.deadlineTimestamp, "1100")
+  assert.strictEqual(near.block, 10)
+  assert.deepStrictEqual(await monitor.check(110, 110), [])
+  const [expired] = await monitor.check(110, 111)
+  assert.strictEqual(expired.title, "Redemption expired without proof")
+  assert.strictEqual(expired.type, SystemEventType.Critical)
+  assert.strictEqual(expired.data.deadlineTimestamp, "1100")
+  assert.deepStrictEqual(chain.stateReads, [90, 111])
+})
+
+test("deadline scans follow irregular block timestamps and cache each header", async () => {
+  const chain = new Chain()
+  const times = [0, 100, 400, 500, 700, 900, 1000, 1080, 1100, 1150, 1200]
+  chain.timestampAt = (block) => times[block]
+  chain.requests = [redemptionRequest(1)]
+  const monitor = new RedemptionLifecycleMonitor(chain, 200)
+  assert.strictEqual(
+    (await monitor.check(4, 5))[0].type,
+    SystemEventType.Warning
+  )
+  assert.strictEqual(
+    new Set(chain.timestampReads).size,
+    chain.timestampReads.length
+  )
+  assert.strictEqual(
+    (await monitor.check(8, 9))[0].type,
+    SystemEventType.Critical
+  )
+})
+
+test("completed requests and reused wallet/script keys do not alert for the old request", async () => {
+  const chain = new Chain()
+  const monitor = new RedemptionLifecycleMonitor(chain, 200)
+  chain.pendingAt = () => 0
+  assert.deepStrictEqual(await monitor.check(80, 90), [])
+  chain.requests.push(redemptionRequest(30, "66"))
+  chain.pendingAt = () => 300
+  assert.deepStrictEqual(await monitor.check(80, 90), [])
+  const events = await monitor.check(100, 110)
+  assert.strictEqual(events.length, 1)
+  assert.strictEqual(events[0].data.ethRequestTxHash, `0x${"66".repeat(32)}`)
+})
+
+test("a coarse catch-up window emits expiry instead of a stale near-timeout warning", async () => {
+  const events = await new RedemptionLifecycleMonitor(new Chain(), 200).check(
+    80,
+    120
+  )
+  assert.strictEqual(events.length, 1)
+  assert.strictEqual(events[0].type, SystemEventType.Critical)
+})
+
+test("a timeout reduction detects a request newly expired by governance", async () => {
+  const chain = new Chain()
+  chain.timeoutAt = (block) => (block < 95 ? 2000 : 700)
+  const [event] = await new RedemptionLifecycleMonitor(chain, 200).check(
+    90,
+    100
+  )
+  assert.strictEqual(event.type, SystemEventType.Critical)
+  assert.strictEqual(event.data.deadlineTimestamp, "800")
+})
+
+test("a timeout extension avoids a false expiration", async () => {
+  const chain = new Chain()
+  chain.timeoutAt = (block) => (block < 115 ? 1000 : 2000)
+  assert.deepStrictEqual(
+    await new RedemptionLifecycleMonitor(chain, 200).check(110, 120),
+    []
+  )
+})
+
+test("a short contract timeout clamps the warning lead time to request creation", async () => {
+  const chain = new Chain()
+  chain.timeoutAt = () => 100
+  const [event] = await new RedemptionLifecycleMonitor(chain, 200).check(9, 10)
+  assert.strictEqual(event.type, SystemEventType.Warning)
+  assert.strictEqual(event.data.deadlineTimestamp, "200")
+})
+
+test("proof acceptance and accepted timeout reports have distinct stable event payloads", async () => {
+  const chain = new Chain()
+  chain.requests = []
+  chain.completions = [
+    {
+      ...redemptionRequest(95),
+      redemptionTxHash: BitcoinTxHash.from(`ab${"00".repeat(30)}01`),
+    },
+  ]
+  chain.reports = [redemptionRequest(96, "77")]
+  const events = await new RedemptionLifecycleMonitor(chain).check(90, 100)
+  assert.deepStrictEqual(
+    events.map((event) => [event.title, event.type, event.block]),
+    [
+      ["Redemption proof accepted", SystemEventType.Informational, 95],
+      ["Redemption timeout reported", SystemEventType.Critical, 96],
+    ]
+  )
+  assert.ok(
+    events[0].data.redemptionTxHashURL.endsWith(events[0].data.redemptionTxHash)
+  )
+  assert.ok(
+    events[0].data.ethProofTxHashURL.endsWith(events[0].data.ethProofTxHash)
+  )
+  assert.ok(
+    events[1].data.ethTimeoutTxHashURL.endsWith(events[1].data.ethTimeoutTxHash)
+  )
+})
+
+test("overlapping windows deduplicate the same deadline alert through Manager", async () => {
+  const chain = new Chain()
+  const monitor = new RedemptionLifecycleMonitor(chain, 200)
+  const stored = await monitor.check(80, 91)
+  assert.deepStrictEqual(await monitor.check(85, 92), stored)
+  let delivered = false
+  const receiver: Receiver = {
+    id: () => "test",
+    receive: async (event) => {
+      delivered = true
+      return { receiverId: "test", systemEvent: event, status: "handled" }
+    },
+  }
+  const persistence: Persistence = {
+    checkpointBlock: async () => 91,
+    updateCheckpointBlock: async () => undefined,
+    handledSystemEvents: async () => ({ test: stored }),
+    storeHandledSystemEvents: async () => undefined,
+  }
+  const report = await new Manager([monitor], [receiver], persistence).check(
+    85,
+    92
+  )
+  assert.deepStrictEqual(report.errors, [])
+  assert.strictEqual(report.systemEventsAcks[0].status, "duplicate")
+  assert.strictEqual(delivered, false)
+})
+
+test("a failed historical RPC read preserves the Manager checkpoint and retries the same notification", async () => {
+  const chain = new Chain()
+  chain.pendingAt = () => {
+    throw new Error("historical state unavailable")
+  }
+  let checkpoint = 90
+  const events: SystemEvent[] = []
+  const receiver: Receiver = {
+    id: () => "test",
+    receive: async (event) => {
+      events.push(event)
+      return { receiverId: "test", systemEvent: event, status: "handled" }
+    },
+  }
+  const persistence: Persistence = {
+    checkpointBlock: async () => checkpoint,
+    updateCheckpointBlock: async (block) => {
+      checkpoint = block
+    },
+    handledSystemEvents: async () => ({}),
+    storeHandledSystemEvents: async () => undefined,
+  }
+  const originalLatest = blocks.latestBlock
+  blocks.latestBlock = async () => 92
+  try {
+    const manager = new Manager(
+      [new RedemptionLifecycleMonitor(chain, 200)],
+      [receiver],
+      persistence
+    )
+    const failed = await manager.trigger()
+    assert.strictEqual(failed.status, "failure")
+    assert.ok(
+      failed.errors.some((error) =>
+        error.includes("historical state unavailable")
+      )
+    )
+    assert.strictEqual(checkpoint, 90)
+    assert.strictEqual(events.length, 0)
+    chain.pendingAt = () => 100
+    assert.strictEqual((await manager.trigger()).status, "success")
+    assert.strictEqual(checkpoint, 92)
+    assert.strictEqual(events.length, 1)
+  } finally {
+    blocks.latestBlock = originalLatest
+  }
+})
+
+test("invalid timeout configuration fails explicitly", async () => {
+  const warnings = [0, -1, 0.5, Number.NaN, Infinity]
+  warnings.forEach((warning) => {
+    assert.throws(
+      () => new RedemptionLifecycleMonitor(new Chain(), warning),
+      /positive integer/
+    )
+  })
+  const chain = new Chain()
+  chain.timeoutAt = () => 0
+  await assert.rejects(
+    () => new RedemptionLifecycleMonitor(chain).check(90, 100),
+    /invalid Bridge/
+  )
+})

--- a/monitoring/test/redemption-lifecycle-monitor.test.ts
+++ b/monitoring/test/redemption-lifecycle-monitor.test.ts
@@ -1,10 +1,15 @@
 import assert from "assert"
+import { promises as fs } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
 
 import { BitcoinTxHash } from "@keep-network/tbtc-v2.ts"
 
 import { RedemptionLifecycleMonitor } from "../src/redemption-lifecycle-monitor"
 import { Manager, SystemEventType } from "../src/system-event"
 import { blocks } from "../src/blocks"
+import { SystemEventFilePersistence } from "../src/file-persistence"
+import { context } from "../src/context"
 
 import { redemptionRequest } from "./redemption-fixtures"
 import { test } from "./test-runner"
@@ -15,7 +20,12 @@ import type {
   RedemptionsCompletedEvent,
   RedemptionTimedOutEvent,
 } from "../src/redemption-chain"
-import type { Persistence, Receiver, SystemEvent } from "../src/system-event"
+import type {
+  BlockRange,
+  Persistence,
+  Receiver,
+  SystemEvent,
+} from "../src/system-event"
 
 class Chain implements RedemptionLifecycleSource {
   requests = [redemptionRequest()]
@@ -31,8 +41,9 @@ class Chain implements RedemptionLifecycleSource {
   // eslint-disable-next-line class-methods-use-this
   timeoutAt: (block: number) => number = () => 1000
 
-  pendingAt = (request: RedemptionRequestedEvent) =>
-    this.timestampAt(request.blockNumber)
+  pendingAt: (request: RedemptionRequestedEvent, block: number) => number = (
+    request
+  ) => this.timestampAt(request.blockNumber)
 
   stateReads: number[] = []
 
@@ -70,7 +81,7 @@ class Chain implements RedemptionLifecycleSource {
 
   async pendingRequestedAt(request: RedemptionRequestedEvent, block: number) {
     this.stateReads.push(block)
-    return this.pendingAt(request)
+    return this.pendingAt(request, block)
   }
 }
 
@@ -206,6 +217,8 @@ test("overlapping windows deduplicate the same deadline alert through Manager", 
   const persistence: Persistence = {
     checkpointBlock: async () => 91,
     updateCheckpointBlock: async () => undefined,
+    pendingBlockRange: async () => null,
+    updatePendingBlockRange: async () => undefined,
     handledSystemEvents: async () => ({ test: stored }),
     storeHandledSystemEvents: async () => undefined,
   }
@@ -224,6 +237,7 @@ test("a failed historical RPC read preserves the Manager checkpoint and retries 
     throw new Error("historical state unavailable")
   }
   let checkpoint = 90
+  let pendingRange: BlockRange | null = null
   const events: SystemEvent[] = []
   const receiver: Receiver = {
     id: () => "test",
@@ -236,6 +250,10 @@ test("a failed historical RPC read preserves the Manager checkpoint and retries 
     checkpointBlock: async () => checkpoint,
     updateCheckpointBlock: async (block) => {
       checkpoint = block
+    },
+    pendingBlockRange: async () => pendingRange,
+    updatePendingBlockRange: async (range) => {
+      pendingRange = range
     },
     handledSystemEvents: async () => ({}),
     storeHandledSystemEvents: async () => undefined,
@@ -263,6 +281,87 @@ test("a failed historical RPC read preserves the Manager checkpoint and retries 
     assert.strictEqual(events.length, 1)
   } finally {
     blocks.latestBlock = originalLatest
+  }
+})
+
+test("a rejected expiration survives restart and proof acceptance before retry", async () => {
+  const originalDataDir = context.dataDirPath
+  const originalLatest = blocks.latestBlock
+  const directory = await fs.mkdtemp(
+    join(tmpdir(), "redemption-delivery-retry-")
+  )
+  context.dataDirPath = directory
+  let latestBlock = 111
+  blocks.latestBlock = async () => latestBlock
+  try {
+    const chain = new Chain()
+    chain.pendingAt = (request, block) =>
+      block < 112 ? chain.timestampAt(request.blockNumber) : 0
+    chain.completions = [
+      {
+        ...redemptionRequest(112),
+        redemptionTxHash: BitcoinTxHash.from("aa".repeat(32)),
+      },
+    ]
+    const attempts: SystemEvent[] = []
+    let reject = true
+    const receiver: Receiver = {
+      id: () => "test",
+      receive: async (event) => {
+        attempts.push(event)
+        if (reject) throw new Error("Sentry delivery failed")
+        return { receiverId: "test", systemEvent: event, status: "handled" }
+      },
+    }
+    const persistence = new SystemEventFilePersistence()
+    await persistence.updateCheckpointBlock(110)
+    const createManager = () =>
+      new Manager(
+        [new RedemptionLifecycleMonitor(chain, 200)],
+        [receiver],
+        new SystemEventFilePersistence()
+      )
+    const failed = await createManager().trigger()
+    assert.strictEqual(failed.status, "failure")
+    assert.strictEqual(attempts[0].title, "Redemption expired without proof")
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      110
+    )
+
+    latestBlock = 120
+    reject = false
+    // Recreate both Manager and persistence, as the scheduled job does.
+    const retried = await createManager().trigger()
+    assert.strictEqual(retried.status, "success")
+    assert.strictEqual(retried.fromBlock, failed.fromBlock)
+    assert.strictEqual(retried.toBlock, failed.toBlock)
+    assert.deepStrictEqual(attempts[1], attempts[0])
+    assert.strictEqual(
+      await new SystemEventFilePersistence().checkpointBlock(),
+      111
+    )
+
+    const caughtUp = await createManager().trigger()
+    assert.strictEqual(caughtUp.status, "success")
+    assert.strictEqual(caughtUp.toBlock, 120)
+    assert.deepStrictEqual(
+      attempts.map((event) => event.title),
+      [
+        "Redemption expired without proof",
+        "Redemption expired without proof",
+        "Redemption proof accepted",
+      ]
+    )
+  } finally {
+    context.dataDirPath = originalDataDir
+    blocks.latestBlock = originalLatest
+    await Promise.all(
+      (
+        await fs.readdir(directory)
+      ).map((name) => fs.unlink(join(directory, name)))
+    )
+    await fs.rmdir(directory)
   }
 })
 

--- a/monitoring/test/redemption-lifecycle-monitor.test.ts
+++ b/monitoring/test/redemption-lifecycle-monitor.test.ts
@@ -219,6 +219,8 @@ test("overlapping windows deduplicate the same deadline alert through Manager", 
     updateCheckpointBlock: async () => undefined,
     pendingBlockRange: async () => null,
     updatePendingBlockRange: async () => undefined,
+    pendingSystemEvents: async () => ({}),
+    updatePendingSystemEvents: async () => undefined,
     handledSystemEvents: async () => ({ test: stored }),
     storeHandledSystemEvents: async () => undefined,
   }
@@ -255,6 +257,8 @@ test("a failed historical RPC read preserves the Manager checkpoint and retries 
     updatePendingBlockRange: async (range) => {
       pendingRange = range
     },
+    pendingSystemEvents: async () => ({}),
+    updatePendingSystemEvents: async () => undefined,
     handledSystemEvents: async () => ({}),
     storeHandledSystemEvents: async () => undefined,
   }
@@ -326,7 +330,7 @@ test("a rejected expiration survives restart and proof acceptance before retry",
     assert.strictEqual(attempts[0].title, "Redemption expired without proof")
     assert.strictEqual(
       await new SystemEventFilePersistence().checkpointBlock(),
-      110
+      111
     )
 
     latestBlock = 120
@@ -334,12 +338,11 @@ test("a rejected expiration survives restart and proof acceptance before retry",
     // Recreate both Manager and persistence, as the scheduled job does.
     const retried = await createManager().trigger()
     assert.strictEqual(retried.status, "success")
-    assert.strictEqual(retried.fromBlock, failed.fromBlock)
-    assert.strictEqual(retried.toBlock, failed.toBlock)
+    assert.strictEqual(retried.toBlock, 120)
     assert.deepStrictEqual(attempts[1], attempts[0])
     assert.strictEqual(
       await new SystemEventFilePersistence().checkpointBlock(),
-      111
+      120
     )
 
     const caughtUp = await createManager().trigger()

--- a/monitoring/test/run.ts
+++ b/monitoring/test/run.ts
@@ -7,6 +7,7 @@ process.env.ELECTRUM_URL = process.env.ELECTRUM_URL ?? "tcp://localhost:50001"
 async function main() {
   await import("./sentry-receiver.test")
   await import("./system-event-manager.test")
+  await import("./receiver-isolation.test")
   await import("./redemption-chain.test")
   await import("./redemption-lifecycle-monitor.test")
 

--- a/monitoring/test/run.ts
+++ b/monitoring/test/run.ts
@@ -7,6 +7,8 @@ process.env.ELECTRUM_URL = process.env.ELECTRUM_URL ?? "tcp://localhost:50001"
 async function main() {
   await import("./sentry-receiver.test")
   await import("./system-event-manager.test")
+  await import("./redemption-chain.test")
+  await import("./redemption-lifecycle-monitor.test")
 
   await runTests()
 }

--- a/monitoring/test/system-event-manager.test.ts
+++ b/monitoring/test/system-event-manager.test.ts
@@ -1,10 +1,12 @@
 import assert from "assert"
 
 import { Manager, SystemEventType } from "../src/system-event"
+import { blocks } from "../src/blocks"
 
 import { test } from "./test-runner"
 
 import type {
+  BlockRange,
   Monitor,
   Persistence,
   Receiver,
@@ -30,6 +32,8 @@ function persistence(
   return {
     checkpointBlock: async () => 0,
     updateCheckpointBlock: async () => undefined,
+    pendingBlockRange: async () => null,
+    updatePendingBlockRange: async () => undefined,
     handledSystemEvents: async () => handledSystemEvents,
     storeHandledSystemEvents: async () => undefined,
   }
@@ -93,4 +97,100 @@ test("Manager treats duplicate system events as already covered", async () => {
   assert.deepStrictEqual(report.errors, [])
   assert.strictEqual(report.systemEventsAcks[0].status, "duplicate")
   assert.strictEqual(receiverCalled, false)
+})
+
+test("Manager requires a durable range before checking, including a retry after a failed save", async () => {
+  const originalLatest = blocks.latestBlock
+  blocks.latestBlock = async () => 150
+  let pending: BlockRange | null = null
+  let checks = 0
+  const state = persistence({})
+  state.pendingBlockRange = async () => pending
+  state.updatePendingBlockRange = async (range) => {
+    // File persistence can update its cache before the disk write fails.
+    pending = range
+    throw new Error("cannot save range")
+  }
+  const manager = new Manager(
+    [
+      {
+        check: async () => {
+          checks += 1
+          return []
+        },
+      },
+    ],
+    [],
+    state
+  )
+  try {
+    assert.strictEqual((await manager.trigger()).status, "failure")
+    assert.strictEqual((await manager.trigger()).status, "failure")
+    assert.strictEqual(checks, 0)
+  } finally {
+    blocks.latestBlock = originalLatest
+  }
+})
+
+test("Manager retains a failed delivery range and deduplicates the receiver that already accepted it", async () => {
+  const originalLatest = blocks.latestBlock
+  let latestBlock = 150
+  blocks.latestBlock = async () => latestBlock
+  let checkpoint = 100
+  let pending: BlockRange | null = null
+  const handled: Record<string, SystemEvent[]> = {}
+  const state = persistence(handled)
+  state.checkpointBlock = async () => checkpoint
+  state.updateCheckpointBlock = async (block) => {
+    checkpoint = block
+  }
+  state.pendingBlockRange = async () => pending
+  state.updatePendingBlockRange = async (range) => {
+    pending = range
+  }
+  state.storeHandledSystemEvents = async (events) => {
+    Object.entries(events).forEach(([id, accepted]) => {
+      handled[id] = [...(handled[id] ?? []), ...accepted]
+    })
+  }
+  let acceptedCalls = 0
+  let rejectedCalls = 0
+  let reject = true
+  const receivers: Receiver[] = [
+    {
+      id: () => "accepted",
+      receive: async (event) => {
+        acceptedCalls += 1
+        return { receiverId: "accepted", systemEvent: event, status: "handled" }
+      },
+    },
+    {
+      id: () => "rejected",
+      receive: async (event) => {
+        rejectedCalls += 1
+        if (reject) throw new Error("delivery failed")
+        return { receiverId: "rejected", systemEvent: event, status: "handled" }
+      },
+    },
+  ]
+  try {
+    assert.strictEqual(
+      (await new Manager([monitor], receivers, state).trigger()).status,
+      "failure"
+    )
+    assert.strictEqual(checkpoint, 100)
+    assert.deepStrictEqual(pending, { fromBlock: 88, toBlock: 150 })
+    latestBlock = 200
+    reject = false
+    assert.strictEqual(
+      (await new Manager([monitor], receivers, state).trigger()).status,
+      "success"
+    )
+    assert.strictEqual(checkpoint, 150)
+    assert.strictEqual(pending, null)
+    assert.strictEqual(acceptedCalls, 1)
+    assert.strictEqual(rejectedCalls, 2)
+  } finally {
+    blocks.latestBlock = originalLatest
+  }
 })

--- a/monitoring/test/system-event-manager.test.ts
+++ b/monitoring/test/system-event-manager.test.ts
@@ -29,11 +29,16 @@ const monitor: Monitor = {
 function persistence(
   handledSystemEvents: Awaited<ReturnType<Persistence["handledSystemEvents"]>>
 ): Persistence {
+  let pendingEvents: Record<string, SystemEvent[]> = {}
   return {
     checkpointBlock: async () => 0,
     updateCheckpointBlock: async () => undefined,
     pendingBlockRange: async () => null,
     updatePendingBlockRange: async () => undefined,
+    pendingSystemEvents: async () => pendingEvents,
+    updatePendingSystemEvents: async (events) => {
+      pendingEvents = events
+    },
     handledSystemEvents: async () => handledSystemEvents,
     storeHandledSystemEvents: async () => undefined,
   }
@@ -132,7 +137,7 @@ test("Manager requires a durable range before checking, including a retry after 
   }
 })
 
-test("Manager retains a failed delivery range and deduplicates the receiver that already accepted it", async () => {
+test("Manager queues failed deliveries and deduplicates the receiver that already accepted them", async () => {
   const originalLatest = blocks.latestBlock
   let latestBlock = 150
   blocks.latestBlock = async () => latestBlock
@@ -178,16 +183,20 @@ test("Manager retains a failed delivery range and deduplicates the receiver that
       (await new Manager([monitor], receivers, state).trigger()).status,
       "failure"
     )
-    assert.strictEqual(checkpoint, 100)
-    assert.deepStrictEqual(pending, { fromBlock: 88, toBlock: 150 })
+    assert.strictEqual(checkpoint, 150)
+    assert.strictEqual(pending, null)
+    assert.deepStrictEqual(await state.pendingSystemEvents(), {
+      rejected: [systemEvent],
+    })
     latestBlock = 200
     reject = false
     assert.strictEqual(
       (await new Manager([monitor], receivers, state).trigger()).status,
       "success"
     )
-    assert.strictEqual(checkpoint, 150)
+    assert.strictEqual(checkpoint, 200)
     assert.strictEqual(pending, null)
+    assert.deepStrictEqual(await state.pendingSystemEvents(), {})
     assert.strictEqual(acceptedCalls, 1)
     assert.strictEqual(rejectedCalls, 2)
   } finally {


### PR DESCRIPTION
The redemption monitor currently reports requests and stale requests but cannot report accepted proofs, approaching contract deadlines, expiration, or accepted timeout reports. This adds those four lifecycle events, using Ethereum timestamps and checkpointed contract state rather than an assumed block duration.

Pending requests are matched by wallet/script and request timestamp so a reused key does not alert for an older completed request. Deadline notifications have stable payloads for retry/reorg-window deduplication. Timeout changes are read at both ends of a window, event queries are batched, and RPC failures preserve the Manager checkpoint. Expiration is strictly after the contract deadline; it is separate from the `RedemptionTimedOut` report event.

The Manager saves notification payloads in a durable queue for each receiver before delivery. The scan checkpoint advances after successful event capture even if a receiver rejects delivery, so a Discord outage cannot prevent newer critical events from reaching Sentry. Failed notifications are retried independently alongside newly scanned events, survive process restarts and later proof acceptance, and remain queued if their receiver is temporarily removed. Handled history is saved before acknowledged notifications are removed. Scan or initial queue-storage failures retain the historical window for retry; delivery failures still appear in the run report. Existing data directories are supported.

Backfills may overlap blocks before Bridge deployment because of the reorg allowance. Historical empty responses are treated as absent contract state only after verifying that no code existed at that block. Crossing windows use the first deployed timeout state; wholly pre-deployment windows skip pending-request scans. RPC failures and invalid responses from deployed contracts still fail the run.

Refs threshold-network/keep-core#3664. Targets `dev` independently of SDK #1124: monitoring pins the published SDK 2.5 while the SDK source tree is 4.0-dev, so a narrow read-only adapter provides the missing methods without requiring an unpublished major upgrade or changing dependencies. Existing request/large/stale checks and receiver event-type filtering are preserved.

Rollout requires historical RPC state, an initial checkpoint backfill for older pending requests, and both Discord (informational) and Sentry (warning/critical) receivers. The runbook explains backup, replay, delivery-queue recovery, bounded deduplication history, delivery validation, and rollback. Off-chain proposals are covered by threshold-network/keep-core#4292; maintainer health and alert configuration are in threshold-network/keep-core#4290 and threshold-network/keep-core#4291. These PRs do not close threshold-network/keep-core#3664 before operational validation.

Validation:
- TypeScript build and all 30 monitoring tests pass on Node 22, with the existing frozen Yarn 1 dependency installation.
- Regression tests cover an unavailable Discord receiver while newer critical events reach Sentry, receiver removal/reconfiguration, queue-capture and acknowledgment-storage failures, expiration delivery after proof acceptance and process restart, deployment overlap, and historical RPC errors. Existing ABI, timing, timeout-change, and deduplication tests also pass.
- Full monitoring lint, touched TypeScript formatting, and `git diff --check` pass.
- No live RPC, receiver delivery, or deployment was performed.
