### PR TITLE
docs(solidity): document L1BTCDepositorNttWithExecutor Prettier exclusion

### DIFF
--- a/solidity/.prettierignore
+++ b/solidity/.prettierignore
@@ -8,4 +8,6 @@ hardhat-dependency-compiler/
 typechain/
 docgen-templates/
 export.json
+# L1BTCDepositorNttWithExecutor.sol stays byte-frozen: its deployment record is
+# reconstructed from on-chain state and verification depends on the exact source.
 contracts/cross-chain/wormhole/L1BTCDepositorNttWithExecutor.sol

--- a/solidity/docs/toolchain-upgrades.md
+++ b/solidity/docs/toolchain-upgrades.md
@@ -123,6 +123,9 @@ configuration retains `semi: false`, Solidity's four-space indentation, and
 `trailingComma: "es5"` so upgrading does not silently adopt Prettier 3's new
 trailing-comma default. The formatting-only commit is separate from the
 dependency and configuration changes. Existing generated and deployment
-artifacts remain excluded. Formatting Solidity source changes its compiler
+artifacts remain excluded, as does
+`contracts/cross-chain/wormhole/L1BTCDepositorNttWithExecutor.sol`: its
+deployment record is reconstructed from on-chain state, so the source must stay
+byte-frozen to remain verifiable. Formatting Solidity source changes its compiler
 metadata hash even when the parsed code is unchanged; this does not regenerate
 or replace historical deployment records.


### PR DESCRIPTION
Follow-up to the merged Prettier 3 migration (#1134).

The toolchain-upgrades doc claimed \"Existing generated and deployment artifacts remain excluded\" without naming the one production contract that is also exempt. solidity/.prettierignore excludes contracts/cross-chain/wormhole/L1BTCDepositorNttWithExecutor.sol because its deployment record is reconstructed from on-chain state and verification depends on the source staying byte-frozen; keeping that exclusion intentional requires recording the reason.

- solidity/docs/toolchain-upgrades.md: name the excluded contract and the byte-frozen rationale
- solidity/.prettierignore: comment above the exclusion entry

Doc-only change; no contract or formatting behavior changes.

Validated in #1134's review: the exclusion is pre-existing and load-bearing, the reformat claim covers 72 of 73 production .sol files, and no stored-bytecode gate is affected.