### PR TITLE
Remove retired Goerli, Mumbai, and Ropsten configuration

### DIFF
--- a/cross-chain/arbitrum/hardhat.config.ts
+++ b/cross-chain/arbitrum/hardhat.config.ts
@@ -43,15 +43,6 @@ const config: HardhatUserConfig = {
         "deploy_l2",
       ],
     },
-    goerli: {
-      url: process.env.L1_CHAIN_API_URL || "",
-      chainId: 5,
-      deploy: ["deploy_l1"],
-      accounts: process.env.L1_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.L1_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["etherscan"],
-    },
     sepolia: {
       url: process.env.L1_CHAIN_API_URL || "",
       chainId: 11155111,
@@ -77,18 +68,6 @@ const config: HardhatUserConfig = {
     system_tests: {
       url: "http://127.0.0.1:8545",
       chainId: 1,
-    },
-    arbitrumGoerli: {
-      url: process.env.L2_CHAIN_API_URL || "",
-      chainId: 421613,
-      deploy: ["deploy_l2"],
-      accounts: process.env.L2_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.L2_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["arbiscan"],
-      // companionNetworks: {
-      //   l1: "goerli",
-      // },
     },
     arbitrumSepolia: {
       url: process.env.L2_CHAIN_API_URL || "",
@@ -118,10 +97,8 @@ const config: HardhatUserConfig = {
 
   external: {
     deployments: {
-      goerli: ["./external/goerli"],
       sepolia: ["./external/sepolia"],
       mainnet: ["./external/mainnet"],
-      arbitrumGoerli: ["./external/arbitrumGoerli"],
       arbitrumSepolia: ["./external/arbitrumSepolia"],
       arbitrumOne: ["./external/arbitrumOne"],
       // Fork tests run under `--network system_tests` (chainId 1) and read the
@@ -132,20 +109,16 @@ const config: HardhatUserConfig = {
   },
 
   deploymentArtifactsExport: {
-    goerli: "artifacts/l1",
     sepolia: "artifacts/l1",
     mainnet: "artifacts/l1",
-    arbitrumGoerli: "artifacts/l2",
     arbitrumSepolia: "artifacts/l2",
     arbitrumOne: "artifacts/l2",
   },
 
   etherscan: {
     apiKey: {
-      goerli: process.env.ETHERSCAN_API_KEY,
       sepolia: process.env.ETHERSCAN_API_KEY,
       mainnet: process.env.ETHERSCAN_API_KEY,
-      arbitrumGoerli: process.env.ARBISCAN_API_KEY,
       arbitrumSepolia: process.env.ARBISCAN_API_KEY,
       arbitrumOne: process.env.ARBISCAN_API_KEY,
     },
@@ -164,18 +137,14 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1,
-      goerli: 0,
       sepolia: 0,
-      arbitrumGoerli: 0,
       arbitrumSepolia: 0,
       mainnet: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
       arbitrumOne: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
     },
     governance: {
       default: 2,
-      goerli: 0,
       sepolia: 0,
-      arbitrumGoerli: 0,
       arbitrumSepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
       arbitrumOne: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",

--- a/cross-chain/arbitrum/package.json
+++ b/cross-chain/arbitrum/package.json
@@ -30,7 +30,6 @@
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
-    "export-artifacts:goerli": "yarn hardhat export-deployment-artifacts --network arbitrumGoerli",
     "export-artifacts:sepolia": "yarn hardhat export-deployment-artifacts --network arbitrumSepolia",
     "export-artifacts:mainnet": "yarn hardhat export-deployment-artifacts --network arbitrumOne",
     "prepublishOnly": "npm run export-artifacts:$npm_config_network",

--- a/cross-chain/base/README.adoc
+++ b/cross-chain/base/README.adoc
@@ -42,7 +42,6 @@ yarn deploy --network <network>
 
 Supported networks:
 - `hardhat` - for local development
-- `baseGoerli` - L2 testing network (will become deprecated with end of 2023)
 - `baseSepolia` - L2 testing network
 - `base` - L2 mainnet
 

--- a/cross-chain/base/hardhat.config.ts
+++ b/cross-chain/base/hardhat.config.ts
@@ -53,15 +53,6 @@ const config: HardhatUserConfig = {
         "deploy_l2",
       ],
     },
-    goerli: {
-      url: process.env.L1_CHAIN_API_URL || "",
-      chainId: 5,
-      deploy: ["deploy_l1"],
-      accounts: process.env.L1_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.L1_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["etherscan"],
-    },
     sepolia: {
       url: process.env.L1_CHAIN_API_URL || "",
       chainId: 11155111,
@@ -90,21 +81,6 @@ const config: HardhatUserConfig = {
     system_tests: {
       url: "http://127.0.0.1:8545",
       chainId: 1,
-    },
-    baseGoerli: {
-      url: process.env.L2_CHAIN_API_URL || "",
-      chainId: 84531,
-      deploy: ["deploy_l2"],
-      accounts: process.env.L2_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.L2_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["basescan"],
-      // In case of deployment failing with underpriced transaction error set
-      // the `gasPrice` parameter.
-      // gasPrice: 1000000000,
-      // companionNetworks: {
-      //   l1: "goerli",
-      // },
     },
     baseSepolia: {
       url: process.env.L2_CHAIN_API_URL || "",
@@ -140,46 +116,32 @@ const config: HardhatUserConfig = {
 
   external: {
     deployments: {
-      goerli: ["./external/goerli"],
       sepolia: ["./external/sepolia"],
       mainnet: ["./external/mainnet"],
       // Fork tests run under `--network system_tests` (chainId 1) and read the
       // committed mainnet deployment so deployments resolve the live proxy on
       // the anvil fork.
       system_tests: ["deployments/mainnet", "./external/mainnet"],
-      baseGoerli: ["./external/baseGoerli"],
       baseSepolia: ["./external/baseSepolia"],
       base: ["./external/base"],
     },
   },
 
   deploymentArtifactsExport: {
-    goerli: "artifacts/l1",
     sepolia: "artifacts/l1",
     mainnet: "artifacts/l1",
-    baseGoerli: "artifacts/l2",
     baseSepolia: "artifacts/l2",
     base: "artifacts/l2",
   },
 
   etherscan: {
     apiKey: {
-      goerli: process.env.ETHERSCAN_API_KEY,
       sepolia: process.env.ETHERSCAN_API_KEY,
       mainnet: process.env.ETHERSCAN_API_KEY,
-      "base-goerli": process.env.BASESCAN_API_KEY,
       "base-sepolia": process.env.BASESCAN_API_KEY,
       "base-mainnet": process.env.BASESCAN_API_KEY,
     },
     customChains: [
-      {
-        network: "base-goerli",
-        chainId: 84531,
-        urls: {
-          apiURL: "https://api-goerli.basescan.org/api",
-          browserURL: "https://goerli.basescan.org",
-        },
-      },
       {
         network: "base-sepolia",
         chainId: 84532,
@@ -202,18 +164,14 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1,
-      goerli: 0,
       sepolia: 0,
-      baseGoerli: 0,
       baseSepolia: 0,
       mainnet: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
       base: "0x716089154304f22a2F9c8d2f8C45815183BF3532",
     },
     governance: {
       default: 2,
-      goerli: 0,
       sepolia: 0,
-      baseGoerli: 0,
       baseSepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f", // Threshold Council
       base: "0x518385dd31289F1000fE6382b0C65df4d1Cd3bfC", // Threshold Council

--- a/cross-chain/base/package.json
+++ b/cross-chain/base/package.json
@@ -30,7 +30,6 @@
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
-    "export-artifacts:goerli": "yarn hardhat export-deployment-artifacts --network baseGoerli",
     "export-artifacts:sepolia": "yarn hardhat export-deployment-artifacts --network baseSepolia",
     "export-artifacts:mainnet": "yarn hardhat export-deployment-artifacts --network base",
     "prepublishOnly": "npm run export-artifacts:$npm_config_network",

--- a/cross-chain/bob/hardhat.config.ts
+++ b/cross-chain/bob/hardhat.config.ts
@@ -1,4 +1,4 @@
-import "dotenv/config";
+import "dotenv/config"
 import type { HardhatUserConfig } from "hardhat/config"
 
 import "@nomiclabs/hardhat-etherscan"
@@ -56,7 +56,7 @@ const config: HardhatUserConfig = {
       forking: {
         url: process.env.BOB_MAINNET_URL || "https://rpc.gobob.xyz/",
         blockNumber: 20191668,
-      }
+      },
     },
     sepolia: {
       url: process.env.L1_CHAIN_API_URL || "",
@@ -97,17 +97,14 @@ const config: HardhatUserConfig = {
   },
 
   deploymentArtifactsExport: {
-    goerli: "artifacts/l1",
     sepolia: "artifacts/l1",
     mainnet: "artifacts/l1",
-    arbitrumGoerli: "artifacts/l2",
     arbitrumSepolia: "artifacts/l2",
     arbitrumOne: "artifacts/l2",
   },
 
   etherscan: {
     apiKey: {
-      goerli: process.env.ETHERSCAN_API_KEY,
       sepolia: process.env.ETHERSCAN_API_KEY,
       mainnet: process.env.ETHERSCAN_API_KEY,
       bobMainnet: "empty",
@@ -119,40 +116,40 @@ const config: HardhatUserConfig = {
         chainId: 11155111,
         urls: {
           apiURL: "https://api.etherscan.io/v2/api?chainid=11155111",
-          browserURL: "https://sepolia.etherscan.io"
-        }
+          browserURL: "https://sepolia.etherscan.io",
+        },
       },
       {
         network: "mainnet",
         chainId: 1,
         urls: {
           apiURL: "https://api.etherscan.io/v2/api?chainid=1",
-          browserURL: "https://etherscan.io"
-        }
+          browserURL: "https://etherscan.io",
+        },
       },
       {
         network: "bobMainnet",
         chainId: 60808,
         urls: {
           apiURL: "https://explorer-bob-mainnet-0.t.conduit.xyz/api",
-          browserURL: "https://explorer-bob-mainnet-0.t.conduit.xyz:443"
-        }
+          browserURL: "https://explorer-bob-mainnet-0.t.conduit.xyz:443",
+        },
       },
       {
         network: "bobSepolia",
         chainId: 808813,
         urls: {
           apiURL: "https://explorer-bob-sepolia-dm6uw0yhh3.t.conduit.xyz/api",
-          browserURL: "https://explorer-bob-sepolia-dm6uw0yhh3.t.conduit.xyz:443"
-        }
-      }
+          browserURL:
+            "https://explorer-bob-sepolia-dm6uw0yhh3.t.conduit.xyz:443",
+        },
+      },
     ],
   },
 
   namedAccounts: {
     deployer: {
       default: 1,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x15424dC94D4da488DB0d0e0B7aAdB86835813a63",
       bobMainnet: "0x15424dC94D4da488DB0d0e0B7aAdB86835813a63",
@@ -160,7 +157,6 @@ const config: HardhatUserConfig = {
     },
     governance: {
       default: 2,
-      goerli: 0,
       sepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
       bobMainnet: "0x694DeC29F197c76eb13d4Cc549cE38A1e06Cd24C",

--- a/cross-chain/optimism/hardhat.config.ts
+++ b/cross-chain/optimism/hardhat.config.ts
@@ -35,15 +35,6 @@ const config: HardhatUserConfig = {
         "deploy_l2",
       ],
     },
-    goerli: {
-      url: process.env.L1_CHAIN_API_URL || "",
-      chainId: 5,
-      deploy: ["deploy_l1"],
-      accounts: process.env.L1_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.L1_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["etherscan"],
-    },
     sepolia: {
       url: process.env.L1_CHAIN_API_URL || "",
       chainId: 11155111,
@@ -61,18 +52,6 @@ const config: HardhatUserConfig = {
         ? process.env.L1_ACCOUNTS_PRIVATE_KEYS.split(",")
         : undefined,
       tags: ["etherscan"],
-    },
-    optimismGoerli: {
-      url: process.env.L2_CHAIN_API_URL || "",
-      chainId: 420,
-      deploy: ["deploy_l2"],
-      accounts: process.env.L2_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.L2_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["optimism_etherscan"],
-      // companionNetworks: {
-      //   l1: "goerli",
-      // },
     },
     optimismSepolia: {
       url: process.env.L2_CHAIN_API_URL || "",
@@ -105,30 +84,24 @@ const config: HardhatUserConfig = {
 
   external: {
     deployments: {
-      goerli: ["./external/goerli"],
       sepolia: ["./external/sepolia"],
       mainnet: ["./external/mainnet"],
-      optimismGoerli: ["./external/optimismGoerli"],
       optimismSepolia: ["./external/optimismSepolia"],
       optimism: ["./external/optimism"],
     },
   },
 
   deploymentArtifactsExport: {
-    goerli: "artifacts/l1",
     sepolia: "artifacts/l1",
     mainnet: "artifacts/l1",
-    optimismGoerli: "artifacts/l2",
     optimismSepolia: "artifacts/l2",
     optimism: "artifacts/l2",
   },
 
   etherscan: {
     apiKey: {
-      goerli: process.env.ETHERSCAN_API_KEY,
       sepolia: process.env.ETHERSCAN_API_KEY,
       mainnet: process.env.ETHERSCAN_API_KEY,
-      optimisticGoerli: process.env.OPTIMISM_ETHERSCAN_API_KEY,
       optimisticSepolia: process.env.OPTIMISM_ETHERSCAN_API_KEY,
       optimisticEthereum: process.env.OPTIMISM_ETHERSCAN_API_KEY,
     },
@@ -147,18 +120,14 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1,
-      goerli: 0,
       sepolia: 0,
-      optimismGoerli: 0,
       optimismSepolia: 0,
       mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
       optimism: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
     },
     governance: {
       default: 2,
-      goerli: 0,
       sepolia: 0,
-      optimismGoerli: 0,
       optimismSepolia: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
       optimism: "0x7fB50BBabeDEE52b8760Ba15c0c199aF33Fc2EfA",

--- a/cross-chain/optimism/package.json
+++ b/cross-chain/optimism/package.json
@@ -30,7 +30,6 @@
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
-    "export-artifacts:goerli": "yarn hardhat export-deployment-artifacts --network optimismGoerli",
     "export-artifacts:sepolia": "yarn hardhat export-deployment-artifacts --network optimismSepolia",
     "export-artifacts:mainnet": "yarn hardhat export-deployment-artifacts --network optimism",
     "prepublishOnly": "npm run export-artifacts:$npm_config_network",

--- a/cross-chain/polygon/README.adoc
+++ b/cross-chain/polygon/README.adoc
@@ -27,11 +27,10 @@ Wormhole-specific tBTC representation into the canonical `PolygonTBTC` token.
 
 The deployment scripts are responsible for managing updates of the tBTC gateway
 addresses across various chains. These addresses are stored in the `external/`
-directory for a specific network, such as `mumbai/ArbitrumWormholeGateway.json.` 
-It is important to note that these addresses should remain constant for the 
-mainnet network. However, there may be instances where a new version of a 
-cross-chain module is deployed to the testing network, which would require a 
-manual update of the corresponding address.
+directory for a specific network, such as `polygon/ArbitrumWormholeGateway.json`.
+Mainnet gateway addresses should remain constant. Historical Goerli and Mumbai
+deployment records are retained for reference; those networks are no longer
+configured for deployment.
 
 === Deploy contracts
 
@@ -42,7 +41,6 @@ yarn deploy --network <network>
 
 Supported networks:
 - `hardhat` - for local development
-- `mumbai` - testing network
 - `polygon` - mainnet
 
 Currently, this module does not deploy any contracts on L1. All the existing 

--- a/cross-chain/polygon/deploy_sidechain/02_verify_polygon_tbtc_token.ts
+++ b/cross-chain/polygon/deploy_sidechain/02_verify_polygon_tbtc_token.ts
@@ -12,12 +12,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Contracts can be verified on Polygonscan in a similar way as we
   // do it on L1 Etherscan
   if (hre.network.tags.polygonscan) {
-    if (hre.network.name === "mumbai") {
-      // Polygonscan might not include the recently added proxy transaction right
-      // after deployment. We need to wait some time so that transaction is
-      // visible on Polygonscan.
-      await new Promise((resolve) => setTimeout(resolve, 10000)) // 10sec
-    }
     // We use `verify` instead of `verify:verify` as the `verify` task is defined
     // in "@openzeppelin/hardhat-upgrades" to verify the proxy’s implementation
     // contract, the proxy itself and any proxy-related contracts, as well as

--- a/cross-chain/polygon/deploy_sidechain/04_verify_polygon_wormhole_gateway.ts
+++ b/cross-chain/polygon/deploy_sidechain/04_verify_polygon_wormhole_gateway.ts
@@ -12,12 +12,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Contracts can be verified on Polygonscan in a similar way as we
   // do it on L1 Etherscan
   if (hre.network.tags.polygonscan) {
-    if (hre.network.name === "mumbai") {
-      // Polygonscan might not include the recently added proxy transaction right
-      // after deployment. We need to wait some time so that transaction is
-      // visible on Polygonscan.
-      await new Promise((resolve) => setTimeout(resolve, 10000)) // 10sec
-    }
     // We use `verify` instead of `verify:verify` as the `verify` task is defined
     // in "@openzeppelin/hardhat-upgrades" to verify the proxy’s implementation
     // contract, the proxy itself and any proxy-related contracts, as well as

--- a/cross-chain/polygon/deploy_sidechain/32_manual_upgrade_polygon_wormhole_gateway.ts
+++ b/cross-chain/polygon/deploy_sidechain/32_manual_upgrade_polygon_wormhole_gateway.ts
@@ -57,12 +57,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Contracts can be verified on L2 Polygonscan in a similar way as we do it on
   // L1 Etherscan
   if (hre.network.tags.polygonscan) {
-    if (hre.network.name === "mumbai") {
-      // Polygonscan might not include the recently added proxy transaction right
-      // after deployment. We need to wait some time so that transaction is
-      // visible on Polygonscan.
-      await new Promise((resolve) => setTimeout(resolve, 10000)) // 10sec
-    }
     // We use `verify` instead of `verify:verify` as the `verify` task is defined
     // in "@openzeppelin/hardhat-upgrades" to verify the proxy’s implementation
     // contract, the proxy itself and any proxy-related contracts, as well as

--- a/cross-chain/polygon/hardhat.config.ts
+++ b/cross-chain/polygon/hardhat.config.ts
@@ -35,15 +35,6 @@ const config: HardhatUserConfig = {
         "deploy_sidechain",
       ],
     },
-    goerli: {
-      url: process.env.PARENTCHAIN_API_URL || "",
-      chainId: 5,
-      deploy: ["deploy_parentchain"],
-      accounts: process.env.PARENTCHAIN_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.PARENTCHAIN_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["etherscan"],
-    },
     mainnet: {
       url: process.env.PARENTCHAIN_API_URL || "",
       chainId: 1,
@@ -52,18 +43,6 @@ const config: HardhatUserConfig = {
         ? process.env.PARENTCHAIN_ACCOUNTS_PRIVATE_KEYS.split(",")
         : undefined,
       tags: ["etherscan"],
-    },
-    mumbai: {
-      url: process.env.SIDECHAIN_API_URL || "",
-      chainId: 80001,
-      deploy: ["deploy_sidechain"],
-      accounts: process.env.SIDECHAIN_ACCOUNTS_PRIVATE_KEYS
-        ? process.env.SIDECHAIN_ACCOUNTS_PRIVATE_KEYS.split(",")
-        : undefined,
-      tags: ["polygonscan"],
-      // companionNetworks: {
-      //   parentchain: "goerli",
-      // },
     },
     polygon: {
       url: process.env.SIDECHAIN_API_URL || "",
@@ -81,25 +60,19 @@ const config: HardhatUserConfig = {
 
   external: {
     deployments: {
-      goerli: ["./external/goerli"],
       mainnet: ["./external/mainnet"],
-      mumbai: ["./external/mumbai"],
       polygon: ["./external/polygon"],
     },
   },
 
   deploymentArtifactsExport: {
-    goerli: "artifacts/parentchain",
     mainnet: "artifacts/parentchain",
-    mumbai: "artifacts/sidechain",
     polygon: "artifacts/sidechain",
   },
 
   etherscan: {
     apiKey: {
-      goerli: process.env.ETHERSCAN_API_KEY,
       mainnet: process.env.ETHERSCAN_API_KEY,
-      polygonMumbai: process.env.POLYGONSCAN_API_KEY,
       polygon: process.env.POLYGONSCAN_API_KEY,
     },
   },
@@ -107,15 +80,11 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 1,
-      goerli: 0,
-      mumbai: 0,
       mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
       polygon: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
     },
     governance: {
       default: 2,
-      goerli: 0,
-      mumbai: 0,
       mainnet: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
       polygon: "0x9f6e831c8f8939dc0c830c6e492e7cef4f9c2f5f",
     },

--- a/cross-chain/polygon/package.json
+++ b/cross-chain/polygon/package.json
@@ -30,7 +30,6 @@
     "lint:config": "prettier --check '**/*.@(json|yaml)'",
     "lint:config:fix": "prettier --write '**/*.@(json|yaml)'",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
-    "export-artifacts:goerli": "yarn hardhat export-deployment-artifacts --network mumbai",
     "export-artifacts:mainnet": "yarn hardhat export-deployment-artifacts --network polygon",
     "prepublishOnly": "npm run export-artifacts:$npm_config_network",
     "test": "hardhat test"

--- a/solidity/.hardhat/networks_TEMPLATE.ts
+++ b/solidity/.hardhat/networks_TEMPLATE.ts
@@ -7,12 +7,6 @@ import { LocalNetworksConfig } from "@keep-network/hardhat-local-networks-config
 
 const config: LocalNetworksConfig = {
   networks: {
-    ropsten: {
-      url: "url not set",
-      from: "address not set",
-      accounts: ["private key not set"],
-      tags: ["tenderly"],
-    },
     mainnet: {
       url: "url not set",
       from: "address not set",

--- a/solidity/tenderly.yaml
+++ b/solidity/tenderly.yaml
@@ -3,6 +3,3 @@ projects:
   thesis/keep:
     networks:
       - "1" # mainnet
-  thesis/keep-test:
-    networks:
-      - "3" # ropsten


### PR DESCRIPTION
Retired Goerli networks and Mumbai are still selectable deployment targets in the cross-chain packages. Remove their network definitions, account aliases, explorer/export mappings, and package commands; remove the Mumbai-only verification delays and the remaining Ropsten template/Tenderly configuration. Update the supported-network documentation.

Existing Sepolia, local, and mainnet settings are preserved. Historical deployment artifacts and upgrade manifests remain available for reference. Polygon mainnet retirement continues separately in #1000.

This replaces the unmerged cleanup in #790. The other unfinished work from the old migration tracker now has explicit owners:

- Sepolia optimistic-minting integration tests and CI: https://github.com/tlabs-xyz/optimistic-minting/issues/113
- Sepolia L2-to-Solana gateway reconciliation: #1136. The EVM peers already match the committed deployments; the Solana peers are unset on-chain.

Seven unused Goerli/Ropsten GitHub Actions secrets have also been removed from `threshold-network/solidity-contracts` after auditing main and every open PR head. No retired-network secrets were present in this repository.

Validation:

- Loaded all five affected cross-chain Hardhat configurations before and after the change and compared the resolved settings: only retired-network entries were removed, after normalizing Hardhat's generated initial timestamp.
- Confirmed Hardhat rejects all eight removed network selections with `HH100`.
- Prettier checks and targeted ESLint checks passed. Arbitrum/Base/Optimism/Polygon ESLint used the existing `tsconfig.json` explicitly because the installed shared lint configuration expects a missing `.tsconfig-eslint.json`; existing unnamed-function warnings remain in Polygon's deployment scripts.
- `git diff --check` passed.
- CI passed at `8bd98cdeccc7ec16c0cd831c4efc1bbc38ae7d2c`: Solidity unit and integration tests, the configured cross-chain test suites, deployment dry runs, formatting, and Slither. No public-chain deployment transactions were submitted.

Closes threshold-network/solidity-contracts#163 by completing the remaining housekeeping and moving ongoing work to the owning repositories.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated supported testnet configurations across Arbitrum, Base, Optimism, and Polygon to use Sepolia-era networks.
  * Removed deprecated Goerli, Mumbai, and Ropsten network support and related deployment artifact exports.

* **Documentation**
  * Updated network support and gateway mapping documentation to reflect current testnets and retained historical records.

* **Deployment**
  * Polygon verification now proceeds without the former Mumbai-specific delay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->