### PR TITLE
chore(solidity): remove orphaned ENVIRONMENT env var

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -176,7 +176,6 @@ jobs:
         env:
           RANDOM_BEACON_CONTRACTS_VERSION: ${{ steps.upstream-builds-query.outputs.random-beacon-contracts-version }}
           ECDSA_CONTRACTS_VERSION: ${{ steps.upstream-builds-query.outputs.ecdsa-contracts-version }}
-          ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           yarn up \
             "@keep-network/random-beacon@${RANDOM_BEACON_CONTRACTS_VERSION}" \
@@ -314,7 +313,6 @@ jobs:
         env:
           RANDOM_BEACON_CONTRACTS_VERSION: ${{ steps.upstream-builds-query.outputs.random-beacon-contracts-version }}
           ECDSA_CONTRACTS_VERSION: ${{ steps.upstream-builds-query.outputs.ecdsa-contracts-version }}
-          ENVIRONMENT: ${{ github.event.inputs.environment }}
         run: |
           yarn up \
             "@keep-network/random-beacon@${RANDOM_BEACON_CONTRACTS_VERSION}" \


### PR DESCRIPTION
This PR originally proposed removing the unused `@keep-network/tbtc` v1
dependency from `solidity/`, its unused artifact search path, and the
CI steps that updated it or worked around its obsolete Git dependencies.

**That work already landed via #1145** (merged first, and more complete
— it removed all 8 pre-existing git-protocol-workaround occurrences
across `contracts.yml`/`npm-contracts.yml` vs this PR's original 7).
This branch has been rebased onto `dev`; 4 of the original 5 changed
files (`package.json`, `yarn.lock`, `hardhat.config.ts`,
`npm-contracts.yml`) are now identical to `dev` and carry zero diff.

**What actually remains:** 2 lines in `.github/workflows/contracts.yml`
removing an orphaned `ENVIRONMENT: ${{ github.event.inputs.environment }}`
declaration in the `Resolve latest contracts` step of
`contracts-deployment-testnet` and
`contracts-dapp-development-deployment-testnet`. #1145 removed the line
that consumed it (`yarn up "@keep-network/tbtc@${ENVIRONMENT}"`) but left
the now-unused declaration behind — verified dead by reading both
steps' `run:` blocks and grepping the file for any other reference.

Not addressed here (neither this PR nor #1145 touches these; tracked
separately, not blocking): a stale `@summa-tx` git-protocol workaround
note at `solidity/README.adoc:36-46`, and 2 stale artifact-path-warning
comment lines at `solidity/hardhat.config.ts:215-216`.

CI green on the rebased branch: contracts-build-and-test,
contracts-format, contracts-slither, contracts-deployment-dry-run,
code-format all pass.
