### PR TITLE
Use Threshold-owned CI and release actions

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -39,7 +39,7 @@ jobs:
       needs.docs-detect-changes.outputs.path-filter == 'true'
         || github.event_name == 'push'
         || github.event_name == 'workflow_dispatch'
-    uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
     with:
       projectDir: /solidity
       # We need to remove unnecessary `//` comment used in the `@dev`
@@ -71,7 +71,7 @@ jobs:
     name: Publish contracts documentation
     needs: docs-detect-changes
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/solidity/')
-    uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
     with:
       projectDir: /solidity
       # We need to remove unnecessary `//` comment used in the `@dev`

--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -39,7 +39,7 @@ jobs:
       needs.docs-detect-changes.outputs.path-filter == 'true'
         || github.event_name == 'push'
         || github.event_name == 'workflow_dispatch'
-    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@20b35345d276a3c7365e3829b8078387a7c9dccb
     with:
       projectDir: /solidity
       # We need to remove unnecessary `//` comment used in the `@dev`
@@ -71,7 +71,7 @@ jobs:
     name: Publish contracts documentation
     needs: docs-detect-changes
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/solidity/')
-    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@20b35345d276a3c7365e3829b8078387a7c9dccb
     with:
       projectDir: /solidity
       # We need to remove unnecessary `//` comment used in the `@dev`

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -43,10 +43,10 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -65,7 +65,7 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -110,7 +110,7 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -146,7 +146,7 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -172,13 +172,13 @@ jobs:
         run: yarn install --immutable
 
       - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v2
+        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            random-beacon-contracts-version = github.com/keep-network/keep-core/random-beacon#version
-            ecdsa-contracts-version = github.com/keep-network/keep-core/ecdsa#version
+            random-beacon-contracts-version = github.com/threshold-network/keep-core/random-beacon#version
+            ecdsa-contracts-version = github.com/threshold-network/keep-core/ecdsa#version
 
       - name: Resolve latest contracts
         run: |
@@ -200,7 +200,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: solidity
           environment: ${{ github.event.inputs.environment }}
@@ -213,11 +213,11 @@ jobs:
         run: npm publish --access=public --tag ${{ github.event.inputs.environment }} --network=${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          module: "github.com/keep-network/tbtc-v2"
+          module: "github.com/threshold-network/tbtc-v2"
           url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
@@ -225,8 +225,9 @@ jobs:
           version: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: Artifacts for etherscan verification
           path: |
             ./solidity/deployments
@@ -240,10 +241,10 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Artifacts for etherscan verification
           path: ./solidity
@@ -298,7 +299,7 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -324,13 +325,13 @@ jobs:
         run: yarn install --immutable
 
       - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v2
+        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            random-beacon-contracts-version = github.com/keep-network/keep-core/random-beacon#version
-            ecdsa-contracts-version = github.com/keep-network/keep-core/ecdsa#version
+            random-beacon-contracts-version = github.com/threshold-network/keep-core/random-beacon#version
+            ecdsa-contracts-version = github.com/threshold-network/keep-core/ecdsa#version
 
       - name: Resolve latest contracts
         run: |
@@ -347,7 +348,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: solidity
           environment: dapp-dev-${{ github.event.inputs.environment }}
@@ -369,7 +370,7 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -421,7 +422,7 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
@@ -432,7 +433,7 @@ jobs:
           corepack enable
           corepack prepare yarn@4.12.0 --activate
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.10.8
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -172,7 +172,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -200,7 +200,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: solidity
           environment: ${{ github.event.inputs.environment }}
@@ -213,7 +213,7 @@ jobs:
         run: npm publish --access=public --tag ${{ github.event.inputs.environment }} --network=${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -325,7 +325,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Get upstream packages versions
-        uses: threshold-network/ci/actions/upstream-builds-query@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/upstream-builds-query@20b35345d276a3c7365e3829b8078387a7c9dccb
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -348,7 +348,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: solidity
           environment: dapp-dev-${{ github.event.inputs.environment }}

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Load environment variables
         if: ${{ github.event.inputs.environment != 'local' }}
-        uses: threshold-network/ci/actions/load-env-variables@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/load-env-variables@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           environment: ${{ github.event.inputs.environment }}
 

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -27,10 +27,10 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -48,9 +48,9 @@ jobs:
       run:
         working-directory: ./monitoring
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           cache-dependency-path: monitoring/yarn.lock
@@ -75,18 +75,18 @@ jobs:
       run:
         working-directory: ./monitoring
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Load environment variables
         if: ${{ github.event.inputs.environment != 'local' }}
-        uses: keep-network/ci/actions/load-env-variables@v2
+        uses: threshold-network/ci/actions/load-env-variables@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           environment: ${{ github.event.inputs.environment }}
 
-      - uses: docker/setup-buildx-action@v2
+      - uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -95,7 +95,7 @@ jobs:
 
       - name: Login to Docker registry
         if: ${{ github.event.inputs.environment != 'local' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         env:
           CLUSTER_MAPPING: '{"sepolia": "KEEP_TEST", "mainnet": "KEEP_PRD"}'
         with:
@@ -104,8 +104,10 @@ jobs:
           password: ${{ secrets[format('{0}_GCR_JSON_KEY', fromJson(env.CLUSTER_MAPPING)[github.event.inputs.environment])] }}
 
       - name: Build Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
+          # Preserve the existing image format.
+          provenance: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           context: ./monitoring
@@ -131,9 +133,9 @@ jobs:
       run:
         working-directory: ./monitoring
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           cache-dependency-path: monitoring/yarn.lock

--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -20,9 +20,9 @@ jobs:
       run:
         working-directory: ./solidity
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
@@ -53,7 +53,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: ./solidity
           environment: dev

--- a/.github/workflows/npm-contracts.yml
+++ b/.github/workflows/npm-contracts.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: ./solidity
           environment: dev

--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -15,9 +15,9 @@ jobs:
       run:
         working-directory: ./typescript
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
@@ -45,7 +45,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           work-dir: ./typescript
           environment: dev

--- a/.github/workflows/npm-typescript.yml
+++ b/.github/workflows/npm-typescript.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           work-dir: ./typescript
           environment: dev


### PR DESCRIPTION
Use the maintained actions from [threshold-network/ci #1](https://github.com/threshold-network/ci/pull/1), pinned to `20b35345d276a3c7365e3829b8078387a7c9dccb`. This includes the vendored npm-version-bump action. Completion payloads and upstream-build queries use the Threshold module identifiers configured by the new release manager.

Update obsolete action runtimes in the affected workflows. Artifact uploads preserve hidden deployment metadata when moving to artifact v4. The producer and all consumer migrations must merge before starting a new inter-repository release pipeline; `CI_GITHUB_TOKEN` must be configured where missing. npm/cloud/docs credentials stay in their existing consumer repositories.

Validation: actionlint passes for every changed workflow; producer paths, input names, commit pins, dispatch input contracts, and module/query identifiers were checked against the producer. Its 51 tests and four standalone action-bundle checks pass in GitHub CI. Release/deployment/publishing paths were not invoked during validation.

The shared docs workflow is now owned and pinned. The docs destination rename remains in #1135; the JavaScript Electrum dependency switch remains in #1140. Monitoring's Docker action upgrades preserve its prior image format by disabling provenance attestations.
