### PR TITLE
Update contract docs publisher for repository rename

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -64,7 +64,7 @@ jobs:
   # This job will be triggered for releases which name starts with
   # `refs/tags/solidity/`. It will generate contracts documentation in
   # Markdown and sync it with a specific path of
-  # `threshold-network/threshold` repository. If changes will be detected,
+  # `threshold-network/docs` repository. If changes will be detected,
   # a PR updating the docs will be created in the destination repository. The
   # commit pushing the changes will be verified using GPG key.
   contracts-docs-publish:
@@ -91,7 +91,7 @@ jobs:
       publish: true
       addTOC: false
       verifyCommits: true
-      destinationRepo: threshold-network/threshold
+      destinationRepo: threshold-network/docs
       destinationFolder: ./docs/app-development/tbtc-v2/tbtc-contracts-api/tbtc-v2-api
       destinationBaseBranch: main
       userEmail: 38324465+thesis-valkyrie@users.noreply.github.com


### PR DESCRIPTION
The in-place rename of `threshold-network/threshold` to `threshold-network/docs` is complete. This PR updates the contract release job's documentation publishing destination and comment to `threshold-network/docs`.

Merge before the next contract release so the publisher uses the current repository name.

Companion to https://github.com/threshold-network/solidity-contracts/pull/148.

Validation: parsed the YAML and verified that `destinationRepo` is the only configuration value changed; `git diff --check` passes. Live documentation publishing was not executed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contracts documentation publishing destination to the Threshold Network documentation repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->