### PR TITLE
Remove unused direct Thesis dependency from Starknet

### DIFF
--- a/cross-chain/starknet/package.json
+++ b/cross-chain/starknet/package.json
@@ -47,8 +47,7 @@
     "@keep-network/random-beacon": "development",
     "@keep-network/tbtc-v2": "development",
     "@openzeppelin/contracts": "^4.8.1",
-    "@openzeppelin/contracts-upgradeable": "^4.8.1",
-    "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
+    "@openzeppelin/contracts-upgradeable": "^4.8.1"
   },
   "devDependencies": {
     "@defi-wonderland/smock": "^2.3.4",


### PR DESCRIPTION
Remove Starknet's unused direct `@thesis/solidity-contracts` declaration. No Starknet contract, test, deploy script, or Hardhat configuration imports it. The Yarn Classic lock entry remains because published tBTC dependencies still require it transitively.

Validation: checked the package's source/config/task references and parsed the manifest and lockfile. Resolved dependency versions and Solidity source are unchanged. This is independent of tbtc-v2 #1141 and #1144.
